### PR TITLE
Update Ruby version, remove Travis workaround, and add Markdown linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.2.2"
+  - "2.5.1"
 
 ## Allows use of docker-based containers, which are more available than
 ## the xen-based (or whatever) VMs, so builds tend to happen sooner
@@ -8,10 +8,6 @@ sudo: false
 
 ## Save bundler deps.  Requires sudo: false
 cache: bundler
-
-## Required if our Ruby version is 2.2 or below
-before_install:
-   - gem install bundler -v '< 2'
 
 ## Build all possible jekyll pages for use with link checking.
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ## If you update the version here, also update it in .travis.yml and
 ## README.md. Then push your branch and make sure Travis supports that
 ## version.
-ruby '2.2.2'
+ruby '2.5.1'
 
 ## If you add a new Gem below, run `bundle install` to install it.
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ end
 
 group :testing do
   gem 'html-proofer'
+  gem 'mdl'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ DEPENDENCIES
   minima (~> 2.0)
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,10 @@ GEM
     listen (3.1.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
+    mdl (0.5.0)
+      kramdown (~> 1.12, >= 1.12.0)
+      mixlib-cli (~> 1.7, >= 1.7.0)
+      mixlib-config (~> 2.2, >= 2.2.1)
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
     minima (2.5.0)
@@ -64,6 +68,9 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.18)
+      tomlrb
     nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
@@ -81,6 +88,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
+    tomlrb (1.2.8)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
@@ -93,6 +101,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll
+  mdl
   minima (~> 2.0)
 
 RUBY VERSION

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 	bundle exec jekyll build --future --drafts --unpublished
 
 test:
+	## Check for Markdown formatting problems
+	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
+	bundle exec mdl -g -r MD009 .
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	## Check for broken links

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ following command:
 
     source ~/.rvm/scripts/rvm
 
-**Install Ruby 2.2.2**
+**Install Ruby 2.5.1**
 
-To install Ruby 2.2.2, simply run this command:
+To install Ruby 2.5.1, simply run this command:
 
-    rvm install 2.2.2
+    rvm install 2.5.1
 
 Sometimes this will find a pre-compiled Ruby package for your Linux
 distribution, but sometimes it will need to compile Ruby from scratch
 (which takes about 15 minutes).
 
-After Ruby 2.2.2 is installed, make it your default Ruby:
+After Ruby 2.5.1 is installed, make it your default Ruby:
 
-    rvm alias create default ruby-2.2.2
+    rvm alias create default ruby-2.5.1
 
 And tell your system to use it:
 

--- a/_config.yml
+++ b/_config.yml
@@ -37,3 +37,4 @@ exclude:
    - node_modules
    - vendor/
    - Makefile
+   - README.md

--- a/_includes/linkers/issues.md
+++ b/_includes/linkers/issues.md
@@ -1,5 +1,5 @@
 {% capture /dev/null %}
-<!-- 
+<!--
 issues.md: creates Markdown referency-style links to issues and pull
 requests in the Bitcoin Core, LND, C-Lightning, and libsecp256k1 repositories.
 

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -56,7 +56,7 @@ Above all, it's very important to highlight what we're *not*:
 - We're not a Bitcoin foundation. We're just engineers and contributors who
   care about Bitcoin and want to see it succeed.
 - We don't represent Bitcoin Core. We've all contributed to that project, but
-  our work with Bitcoin Optech is project-agnostic. 
+  our work with Bitcoin Optech is project-agnostic.
 - We don't represent and are not beholden to any Bitcoin companies.
 - We're not profit-driven. We're fortunate enough to have sponsorship to
   carry out our work, and are asking for modest contributions from member

