### PR TITLE
blog post: Add review of 2018/plan for 2019

### DIFF
--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -1,5 +1,5 @@
 ---
-title: '2018 Optech Annual Report'
+title: '2018 Annual Report'
 permalink: /en/2018-optech-annual-report/
 name: 2018-12-28-2018-optech-annual-report
 type: posts
@@ -7,6 +7,10 @@ layout: post
 lang: en
 version: 1
 ---
+
+{:.center}
+![logo](/img/logos/optech-horiz.png)<br>
+
 This month, the [Optech team][optech team] met to review the progress that we
 made in 2018 and make plans for 2019. We started Optech earlier this year
 because we wanted to [help companies adopt scaling technologies and raise the

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -1,7 +1,7 @@
 ---
-title: 'Optech review of 2018 and plans for 2019'
-permalink: /en/optech-review-2018-plan-2019/
-name: 2018-12-28-optech-review-2018-plan-2019
+title: '2018 Optech Annual Report'
+permalink: /en/2018-optech-annual-report/
+name: 2018-12-28-2018-optech-annual-report
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
+++ b/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
@@ -7,12 +7,11 @@ layout: post
 lang: en
 version: 1
 ---
-This month, Steve, Mike, James and I met to review the progress that Optech made
-in 2018 and make plans for 2019.
-
-We started Optech earlier this year because we wanted to [help companies adopt
-scaling technologies and raise the level of conversation around scaling
-Bitcoin][announcement]. This year, we’ve:
+This month, the [Optech team][optech team] met to review the progress that
+Optech made in 2018 and make plans for 2019. We started Optech earlier this
+year because we wanted to [help companies adopt scaling technologies and raise
+the level of conversation around scaling Bitcoin][announcement]. This year,
+we’ve:
 
 - Signed up 15 companies as members, including exchanges, custodians, wallets and merchants.
 - Held [two workshops][workshops] to discuss scaling techniques with engineers
@@ -21,7 +20,7 @@ Bitcoin][announcement]. This year, we’ve:
   second.
 - Produced 1 pilot and 26 regular
   [newsletters][]. If all the newsletters to date were printed out on typical
-  book pages, they'd be almost 100 pages long (33,000 words at 350 words per
+  book pages, they'd be over 100 pages long (36,000 words at 350 words per
   page). Over 1,800 Bitcoin engineers and enthusiasts have subscribed to the
   newsletter.
 - Built a [dashboard][] to track the state of the Bitcoin network and the
@@ -32,7 +31,7 @@ Bitcoin][announcement]. This year, we’ve:
 We think that’s a good start, and we’re all proud of what Optech has done so
 far, but we want to do even more next year. Optech's mission has not changed
 for 2019. We remain focused on helping companies adopt Bitcoin scaling
-technologies. Our high-level goals for 2019 are:
+technologies. Our high-level goals for next year are:
 
 1. Hold two workshops, maintaining the high standard of the previous two.
    Following our recent workshop in Europe, we’re provisionally planning a US
@@ -43,8 +42,8 @@ technologies. Our high-level goals for 2019 are:
   have multiple contributors to future chapters.
 1. Publish six more field reports from engineers at member companies that
    describe their experience implementing scaling techniques. We all really
