### PR TITLE
Tidyups

### DIFF
--- a/_includes/link-to-issues.md
+++ b/_includes/link-to-issues.md
@@ -1,5 +1,0 @@
-{% comment %}<!-- DEPRECATED; use linkers/issues.md instead -->{% endcomment %}
-{% assign _issues = include.issues | split: "," %}
-{% for _issue in _issues %}
-[#{{_issue}}]: https://github.com/bitcoin/bitcoin/issues/{{_issue}}
-{% endfor %}

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -6,12 +6,12 @@
 
 	<p>Bitcoin Optech is supported by our member companies.</p>
 
-	<ul class="members n-column-list">
+	<ul class="n-column-list">
 	{% for member in members %}
 	{% assign logo=member.logo %}
 	{% unless member.logo contains 'https://' %}{% capture logo %}/img/members/{{member.logo}}{% endcapture %}{% endunless %}
 	<li>
-		<div style="max-height:75px;min-height:75px;display:flex;align-items:center">
+		<div class="member">
 		<a href="https://twitter.com/{{ member.twitter }}"><img src="{{ logo }}" width="150" alt="{{ member.name }}" title="{{ member.name }}"></a>
 		</div>
 	</li>

--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -1,17 +1,12 @@
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/slim-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; }
-	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
-	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-</style>
 <div id="mc_embed_signup">
 <form action="https://bitcoinops.us18.list-manage.com/subscribe/post?u=70c3f85e5d13ffec674f30af8&amp;id=adc93c9774" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
 	<label for="mce-EMAIL">Subscribe to our newsletter</label>
 	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_70c3f85e5d13ffec674f30af8_adc93c9774" tabindex="-1" value=""></div>
+    <div class="mc-input" aria-hidden="true"><input type="text" name="b_70c3f85e5d13ffec674f30af8_adc93c9774" tabindex="-1" value=""></div>
     <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>
 </form>

--- a/_posts/en/newsletters/2018-07-24-newsletter.md
+++ b/_posts/en/newsletters/2018-07-24-newsletter.md
@@ -68,10 +68,10 @@ Bitcoin transactions, and news on several other notable Bitcoin Core merges.
     it'll break [the coin selection] interface'."
 
 - **First use of output script descriptors:** Pieter Wuille has opened
