### PR TITLE
Use a two-column list for sponsors (when screen space is wide enough)

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -1,9 +1,13 @@
+## When putting either quotes or exposition into the same types of
+## slots, ensure quotations are displayed surrounded by quotes marks to
+## differentiate the two types of information
 sponsors:
   -
     name: John Pfeffer
     twitter: jlppfeffer
     avatar: https://pbs.twimg.com/profile_images/943480113001369600/CD-0Q6jG_400x400.jpg
-    quote: I’m an investor and believer that everyone who has a stake in Bitcoin has a duty to contribute and give back to Bitcoin development, including hodlers!  Wences and I hope that everyone will pitch in, contribute and do their bit to help make this grand challenge to scale Bitcoin a success.
+    quote: >-
+      "I’m an investor and believer that everyone who has a stake in Bitcoin has a duty to contribute and give back to Bitcoin development, including hodlers!  Wences and I hope that everyone will pitch in, contribute and do their bit to help make this grand challenge to scale Bitcoin a success."
   -
     name: Wences Casares
     twitter: wences

--- a/_includes/_sponsors.html
+++ b/_includes/_sponsors.html
@@ -6,7 +6,7 @@
 
 	<p>Our founding sponsors have generously provided funds and resources to cover our start-up and ongoing costs.</p>
 
-	<ul class="sponsors">
+	<ul class="sponsors two-column-list">
 	{% for sponsor in sponsors %}
 	{% assign avatar=sponsor.avatar %}
 	{% unless sponsor.avatar contains 'https://' %}{% capture avatar %}/assets/images/team/{{sponsor.avatar}}{% endcapture %}{% endunless %}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,5 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@import "minima";

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -3,3 +3,45 @@
 ---
 
 @import "minima";
+
+br.clear {
+    clear: left;
+}
+
+.two-column-list ul {
+        margin-left: 4em;
+}
+
+.two-column-list li {
+        list-style: none;
+        float: left;
+        width: 16em;
+        text-align: left;
+        margin-bottom: 20px;
+}
+
+.two-column-list li:nth-child(2n+1) {
+        margin-right: 100px;
+        clear: both;
+}
+
+// Enable this if you want to use a two-column list with FontAwesome
+// icons replacing the bullets
+//.two-column-list .fa-li {
+//        top: 0.75em;
+//}
+
+p.sponsor-quote {
+        font-style: italic;
+}
+
+.sponsors h3 {
+        font-weight: 700;
+        font-size: 120%;
+}
+
+// The long text quotes make this application of a two-column list
+// desire more vertical spacing between the quotes
+.sponsors li {
+        margin-bottom: 60px;
+}


### PR DESCRIPTION
![2018-06-28-19_47_49_721971381](https://user-images.githubusercontent.com/61096/42066057-9796cc0c-7b0c-11e8-8c0f-1799a9b3bc97.png)

Adds a general two-column-list I've used before (e.g. Bitcoin.org) and then customizes it to this particular application.  Also puts Pfeffer's quote in quotations for reasons described in the YAML file (feel free to drop that commit if you disagree).

Note the unused `br.clear` entry in the CSS can be useful if a list with an odd number of entries is interacting with other floating content.  That's not the case now, so it's not used, but it's implemented against that future situation.

I would suggest adding some content for Casares, as his entry looks lonely without it.