### PR TITLE
Always start a new row of content for <h2>s

### DIFF
--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -2,7 +2,7 @@
 
 <div id="sponsors">
 
-	<h2 style="width:max-content">Founding Sponsors</h2>
+	<h2>Founding Sponsors</h2>
 
 	<p>Our founding sponsors have generously provided funds and resources to cover our start-up and ongoing costs.</p>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,6 +7,12 @@
 
 h2 {
     margin-top: 2em;
+    // A subhead always starts a new row of content, so clear any
+    // floating elements
+    clear: both;
+    // And tell any flexboxes that we don't want to share space with
+    // other content
+    width: 100%;
 }
 
 br.clear {


### PR DESCRIPTION
On Firefox, I was having the issues mentioned in https://github.com/bitcoinops/bitcoinops.github.io/pull/30#issuecomment-406467996 despite the fix introduced in #31, so here's a solution that works for me (tested in FF and Chromium with various screen widths).