### PR TITLE
Makefile: test for broken reference-style links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,7 @@ build:
 	bundle exec jekyll build --future --drafts --unpublished
 
 test:
+	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
+	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
+	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site

--- a/_posts/en/2018-07-30-xapo-consolidation.md
+++ b/_posts/en/2018-07-30-xapo-consolidation.md
@@ -6,6 +6,10 @@ type: posts
 layout: post
 lang: en
 version: 1
+excerpt: >
+  A field report from Anthony Towns, a developer at Xapo, about how they
+  consolidated around 4 million UTXOs to prepare for potential future
+  fee increases.
 ---
 
 {:.post-meta}


### PR DESCRIPTION
This adds a test that should catch the problem that lead to #79.  This is the same test I've [used](https://github.com/bitcoin-core/bitcoincore.org/blob/master/Makefile#L21) in the BitcoinCore.org repository (and Bitcoin.org before it).

This PR also fixes an incidence of a broken ref-style link, although it only occurred in the HTML metadata for an article.  The excerpt used to fix that bug is the same as appears on the site [here](https://bitcoinops.org/en/newsletters/2018/07/24/#coming-attractions).  This should not result in any user-visible changes to the site (and I don't see any in my quick testing).