### PR TITLE
Add date to launch announcement

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+<link rel="stylesheet" href="/assets/css/main.css">
+
+<article class="post">
+
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        {{ page.date | date: date_format }}
+      </time>
+  </header>
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+
+</article>

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -3,7 +3,7 @@ title: 'Announcing Bitcoin Optech'
 permalink: /en/announcing-bitcoin-optech/
 name: 2018-07-20-announcing-bitcoin-optech
 type: posts
-layout: page
+layout: post
 lang: en
 version: 1
 ---


### PR DESCRIPTION
Fixes #37 

~I added the date in parens after _today_. That meant the first sentence had two parens, which felt a bit unwieldy to me. I've moved the _(Optech)_ down to the second paragraph.~

Added a `post` layout and changed the launch post to use it.