--- a/_posts/en/2018-09-04-dashboard-announcement.md
+++ b/_posts/en/2018-09-04-dashboard-announcement.md
@@ -11,25 +11,25 @@ version: 1
 {:.post-meta}
 *by [Marcin Jachymiak](https://github.com/marcinja)<br>Intern at Bitcoin Optech*
 
-This summer I was an intern for [Bitcoin Optech](https://bitcoinops.org), working on a Bitcoin metrics dashboard. In this post I'll be describing the purpose of the dashboard and how it was implemented. 
+This summer I was an intern for [Bitcoin Optech](https://bitcoinops.org), working on a Bitcoin metrics dashboard. In this post I'll be describing the purpose of the dashboard and how it was implemented.
 
-The goal of the Optech dashboard is to show a variety of metrics of how effectively blockspace is being used. Important metrics are those that show activity like: 
+The goal of the Optech dashboard is to show a variety of metrics of how effectively blockspace is being used. Important metrics are those that show activity like:
  - [batching](https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Payment_batching): combining the outputs of what would otherwise be many different transactions into a single transaction
  - [consolidations](https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation): combining many UTXOs in a single UTXO during low fee period, to avoid paying a higher fee in the future
  - dust creation: creation of UTXOs that cost more to spend than they have value, at different fee-rates
  - SegWit adoption: creation of and spending from SegWit outputs
- 
+
 
 The dashboard is live and is showing these stats and more at [dashboard.bitcoinops.org](https://dashboard.bitcoinops.org).
 
 The dataset used for the dashboard is also saved as a directory of JSON files, updated nightly. You can download the zipped dataset from our [S3 bucket](http://dashboard.dataset.s3.us-east-2.amazonaws.com/backups/bitcoinops-dataset.tar.gz). If you just want the JSON file for a specific block, you can get it at: `http://dashboard.dataset.s3.us-east-2.amazonaws.com/blocks/BLOCK_NUMBER.json` If you'd rather recreate the data using your own full node (it might take a few days), you can use the code with instructions at [github.com/bitcoinops/btc-dashboard](https://github.com/bitcoinops/btc-dashboard).
 
 An [example JSON file with an explanation of added fields](https://github.com/bitcoinops/btc-dashboard/blob/master/STATS_TRACKED.md) is available in the same repository.
- 
+
 ## Implementation
 The rest of this post will be about my experience building the dashboard. To start, I looked at an existing tool for blockchain analysis, like BlockSci. Although BlockSci works pretty well, it has a long setup time and I was also looking to analyze blocks as they were being confirmed. In my experience using BlockSci, I found it very easy to write queries similar to [those in the demo they produced](https://citp.github.io/BlockSci/demo.html), which took just a few minutes to return a result. The main downside with using BlockSci is that its parser takes a long time to pre-process blockchain data, but once that is done it performs quite well.
 
-After exploring these options, I decided I could probably get most of the stats needed for the dashboard through RPCs from bitcoind. I wrote some simple code (using btcd's RPC client) to get the stats I needed from each transaction with the `getblock` and `getrawtransaction` RPCs. This code worked pretty well for smaller blocks, but when I tried using it to get the stats of a more recent block - which often have over a thousand transactions - I quickly noticed a problem. My code was calling `getrawtransaction` for every single transaction input in the block. Asking bitcoind to do thousands of RPCs for every single block quickly becomes unsustainable, and was taking a very long time. 
+After exploring these options, I decided I could probably get most of the stats needed for the dashboard through RPCs from bitcoind. I wrote some simple code (using btcd's RPC client) to get the stats I needed from each transaction with the `getblock` and `getrawtransaction` RPCs. This code worked pretty well for smaller blocks, but when I tried using it to get the stats of a more recent block - which often have over a thousand transactions - I quickly noticed a problem. My code was calling `getrawtransaction` for every single transaction input in the block. Asking bitcoind to do thousands of RPCs for every single block quickly becomes unsustainable, and was taking a very long time.
 
 This code looked something like this:
 ```
@@ -37,7 +37,7 @@ block, err := rpcclient.GetBlock(blockHash)
 for _, tx := range block.Transactions {
     for _, input := range tx.TxIn {
         analyzeInput(input)
-            
+
         prevTx := rpcclient.GetRawTransaction(input.PreviousOutPoint.Hash)
         analyzePrevOut(input, prevTx)
     }
@@ -61,15 +61,15 @@ I patched `getblockstats` in bitcoind to get the following stats:
 
     ![segwit](/img/posts/dashboard-announcement/segwit-example-graph.png)
 
-- consolidation metrics: the number of transactions that consolidate many UTXOs into one transaction output, and the total number of outputs consolidated. The heuristic used is a "many-to-one" transaction: a transaction with at least 3 inputs and exactly 1 output. 
+- consolidation metrics: the number of transactions that consolidate many UTXOs into one transaction output, and the total number of outputs consolidated. The heuristic used is a "many-to-one" transaction: a transaction with at least 3 inputs and exactly 1 output.
 
     ![mto](/img/posts/dashboard-announcement/mto-consolidations.png)
 
 - batching metrics: transactions that have many outputs, grouped by output counts in various ranges (inspired by a [P2SH.info](https://p2sh.info/dashboard/db/batching?orgId=1) graph).
 
     ![batching](/img/posts/dashboard-announcement/batching.png)
-  
-- dust creation: the number of new UTXOs that would be considered dust at several different fee-rates. 
+
+- dust creation: the number of new UTXOs that would be considered dust at several different fee-rates.
     ![dust](/img/posts/dashboard-announcement/dust.png)
 
 The patch to `getblockstats` with these extra stats (and some more) is [publicly available](https:///github.com/bitcoinops/bitcoin/tree/expand-getblockstats). I also [patched the btcd RPC client](https://github.com/bitcoinops/btcd/tree/dashboard-rpc) for convenience to allow usage of `getblockstats` in the code I wrote.
@@ -78,7 +78,7 @@ The patch to `getblockstats` with these extra stats (and some more) is [publicly
 Using the `getblockstats` RPC to get data from the entire history of Bitcoin can still be pretty slow! Running the code to backfill data from all blocks on my desktop, it would have taken weeks to get all the data. After profiling bitcoind while it responded to `getblockstats` RPCs, we saw that as expected most of its time was spent retrieving transactions from the tx_index, so we configured bitcoind to better handle all these database reads:
 
 - First, we increased the `dbcache` option to around 2GB. Since most of the work done in the RPC is just reading through the database for blocks and transactions, this is pretty useful.
-- Second, we turned off the network connection of the node using `noconnect` and `nolisten`. Without any network connections, a full node doesn't really have anything to do except respond to RPCs. 
+- Second, we turned off the network connection of the node using `noconnect` and `nolisten`. Without any network connections, a full node doesn't really have anything to do except respond to RPCs.
 
 One final performance improvement was just to use better hardware. I had been running the dashboard backfiller on my desktop where all my blockdata is on a HDD. After getting it running on a server with a SSD, database reads were much faster and therefore the backfilling process took much less time. On average, it was processing a block every 0.6 seconds. Tiny blocks with fewer transactions took even less time than that. With this setup, backfilling took just a few days.
 
@@ -87,9 +87,9 @@ Now that the historical data has been collected, the same setup is used to do a 
 ### Databases
 What do we do with all the data from `getblockstats`?
 
-First, we derive some extra stats like "percentage of X that are Y" from the stats "X" and "Y" for the sake of convenience (the bitcoind patch doesn't include these to give users the option to not have them and because they are trivial to compute). Then we store the result as a JSON file, and in a database. This is done in a program that uses the modified btcd RPC client described above. To make the graphs on our site we use Grafana, a tool for creating dashboards and visualizations, which makes queries into this database. 
+First, we derive some extra stats like "percentage of X that are Y" from the stats "X" and "Y" for the sake of convenience (the bitcoind patch doesn't include these to give users the option to not have them and because they are trivial to compute). Then we store the result as a JSON file, and in a database. This is done in a program that uses the modified btcd RPC client described above. To make the graphs on our site we use Grafana, a tool for creating dashboards and visualizations, which makes queries into this database.
 
-The first database I used was InfluxDB. I chose it because it seemed popular for Grafana dashboards and was easy to use and set up. Unfortunately, I quickly ran into some issues while using it. InfluxDB likes to use a lot of memory, around 14GB with the full dataset loaded. This is less of a problem if you throw hardware at it. With better hardware, we still ran into another issue of slow query times. After trying to tweak the settings I couldn't find a way to make the situation much better. 
+The first database I used was InfluxDB. I chose it because it seemed popular for Grafana dashboards and was easy to use and set up. Unfortunately, I quickly ran into some issues while using it. InfluxDB likes to use a lot of memory, around 14GB with the full dataset loaded. This is less of a problem if you throw hardware at it. With better hardware, we still ran into another issue of slow query times. After trying to tweak the settings I couldn't find a way to make the situation much better.
 
 In the dashboard, we want to be able to show historic trends, which means making queries that might ask for years worth of data. These queries were especially slow and often took over 60 seconds to make. After trying a bunch of different settings in InfluxDB, I decided to try a different database and compare the performance. Disclaimer: I don't really know what I'm doing with InfluxDB and more or less was using default settings with some changes here and there. I will say that InfluxDB worked just fine for queries at smaller time-scales.
 
@@ -111,7 +111,7 @@ err = db.CreateTable(model, &orm.CreateTableOptions{
 err := worker.pgClient.Insert(&data.DashboardDataRow)
 ```
 
-At this point I spent more time writing code to get information *out* of InfluxDB then on inserting it into Postgres. Once the switch to Postgres was done, the dashboard graphs came up much faster in Grafana. 
+At this point I spent more time writing code to get information *out* of InfluxDB then on inserting it into Postgres. Once the switch to Postgres was done, the dashboard graphs came up much faster in Grafana.
 
 ## Results
 You can use the Bitcoin Optech dashboard to see these stats as historical trends from the entire history of Bitcoin, and also from new blocks as they get confirmed. All of this is available live on our dashboard at [dashboard.bitcoinops.org](https://dashboard.bitcoinops.org)!

--- a/_posts/en/newsletters/2018-07-31-newsletter.md
+++ b/_posts/en/newsletters/2018-07-31-newsletter.md
@@ -97,7 +97,7 @@ and answers made there in the past month.*
   scheme.
 
 - [Why does HD key derivation stop working after a certain index in
-  BIP44 wallets?][bse 76998]: a developer testing his wallet finds that 
+  BIP44 wallets?][bse 76998]: a developer testing his wallet finds that
   a payment sent to low-numbered key indexes works as expected, but
   payments sent to high-numbered indexes never appear in his wallets.
   An answer from Viktor T. reveals why.

--- a/_posts/en/newsletters/2018-08-07-newsletter.md
+++ b/_posts/en/newsletters/2018-08-07-newsletter.md
@@ -87,19 +87,19 @@ Bitcoin Core, LND, and C-Lightning projects.
 *Notable commits this week in [Bitcoin Core][core commits], [LND][lnd
 commits], and [C-lightning][cl commits].*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="ef4fac0ea5b4891f4529e4b59dfd1f7aeb3009b5"
   end="2b67354aa584c4aabae049a67767ac7b70e2d01a"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="92b0b10dc75de87be3a9f895c8dfc5a84a2aec7a"
   end="f0f5e11b826e020c11c37343bcbaf9725627378b"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="0b597f671aa31c1c56d32a554fcdf089646fc7c1"

--- a/_posts/en/newsletters/2018-08-14-newsletter.md
+++ b/_posts/en/newsletters/2018-08-14-newsletter.md
@@ -6,7 +6,7 @@ type: newsletter
 layout: newsletter
 lang: en
 ---
-This week's newsletter includes the usual dashboard and action items, 
+This week's newsletter includes the usual dashboard and action items,
 news about the importance of allowing secure and anonymous responsible
 disclosure of bugs, a potential new payment protocol that can improve
 privacy on Bitcoin without any consensus rule changes, shaving one byte
@@ -64,7 +64,7 @@ source: [Optech dashboard][periodic txn data]*
   cryptocurrency maintainers but possibly also useful for organizations
   using cryptocurrencies.
 
-  
+
     Optech encourages our member companies (and any others reading this
     newsletter) to consider how easy it would be for an anonymous
     researcher to report a critical bug to your staff.  An easy way to
@@ -97,7 +97,7 @@ source: [Optech dashboard][periodic txn data]*
     for P2EP spending and [BTCPay
     Server](https://github.com/btcpayserver/btcpayserver) is considering
     adding support for P2EP receiving.
-  
+
 - **Bitcoin Core wallet to begin only creating low-R
   signatures:** the DER format used to encode Bitcoin signatures
   requires adding an entire extra byte to a signature just to indicate
@@ -179,19 +179,19 @@ projects this week seemed to be improvements to their automated testing
 code; we aren't describing those in this newsletter, but we're sure
 users and developers highly appreciate that work.*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="2b67354aa584c4aabae049a67767ac7b70e2d01a"
   end="1b04b55f2d22078ca79cd38fc1078e15fa9cbe94"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="f0f5e11b826e020c11c37343bcbaf9725627378b"
   end="6989316b11c51922b4c6ae3507ac06680ec530b9"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="80a8e57ede82292818032eeb3510da067fddfd5e"

--- a/_posts/en/newsletters/2018-08-21-newsletter.md
+++ b/_posts/en/newsletters/2018-08-21-newsletter.md
@@ -67,7 +67,7 @@ Core.  Here's a summary of the projects discussed:
   RISC-V bitcoin node in the world" which has already synced part of
   the chain.
 
-- **Bandwidth-efficient set reconciliation protocol for transactions** 
+- **Bandwidth-efficient set reconciliation protocol for transactions**
   being worked on by Gregory Maxwell, Gleb Naumenko, and Pieter Wuille.
   This may allow a node that has new transactions in its mempool to tell
   a peer about those transactions by communicating an amount of data
@@ -105,19 +105,19 @@ commits], and [C-lightning][cl commits].*
 minor doc updates, so no news for them.  I'm still leaving them
 mentioned above for easy copy/paste next week. -harding -->{% endcomment %}
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="1b04b55f2d22078ca79cd38fc1078e15fa9cbe94"
   end="df660aa7717a6f4784e90535a13a95d82244565a"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="6989316b11c51922b4c6ae3507ac06680ec530b9"
   end="3f5ec993300e38369110706ac83301b8875500d6"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="a97955845ff43d4780b33a7301695db33823c57c"

--- a/_posts/en/newsletters/2018-08-28-newsletter.md
+++ b/_posts/en/newsletters/2018-08-28-newsletter.md
@@ -106,19 +106,19 @@ wait until version 0.18 in about six months from now.*
 
 {% comment %}<!-- I didn't notice anything interesting in LND this week -harding -->{% endcomment %}
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="df660aa7717a6f4784e90535a13a95d82244565a"
   end="427253cf7e19ed9ef86b45457de41e345676c88e"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="3f5ec993300e38369110706ac83301b8875500d6"
   end="26f68da5b2883885fcf6a8e79b3fc9bb12cc9eef"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="80a875a9a54e26c2ea4c90aee8fe606ddcc27c55"

--- a/_posts/en/newsletters/2018-09-04-newsletter.md
+++ b/_posts/en/newsletters/2018-09-04-newsletter.md
@@ -90,19 +90,19 @@ wait until version 0.18 in about six months from now.*
 
 {% comment %}<!-- LND only had three merges this week, none of them exciting IMO -harding -->{% endcomment %}
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="427253cf7e19ed9ef86b45457de41e345676c88e"
   end="68f3c7eb080e461cfeac37f8db7034fe507241d0"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="26f68da5b2883885fcf6a8e79b3fc9bb12cc9eef"
   end="2b448be048daf85cef4cbb37ceed4413fdb051e6"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"

--- a/_posts/en/newsletters/2018-09-11-newsletter.md
+++ b/_posts/en/newsletters/2018-09-11-newsletter.md
@@ -59,19 +59,19 @@ Bitcoin Core are made to its master development branch and are unlikely
 to become part of the upcoming 0.17 release---you'll probably have to
 wait until version 0.18 in about six months from now.*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="68f3c7eb080e461cfeac37f8db7034fe507241d0"
   end="cb25cd6aa18c69918176d68e36e26f7e373aa48c"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="2b448be048daf85cef4cbb37ceed4413fdb051e6"
   end="1941353fb28755a170793e43595601d75c8f3dda"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -57,7 +57,7 @@ merges in popular Bitcoin infrastructure projects.
   transactions ([BIP174][]), an introduction to output script
   descriptors, suggestions for Lightning Network wallet integration, and
   approaches to efficient coin selection (including output
-  consolidation). 
+  consolidation).
 
 ## News
 
@@ -93,7 +93,7 @@ merges in popular Bitcoin infrastructure projects.
 
     Currently, discussion appears to be most active on the BIP
     proposal's [pull request][BIP322 PR].
-    
+
 - **Bustapay discussion:** a simplified alternative to the proposed
   Pay-to-Endpoint (P2EP) protocol [described in newsletter #8][news8
   news], Bustapay provides improved privacy for both spenders and
@@ -121,19 +121,19 @@ Bitcoin Core are made to its master development branch and are unlikely
 to become part of the upcoming 0.17 release---you'll probably have to
 wait until version 0.18 in about six months from now.*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="cb25cd6aa18c69918176d68e36e26f7e373aa48c"
   end="c53e083a49291b611d278a8db24ff235c1202e43"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="1941353fb28755a170793e43595601d75c8f3dda"
   end="3b2c807288b1b7f40d609533c1e96a510ac5fa6d"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="634f19a7b230edc686be56ab950b80784e56252c"
@@ -147,7 +147,7 @@ wait until version 0.18 in about six months from now.*
   transaction relay problems.  However, there's no requirement (or way
   to require) that nodes send a reject message or an accurate reject
   message, so the messages arguably only end up wasting bandwidth.
-  
+
     It's recommended that developers connect their test clients to their
     own nodes and inspect their nodes' logs for error messages in case
     of problems (perhaps after enabling debug logging).  Users who still

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -16,13 +16,13 @@ infrastructure projects.
   reported early Friday (UTC), the denial-of-service vulnerability
   described in last week's Optech newsletter is now known to allow
   miners to trick affected systems into accepting invalid bitcoins.
-  
+
     As of this writing, it's believed that a majority of large Bitcoin
     services and miners have upgraded, likely ensuring that any blocks
     exploiting the bug will be quickly reorganized out of the most
     proof-of-work chain---reducing the risk for SPV clients and
     non-upgraded nodes.
-  
+
     If you don't plan to upgrade or if you use an SPV client, you should
     consider waiting for more confirmations than you usually do (30
     confirmations---about 5 hours worth---is a normal
@@ -39,7 +39,7 @@ infrastructure projects.
     - [0.15.2][] (backport to old version, may have other issues)
 
     - [0.14.3][] (backport to old version, may have other issues)
-  
+
 - **Allocate time to test Bitcoin Core 0.17RC4:** Bitcoin Core has
   uploaded [binaries][bcc 0.17] for 0.17 Release Candidate (RC) 4.
   Testing is greatly appreciated and can help ensure the quality of the
@@ -75,7 +75,7 @@ infrastructure projects.
     then-undisclosed inflation risk: Pieter Wuille, Gregory Maxwell,
     Wladimir van der Laan, Cory Fields, Suhas Daftuar, Alex Morcos, and
     Matt Corallo.
-    
+
 ## Selected Q&A from Bitcoin StackExchange
 
 {% comment %}<!-- https://bitcoin.stackexchange.com/search?tab=votes&q=created%3a1m..%20is%3aanswer -->{% endcomment %}
@@ -119,19 +119,19 @@ Bitcoin Core are made to its master development branch and are unlikely
 to become part of the upcoming 0.17 release---you'll probably have to
 wait until version 0.18 in about six months from now.*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="c53e083a49291b611d278a8db24ff235c1202e43"
   end="920c090f63f4990bf0f3b3d1a6d3d8a8bcd14ba0"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="3b2c807288b1b7f40d609533c1e96a510ac5fa6d"
   end="f4305097e1638f6f8958dfa9eec941d8bf80246e"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="36eab5de26e203311ceeb65c94ec5beb9c94ff5d"
@@ -152,7 +152,7 @@ wait until version 0.18 in about six months from now.*
   a test case for it) that may have allowed a node to trick one of its
   peers into believing a different peer had a routing failure, thus
   possibly redirecting traffic to the malicious node.
-  
+
 - C-Lightning now provides a `gossipwith` tool that allows you to
   receive gossip from a node independently of lightningd or even to send
   the remote node a message.  This tool is used for additional testing

--- a/_posts/en/newsletters/2018-10-02-newsletter.md
+++ b/_posts/en/newsletters/2018-10-02-newsletter.md
@@ -37,7 +37,7 @@ projects.
   it, leading to a consensus failure (chainsplit) where the chain with
   the most proof of work contained the duplicate inputs and a weaker
   chain did not.
-  
+
     Eventually, the chain without the duplicate inputs gained more proof
     of work and the vulnerable nodes attempted to switch to it.  This
     caused the vulnerable nodes to attempt to re-add the duplicate input
@@ -52,25 +52,25 @@ projects.
     many block explorers with a testnet mode did accept the vulnerable
     block, providing a reminder that users should be careful about using
     third-parties to determine whether or not transactions are valid.
-    
+
 ## Notable code changes
 
 *Notable code changes this week in [Bitcoin Core][core commits],
 [LND][lnd commits], and [C-lightning][cl commits].*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="920c090f63f4990bf0f3b3d1a6d3d8a8bcd14ba0"
   end="c9327306b580bb161d1732c0a0260b46c0df015c"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="f4305097e1638f6f8958dfa9eec941d8bf80246e"
   end="79ed4e8b600e4834f058cbf3cb8b93f5aa5ab3d4"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="3ce53ab9eddd397d57b6afc5faefe6703e56ac26"

--- a/_posts/en/newsletters/2018-10-09-newsletter.md
+++ b/_posts/en/newsletters/2018-10-09-newsletter.md
@@ -278,7 +278,7 @@ newsletter's author.
 [tx script]: https://diyhpl.us/wiki/transcripts/scalingbitcoin/tokyo-2018/bitcoin-script/
 [musig paper]: https://eprint.iacr.org/2018/068
 [schnorr pre-bip]: https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
-[pairing-based cryptography]: https://en.wikipedia.org/wiki/Pairing-based_cryptography 
+[pairing-based cryptography]: https://en.wikipedia.org/wiki/Pairing-based_cryptography
 [bls sigs]: https://en.wikipedia.org/wiki/Boneh%E2%80%93Lynn%E2%80%93Shacham
 [scriptless scripts transcript]: https://scalingbitcoin.org/transcript/stanford2017/using-the-chain-for-what-chains-are-good-for
 [eltoo protocol]: https://blockstream.com/2018/04/30/eltoo-next-lightning.html

--- a/_posts/en/newsletters/2018-10-16-newsletter.md
+++ b/_posts/en/newsletters/2018-10-16-newsletter.md
@@ -102,19 +102,19 @@ on some of the transcripts for the event in Tokyo last week:
 *Notable code changes this week in [Bitcoin Core][core commits],
 [LND][lnd commits], and [C-lightning][cl commits].*
 
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="core commits"
   repo="bitcoin/bitcoin"
   start="c9327306b580bb161d1732c0a0260b46c0df015c"
   end="be992701b018f256db6d64786624be4cb60d8975"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="lnd commits"
   repo="lightningnetwork/lnd"
   start="79ed4e8b600e4834f058cbf3cb8b93f5aa5ab3d4"
   end="e5b84cfadab56037ae3957e704b3e570c9368297"
 %}
-{% include linkers/github-log.md 
+{% include linkers/github-log.md
   refname="cl commits"
   repo="ElementsProject/lightning"
   start="d6fcfe00c722f7e6f4b691cd47743ed593aeea0e"

--- a/_posts/en/newsletters/2018-10-30-newsletter.md
+++ b/_posts/en/newsletters/2018-10-30-newsletter.md
@@ -32,7 +32,7 @@ projects.
   "worst of both worlds" situation where wallets using BIP69 can be
   fairly easily identified and so wallets not using BIP69 may also be
   easier to identify by negation.
-  
+
     In this [thread][bip69 thread] to the Bitcoin-Dev mailing list, Ryan
     Havar suggests that one reason wallet authors like BIP69 is that its
     deterministic ordering makes it easy and fast for their tests to
@@ -118,7 +118,7 @@ answers made since our last update.*
   current block subsidy of about $80,000---but using [AJ Towns's recent
   estimate][towns mining estimate] of $0.16/kWh that includes costs
   beyond electricity and attempts to factor in risk premiums, the
-  estimated block cost is about $135,000. 
+  estimated block cost is about $135,000.
 
 ## Notable merges
 

--- a/_posts/en/newsletters/2018-12-04-newsletter.md
+++ b/_posts/en/newsletters/2018-12-04-newsletter.md
@@ -92,7 +92,7 @@ maintenance release.
     recent Linux distributions as well as fix other [minor issues][0.17.1 milestone].
 
 [LND 0.5.1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.5.1-beta
-    
+
 ## Notable code changes
 
 *Notable code changes this week in [Bitcoin Core][core commits],


### PR DESCRIPTION
This removes the need for the workaround in 71e9fad42cecd44cfc418a5802490cd809703a8d by updating Ruby.  I chose Ruby 2.5.1 because [that's the version](https://packages.ubuntu.com/bionic/ruby2.5) used for Ubuntu 18.04 LTS, so users of that system should, in theory, not even need to use rvm to get a Ruby to build site previews.  I use Debian, not Ubuntu, so I haven't tested that.

This also adds a lint checker suggested by @practicalswift with a single check for extraneous spaces at the end of a line.  I think this is an important rule because some Markdown parsers turn two spaces at the end of a line into a `<br>` tag, complicating review because whitespace at the end of a line is often invisible.  There are plenty of [other rules](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md) we can add if we want, although I'd prefer to focus on preventing problems rather than enforcing a consistent style.

The short steps to upgrade are:

1. `cd` to your checkout
2. (Optional) Checkout current master, run `make all`, then run `cp -a _site _old_site`
2. Checkout this PR
3. Then,

```bash
rvm install 2.5.1
cd ; cd -
ruby --version
# Should say something like: ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
bundle install
make all
```

Optionally, you can finish by running `diff -ru _old_site _site` to see how this change affects the build.  Besides changing in-file datestamps, the only changes I see are rearragements in the order associative arrays are printed and the README.md file is no longer rendered on the site (as expected).

Note that if you checkout out a branch that uses the previous version of Ruby, you need to exit and re-enter the top-level repository directory to get RVM to select the current Ruby version.  You can go to your home directory and back to your last-used directory using: `cd ; cd -`

On my system, going back to an older version of Ruby causes one of HTMLproofer's dependencies to segfault.  This can be resolved by deleting your cached bundler gems (on Linux, try `mv ~/.gems /tmp`) and then re-running `bundle install`