### PR TITLE
Layout: add default opengraph image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,9 @@ exclude:
    - README.md
 
 show_excerpts: true
+
+defaults:
+  - scope:
+      path: ""  ## all pages
+    values:
+      image: https://bitcoinops.org/img/logos/optech-notext.png


### PR DESCRIPTION
Closes #133

![2019-04-09-11_58_14_886257780](https://user-images.githubusercontent.com/61096/55815919-2fe06800-5abf-11e9-8186-3f440cd147d4.png)

Validator: https://cards-dev.twitter.com/validator
Test URL: http://dg2.dtrt.org/en/newsletters/2019/04/09/
How this change works: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md#setting-a-default-image