-   enjoyed AJ Towns’s field report on UTXO consolidation in [Newsletter
-   #6][newsletter 6], and would love to see more reports.
+   enjoyed AJ Towns’s field report on UTXO consolidation in [Newsletter #6][],
+   and would love to see more reports.
 1. Add at least six more members in 2019. There are still a few large exchanges
    that haven’t become members yet and we’d love to reach them.
 1. Publish a ‘compatibility matrix’ showing different wallets’ and exchanges’
@@ -64,10 +63,14 @@ There are a few other areas we think we can help:
   to help early adopters.
 
 Thank you to all of our sponsors, members and subscribers for your support this
-year! It really does mean a lot to us. As always, please contact us if you’d
-like to get involved, and let us know if you have any suggestions for how we
-can help companies adopt best practice and help Bitcoin scale.
+year! It really does mean a lot to us. As always, please [contact us][optech
+email] if you’d like to get involved, and let us know if you have any
+suggestions for how we can help companies adopt best practice and help Bitcoin
+scale.
 
+{% include references.md %}
+
+[optech team]: https://bitcoinops.org/about/
 [announcement]: https://bitcoinops.org/en/announcing-bitcoin-optech/
 [workshops]: https://bitcoinops.org/workshops/
 [newsletters]: https://bitcoinops.org/en/newsletters/
@@ -75,5 +78,4 @@ can help companies adopt best practice and help Bitcoin scale.
 [dashboard blog post]: https://bitcoinops.org/en/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md
-[newsletter 6]: https://bitcoinops.org/en/newsletters/2018/07/31/
 [softfork]: https://bitcoinops.org/en/newsletters/2018/12/18/#news

--- a/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
+++ b/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
@@ -1,6 +1,6 @@
 ---
 title: 'Optech review of 2018 and plans for 2019'
-permalink: /en/optech-review-2018-plan-2019
+permalink: /en/optech-review-2018-plan-2019/
 name: 2018-12-28-optech-review-2018-plan-2019
 type: posts
 layout: post
@@ -22,11 +22,11 @@ Bitcoin][announcement]. This year, we’ve:
 - Produced 1 pilot and 26 regular
   [newsletters][]. If all the newsletters to date were printed out on typical
   book pages, they'd be almost 100 pages long (33,000 words at 350 words per
-  page). Over 1700 Bitcoin engineers and enthusiasts have subscribed to the
+  page). Over 1,800 Bitcoin engineers and enthusiasts have subscribed to the
   newsletter.
 - Built a [dashboard][] to track the state of the Bitcoin network and the
   adoption rate of scaling technologies. Marcin wrote about the [building the
-  dashboard in an Optech blog post][dashboard blog post]. 
+  dashboard in an Optech blog post][dashboard blog post].
 - Started writing the first chapter of our [Scaling Book][scaling book].
 
 We think that’s a good start, and we’re all proud of what Optech has done so

