### PR TITLE
Update about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -21,12 +21,19 @@ businesses and the open source community.
 [dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/
 
-Optech does not exist to make a profit, and all materials and documentation
-produced are released under the MIT license. We are supported by our generous
-founding sponsors and contributions from member companies.
-
 If you're an engineer or manager at a Bitcoin company or an open source contributor and you'd like to be a part of this, please
 contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
+
+## Funding
+
+Optech does not exist to make a profit, and all materials and documentation
+produced are released under the MIT license.
+
+Seed funding was provided by Wences Casares and John Pfeffer to cover outside
+contractors and incidental expenses. Resources are provided by Chaincode Labs
+to support Optech.
+
+Our generous member companies pay an annual contribution to cover expenses.
 
 ## Principles and associates of Optech:
 

--- a/about.md
+++ b/about.md
@@ -35,7 +35,7 @@ to support Optech.
 
 Our generous member companies pay an annual contribution to cover expenses.
 
-## Principles and associates of Optech:
+## Principles and Associates of Optech
 
 {% include associates.html %}
 

--- a/about.md
+++ b/about.md
@@ -3,6 +3,33 @@ layout: page
 title: About
 permalink: /about/
 ---
-Principles and associates of Optech:
+
+The Bitcoin Operations Technology Group (Optech) works to bring the best
+open source technologies and techniques to Bitcoin-using businesses in
+order to lower costs and improve customer experiences.
+
+An initial focus for the group is working with its member organizations to
+reduce transaction sizes and minimize the effect of subsequent transaction fee
+increases.  We provide [workshops][], [documentation][scaling book],
+[weekly newsletters][], [original research][dashboard], [case studies
+and announcements][blog], and help facilitate improved relations between
+businesses and the open source community.
+
+[scaling book]: https://github.com/bitcoinops/scaling-book
+[workshops]: /workshops
+[weekly newsletters]: /en/newsletters/
+[dashboard]: https://dashboard.bitcoinops.org/
+[blog]: /en/blog/
+
+Optech does not exist to make a profit, and all materials and documentation
+produced are released under the MIT license. We are supported by our generous
+founding sponsors and contributions from member companies.
+
+If you're an engineer or manager at a Bitcoin company or an open source contributor and you'd like to be a part of this, please
+contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
+
+## Principles and associates of Optech:
 
 {% include associates.html %}
+
+{% include sponsors.html %}

--- a/index.md
+++ b/index.md
@@ -8,31 +8,22 @@ layout: home
 {:.logo}
 ![Optech Logo](/img/logos/optech-notext.png)
 
-The Bitcoin Operations Technology Group (Optech) works to bring the best
-open source technologies and techniques to Bitcoin-using businesses in
-order to lower costs and improve customer experiences.
+Bitcoin Optech helps Bitcoin users and businesses integrate scaling
+technologies.
 
-An initial focus for the group is working with its member organizations to
-reduce transaction sizes and minimize the effect of subsequent transaction fee
-increases.  We provide [workshops][], [documentation][scaling book],
-[weekly newsletters][], [original research][dashboard], [case studies
-and announcements][blog], and help facilitate improved relations between
-businesses and the open source community.
+We provide [workshops][], [documentation][scaling book], [weekly
+newsletters][], [original research][dashboard], [case studies and
+announcements][blog], and help facilitate improved relations between businesses
+and the open source community.
+
+[Learn more about us][about].
 
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [workshops]: /workshops
 [weekly newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/
-
-Optech does not exist to make a profit, and all materials and documentation
-produced are released under the MIT license. We are supported by our generous
-founding sponsors and contributions from member companies.
-
-If you're an engineer or manager at a Bitcoin company or an open source contributor and you'd like to be a part of this, please
-contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
-
-{% include newsletter-signup.html %}
+[about]: /about
 
 <h2>Recent newsletters and blog posts</h2>
 <ul class="post-list">
@@ -54,6 +45,6 @@ contact us at [info@bitcoinops.org](mailto:info@bitcoinops.org).
 
 <p class="rss-subscribe">View more <a href="/en/newsletters/">newsletters</a> or <a href="/en/blog">blog posts</a>. Learn about new content by subscribing via email or <a href="{{ "/feed.xml" | relative_url }}">RSS</a>.</p>
 
-{% include members.html %}
+{% include newsletter-signup.html %}
 
-{% include sponsors.html %}
+{% include members.html %}


### PR DESCRIPTION
This PR:

- moves the introductory text and sponsors to the about page, making the front page less cluttered
- adds a 'funding' section to the about page (closes #83)