### PR TITLE
Revamp index and content listings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,5 @@ exclude:
    - vendor/
    - Makefile
    - README.md
+
+show_excerpts: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,12 +20,10 @@
         </label>
 
         <div class="trigger">
-          {%- for path in page_paths -%}
-            {%- assign my_page = site.pages | where: "path", path | first -%}
-            {%- if my_page.title -%}
-            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-            {%- endif -%}
-          {%- endfor -%}
+            <a class="page-link" href="/about/">About</a>
+            <a class="page-link" href="/en/blog/">Blog</a>
+            <a class="page-link" href="/en/newsletters/">Newsletters</a>
+            <a class="page-link" href="/workshops/">Workshops</a>
             <a class="page-link" href="https://dashboard.bitcoinops.org/">Dashboard</a>
         </div>
       </nav>

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -6,6 +6,12 @@ type: posts
 layout: post
 lang: en
 version: 1
+excerpt: >
+  Today we’re announcing our new project, Bitcoin Operations Technology
+  Group (Optech). We want to help Bitcoin companies adopt the best
+  scaling techniques and technologies available to make efficient use of
+  the blockchain, and thereby help Bitcoin to scale to more users and
+  use cases.
 ---
 
 Today we’re announcing our new project, Bitcoin Operations Technology Group

--- a/_posts/en/2018-09-04-dashboard-announcement.md
+++ b/_posts/en/2018-09-04-dashboard-announcement.md
@@ -6,6 +6,10 @@ type: posts
 layout: post
 lang: en
 version: 1
+excerpt: >
+  Introducing the Bitcoin Optech Dashboard, which contains live-updated
+  statistics about consolidations, payment batching, RBF, segwit
+  adoption, and more.
 ---
 
 {:.post-meta}

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -6,6 +6,9 @@ type: posts
 layout: post
 lang: en
 version: 1
+excerpt: >
+  Bitcoin Optech reviews our 2018 accomplishments and summarizes our
+  plans for 2019.
 ---
 
 {:.center}

--- a/_posts/en/newsletters/2018-06-08-newsletter.md
+++ b/_posts/en/newsletters/2018-06-08-newsletter.md
@@ -6,6 +6,10 @@ type: newsletter
 layout: newsletter
 lang: en
 version: 1
+excerpt: >
+  A trial run of the Optech newsletter including news about the
+  `OP_CODESEPARATOR` opcode, BetterHash mining protocol, and BIP157/158
+  compact block filters.
 ---
 
 **This newsletter from June 8th 2018 was a preview run of the Optech newsletter.**

--- a/_posts/en/newsletters/2018-06-26-newsletter.md
+++ b/_posts/en/newsletters/2018-06-26-newsletter.md
@@ -6,6 +6,12 @@ type: newsletter
 layout: newsletter
 lang: en
 version: 1
+
+excerpt: >
+  Announces a pending vulnerability disclosure for older Bitcoin Core
+  releases, links to a PR about improved coin selection, and discusses
+  dynamic wallet loading and unloading in Bitcoin Core multiwallet
+  mode.
 ---
 
 ## Welcome

--- a/_posts/en/newsletters/2018-07-03-newsletter.md
+++ b/_posts/en/newsletters/2018-07-03-newsletter.md
@@ -6,6 +6,11 @@ type: newsletter
 layout: newsletter
 lang: en
 version: 1
+excerpt: >
+  Continued discussion over graftroot safety, BIP174 Partially-Signed
+  Bitcoin Transactions (PSBT) officially marked as proposed, and
+  discussion of Dandelion transaction relay.
+
 ---
 ### Unsubscribing
 

--- a/en/blog/index.md
+++ b/en/blog/index.md
@@ -3,9 +3,9 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 layout: page
+title: Posts
 ---
 
-<h2>{{ page.list_title | default: "Posts" }}</h2>
 <ul class="post-list">
   {%- for post in site.posts -%}
   {%- if post.type == 'posts' -%}

--- a/en/blog/index.md
+++ b/en/blog/index.md
@@ -1,0 +1,28 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: page
+---
+
+<h2>{{ page.list_title | default: "Posts" }}</h2>
+<ul class="post-list">
+  {%- for post in site.posts -%}
+  {%- if post.type == 'posts' -%}
+  <li>
+    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+    <span class="post-meta">{{ post.date | date: date_format }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">
+        {{ post.title | escape }}
+      </a>
+    </h3>
+    {%- if site.show_excerpts -%}
+      {{ post.excerpt }}
+    {%- endif -%}
+  </li>
+  {%- endif -%}
+  {%- endfor -%}
+</ul>
+
+<p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>

--- a/index.md
+++ b/index.md
@@ -14,11 +14,16 @@ order to lower costs and improve customer experiences.
 
 An initial focus for the group is working with its member organizations to
 reduce transaction sizes and minimize the effect of subsequent transaction fee
-increases.
+increases.  We provide [workshops][], [documentation][scaling book],
+[weekly newsletters][], [original research][dashboard], [case studies
+and announcements][blog], and help facilitate improved relations between
+businesses and the open source community.
 
-Long-term goals include providing documentation and training materials, a
-weekly newsletter, original research, and facilitating improved relations
-between businesses and the open source community.
+[scaling book]: https://github.com/bitcoinops/scaling-book
+[workshops]: /workshops
+[weekly newsletters]: /en/newsletters/
+[dashboard]: https://dashboard.bitcoinops.org/
+[blog]: /en/blog/
 
 Optech does not exist to make a profit, and all materials and documentation
 produced are released under the MIT license. We are supported by our generous
@@ -29,10 +34,9 @@ contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
 
 {% include newsletter-signup.html %}
 
-<h2>{{ page.list_title | default: "Posts" }}</h2>
+<h2>Recent newsletters and blog posts</h2>
 <ul class="post-list">
-  {%- for post in site.posts -%}
-  {%- if post.type == 'posts' -%}
+  {%- for post in site.posts limit:3 -%}
   <li>
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <span class="post-meta">{{ post.date | date: date_format }}</span>
@@ -45,11 +49,10 @@ contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
       {{ post.excerpt }}
     {%- endif -%}
   </li>
-  {%- endif -%}
   {%- endfor -%}
 </ul>
 
-<p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+<p class="rss-subscribe">View more <a href="/en/newsletters/">newsletters</a> or <a href="/en/blog">blog posts</a>. Learn about new content by subscribing via email or <a href="{{ "/feed.xml" | relative_url }}">RSS</a>.</p>
 
 {% include members.html %}
 

--- a/newsletters.md
+++ b/newsletters.md
@@ -29,3 +29,5 @@ version: 1
   {%- endif -%}
   {%- endfor -%}
 </ul>
+
+<p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>


### PR DESCRIPTION
We originally created the homepage for this site before we had any content.  This revamps it a bit by doing the following:

1. Linking to all the content we now have: workshops, newsletters, dashboard, blog posts, and a WIP scaling book.
2. Replaces the "posts" listing on the main page with a link to our most recent content in both the blog and the newsletters, limiting the display to the most recent three items.
3. Adds a new index page for the blog posts and links to it from the main page
4. Displays excerpts for all the newsletters and blog posts.  This required writing a few excerpts for pages that didn't have nice ones by default

I'm biased, but I think it makes the homepage much more approachable if we were to do something like #116