--- a/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
+++ b/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
@@ -1,0 +1,79 @@
+---
+title: 'Optech review of 2018 and plans for 2019'
+permalink: /en/optech-review-2018-plan-2019
+name: 2018-12-28-optech-review-2018-plan-2019
+type: posts
+layout: post
+lang: en
+version: 1
+---
+This month, Steve, Mike, James and I met to review the progress that Optech made
+in 2018 and make plans for 2019.
+
+We started Optech earlier this year because we wanted to [help companies adopt
+scaling technologies and raise the level of conversation around scaling
+Bitcoin][announcement]. This year, we’ve:
+
+- Signed up 15 companies as members, including exchanges, custodians, wallets and merchants.
+- Held [two workshops][workshops] to discuss scaling techniques with engineers
+  from member companies. Almost all attendees thought the workshops were ‘good’
+  or ‘excellent’, with an average score of 3.7/5 for the first and 4.2/5 for the
+  second.
+- Produced 1 pilot and 26 regular
+  [newsletters][]. If all the newsletters to date were printed out on typical
+  book pages, they'd be almost 100 pages long (33,000 words at 350 words per
+  page). Over 1700 Bitcoin engineers and enthusiasts have subscribed to the
+  newsletter.
+- Built a [dashboard][] to track the state of the Bitcoin network and the
+  adoption rate of scaling technologies. Marcin wrote about the [building the
+  dashboard in an Optech blog post][dashboard blog post]. 
+- Started writing the first chapter of our [Scaling Book][scaling book].
+
+We think that’s a good start, and we’re all proud of what Optech has done so
+far, but we want to do even more next year. Optech's mission has not changed
+for 2019. We remain focused on helping companies adopt Bitcoin scaling
+technologies. Our high-level goals for 2019 are:
+
+1. Hold two workshops, maintaining the high standard of the previous two.
+   Following our recent workshop in Europe, we’re provisionally planning a US
+  East Coast workshop in the first half of 2019 and US West Coast in the second
+  half of 2019.
+1. Make significant progress on the Scaling Book. We want to complete the [fee
+   bumping chapter][scaling book feebumping] and several more chapters, and
+  have multiple contributors to future chapters.
+1. Publish six more field reports from engineers at member companies that
+   describe their experience implementing scaling techniques. We all really
+   enjoyed AJ Towns’s field report on UTXO consolidation in [Newsletter
+   #6][newsletter 6], and would love to see more reports.
+1. Add at least six more members in 2019. There are still a few large exchanges
+   that haven’t become members yet and we’d love to reach them.
+1. Publish a ‘compatibility matrix’ showing different wallets’ and exchanges’
+   support for scaling technologies. Mike has already been working on
+   documenting wallet and exchange compatibility with RBF and we plan to publish
+   that work on our website in early 2019.
+
+There are a few other areas we think we can help:
+
+- We want our newsletter to reach more people who don’t necessarily speak
+  English, particularly in China, Japan and Korea. If you’re a subscriber and
+  would like to help translating the newsletter, let us know!
+- As we move towards formalization and possible implementation of a
+  [Schnorr/Taproot softfork][softfork], we want to help our member companies
+  and other Bitcoin organizations prepare for the change. We think we can help
+  with soliciting industry input to the specification and building docs and tools
+  to help early adopters.
+
+Thank you to all of our sponsors, members and subscribers for your support this
+year! It really does mean a lot to us. As always, please contact us if you’d
+like to get involved, and let us know if you have any suggestions for how we
+can help companies adopt best practice and help Bitcoin scale.
+
+[announcement]: https://bitcoinops.org/en/announcing-bitcoin-optech/
+[workshops]: https://bitcoinops.org/workshops/
+[newsletters]: https://bitcoinops.org/en/newsletters/
+[dashboard]: https://dashboard.bitcoinops.org/
+[dashboard blog post]: https://bitcoinops.org/en/dashboard-announcement/
+[scaling book]: https://github.com/bitcoinops/scaling-book
+[scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md
+[newsletter 6]: https://bitcoinops.org/en/newsletters/2018/07/31/
+[softfork]: https://bitcoinops.org/en/newsletters/2018/12/18/#news

--- a/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
+++ b/_posts/en/2018-12-28-optech-review-2018-plan-2019.md
@@ -7,11 +7,10 @@ layout: post
 lang: en
 version: 1
 ---
-This month, the [Optech team][optech team] met to review the progress that
-Optech made in 2018 and make plans for 2019. We started Optech earlier this
-year because we wanted to [help companies adopt scaling technologies and raise
-the level of conversation around scaling Bitcoin][announcement]. This year,
-we’ve:
+This month, the [Optech team][optech team] met to review the progress that we
+made in 2018 and make plans for 2019. We started Optech earlier this year
+because we wanted to [help companies adopt scaling technologies and raise the
+level of conversation around scaling Bitcoin][announcement]. This year, we’ve:
 
 - Signed up 15 companies as members, including exchanges, custodians, wallets and merchants.
 - Held [two workshops][workshops] to discuss scaling techniques with engineers

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,6 +5,10 @@
 @import "minima";
 @import "vendor/font-awesome/font-awesome";
 
+.center {
+    text-align: center;
+}
+
 .post-meta {
     text-align: center;
 }


### PR DESCRIPTION
Incorporated feedback from @harding @moneyball and @bitschmidty . Thanks!

Could do with an image and a snappier title. It looks a bit :yawning_face: right now.

I suggest we release at the same time as our year-in-review newsletter (and add a link from the newsletter to the blog post).