### PR TITLE
Fix broken links, add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: ruby
+rvm:
+  - "2.2.2"
+
+## Allows use of docker-based containers, which are more available than
+## the xen-based (or whatever) VMs, so builds tend to happen sooner
+sudo: false
+
+## Save bundler deps.  Requires sudo: false
+cache: bundler
+
+## Disable external link checking to prevent spurious failures because
+## of other people's downtime. This can also avoid wasting their
+## bandwidth.
+
+## Build all possible jekyll pages for use with link checking.
+script:
+    - make all
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+    
+# Whitelist all branches
+branches:
+  only:
+  - master
+  - /.*/

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -1,6 +1,6 @@
 ---
 title: 'Announcing Bitcoin Optech'
-permalink: /en/announcing-bitcoin-optech
+permalink: /en/announcing-bitcoin-optech/
 name: 2018-07-20-announcing-bitcoin-optech
 type: posts
 layout: page

--- a/_posts/en/newsletters/2018-07-17-newsletter.md
+++ b/_posts/en/newsletters/2018-07-17-newsletter.md
@@ -119,7 +119,7 @@ flag, and several notable recent Bitcoin Core merges.
 [eltoo]: https://blockstream.com/eltoo.pdf
 [unsafe sighash]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-July/016187.html
 [popular twitter thread]: https://twitter.com/orionwl/status/1014829318986436608
-[schnorr feature]: en/newsletters/2018/07/10/#featured-news-schnorr-signature-proposed-bip
+[schnorr feature]: /en/newsletters/2018/07/10/#featured-news-schnorr-signature-proposed-bip
 [#12257]: https://github.com/bitcoin/bitcoin/pull/12257
 [#13072]: https://github.com/bitcoin/bitcoin/pull/13072
 [#13543]: https://github.com/bitcoin/bitcoin/pull/13543


### PR DESCRIPTION
We haven't been running the tests, which would've told us about one real broken link (my fault) and one not-actually-broken-but-could've-been link.  This commit fixes the errors and also adds a .travis.yml file so that CI can be setup.

Note, once this is merged, the Travis CI integration needs to be setup by the repository owner.