-  PR [#13697][] to Bitcoin Core that implements his [output script
+  PR [#13697][Bitcoin Core #13697] to Bitcoin Core that implements his [output script
   descriptors][] language for describing which output scripts
   (scriptPubKeys) a wallet should monitor for.  This particular PR only
-  applies to the recently-added [`scantxoutset`][#12196] RPC but Wuille's
+  applies to the recently-added [`scantxoutset`][Bitcoin Core #12196] RPC but Wuille's
   ultimate goal is to use this new language elsewhere in the API and "to
   remove the need for importing scripts and keys entirely, and instead
   make the wallet just be a list of these descriptors plus associated
@@ -86,7 +86,7 @@ Bitcoin transactions, and news on several other notable Bitcoin Core merges.
   as CoinJoins.  Several RPCs are added with this merge:
   `walletprocesspsbt`, `walletcreatefundedpsbt`, `decodepsbt`,
   `combinepsbt`, `finalizepsbt`, `createpsbt`, and `convertpsbt`.  For a
-  full description, see PR [#13557][].
+  full description, see PR [#13557][Bitcoin Core #13557].
 
 ## Notable Bitcoin Core merges
 
@@ -96,7 +96,7 @@ Bitcoin transactions, and news on several other notable Bitcoin Core merges.
 git log --merges b25a4c2284babdf1e8cf0ec3b1402200dd25f33f..07ce278455757fb46dab95fb9b97a3f6b1b84faf
 {% endcomment %}
 
-- [#9662][]: New wallets can now be created with private keys disabled.
+- [#9662][Bitcoin Core #9662]: New wallets can now be created with private keys disabled.
   This is primarily meant for users who want to exclusively use their
   wallet in conjunction with another program or hardware wallet that
   stores private keys.  This could also be useful to companies that want
@@ -105,7 +105,7 @@ git log --merges b25a4c2284babdf1e8cf0ec3b1402200dd25f33f..07ce278455757fb46dab9
   performing whatever actions they desire, such as using the
   [`fundrawtransaction`][rpc fundrawtransaction] RPC.
 
-- [#12196][]: New `scantxoutset` RPC method that allows searching the
+- [#12196][Bitcoin Core #12196]: New `scantxoutset` RPC method that allows searching the
   set of spendable bitcoins (UTXOs) for those matching an address,
   public key, private key, or HD keypath.  The main expected use for
   this is "funds sweeping" where transactions matching an old wallet are
@@ -116,12 +116,12 @@ git log --merges b25a4c2284babdf1e8cf0ec3b1402200dd25f33f..07ce278455757fb46dab9
   updated to support output script descriptors, which is planned to
   happen before 0.17.
 
-- [#13604][]: Bitcoin-Qt is now built by default in addition to bitcoind
+- [#13604][Bitcoin Core #13604]: Bitcoin-Qt is now built by default in addition to bitcoind
   on 32-bit ARM systems, and should be distributed by default with the
   other binaries for that system from BitcoinCore.org for future
   releases.  Bitcoin-Qt with 64-bit ARM is not yet supported by default.
 
-- [#13298][]: The node now sends all announcements ([invs][inv]) for
+- [#13298][Bitcoin Core #13298]: The node now sends all announcements ([invs][inv]) for
   new transactions to all of its incoming peers at the same time, after
   a random delay.  Previously, Satoshi Nakamoto [added a feature][rand
   delay] to Bitcoin (the software) that waited for a different random
@@ -148,7 +148,7 @@ git log --merges b25a4c2284babdf1e8cf0ec3b1402200dd25f33f..07ce278455757fb46dab9
     nodes no longer find making multiple connections to be useful,
     reducing overall wasted bandwidth.
 
-- [#13652][]: The [`abandontransaction`][rpc abandontransaction] RPC has
+- [#13652][Bitcoin Core #13652]: The [`abandontransaction`][rpc abandontransaction] RPC has
   been fixed to abandon all descendant transactions, not just children.
 
 ## Coming attractions
@@ -171,4 +171,4 @@ to share your experiences in implementing better Bitcoin technology, please cont
 [workshop announce]: /en/newsletters/2018/06/26/#first-optech-workshop
 
 {% include references.md %}
-{% include link-to-issues.md issues="13697,13557,12196,9662,12196,13604,13298,13652" %}
+{% include linkers/issues.md issues="13697,13557,12196,9662,12196,13604,13298,13652" %}

--- a/_posts/en/newsletters/2018-07-31-newsletter.md
+++ b/_posts/en/newsletters/2018-07-31-newsletter.md
@@ -129,7 +129,7 @@ lnd: git log --topo-order -p 271db7d06da3edf696e22109ce0277eaff11cc5e..92b0b10dc
 c-lightning: git log --topo-order -p d84d358562a3bcdf48856fdea24511907ff53fd9..0b597f671aa31c1c56d32a554fcdf089646fc7c1
 {% endcomment %}
 
-- [Bitcoin Core #12257][#12257]: if you start Bitcoin Core with the
+- [Bitcoin Core #12257][]: if you start Bitcoin Core with the
   optional flag `-avoidpartialspends`, the wallet will by default spend
   all outputs received to the same address whenever any one of them
   would be spent.  This prevents two outputs to the same address from being spent
@@ -163,7 +163,7 @@ c-lightning: git log --topo-order -p d84d358562a3bcdf48856fdea24511907ff53fd9..0
   parts of the system directly connected to the network.
 
 {% include references.md %}
-{% include link-to-issues.md issues="12257" %}
+{% include linkers/issues.md issues="1617,1531,12257" %}
 
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 [bse 77235]: {{bse}}77235
@@ -171,7 +171,4 @@ c-lightning: git log --topo-order -p d84d358562a3bcdf48856fdea24511907ff53fd9..0
 [bse 77191]: {{bse}}77191
 [bse 76541]: {{bse}}76541
 
-{% assign lnd = "https://github.com/lightningnetwork/lnd/pull/" %}
-[lnd #1617]: {{lnd}}1617
-[lnd #1531]: {{lnd}}1531
 [lnd ee2f2573c1b1b33288d05ba59a1e8ef9e8fb621c]: https://github.com/lightningnetwork/lnd/commit/ee2f2573c1b1b33288d05ba59a1e8ef9e8fb621c

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -101,3 +101,13 @@ a.site-title {
         margin-right: 1.3em;
     }
 }
+
+#mc_embed_signup {
+    clear:left;
+    font:14px Helvetica,Arial,sans-serif;
+}
+
+.mc-input {
+   position: absolute;
+   left: -5000px;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -111,3 +111,10 @@ a.site-title {
    position: absolute;
    left: -5000px;
 }
+
+.member {
+    max-height:75px;
+    min-height:75px;
+    display:flex;
+    align-items:center;
+}


### PR DESCRIPTION
Remove some tech debt:

- remove deprecated link-to-issues.md (rendered newsletters 5 and 6 should be the same, except for lnd PRs now pointing to `issue/<PR number>` instead of `pull/<PR number>`
- move mailchimp styles to main.scss
- move member style to main.scss

resolves #35 