### PR TITLE
Blog: add post with all bech32 content to date

### DIFF
--- a/_contrib/update-newsletter-index-variables
+++ b/_contrib/update-newsletter-index-variables
@@ -1,0 +1,44 @@
+#!/bin/bash -eu
+
+## Update the list of variables that point to each newsletter.  Must be
+## run from the top-level directory in the repository.  Update yearly to
+## create variables for all that year's newsletters.  Also requires
+## updating for schedule changes.
+#
+## It's probably best if everything is done in chronolical order
+
+OUTPUT=_includes/linkers/newsletters.md
+if ! [ -f "$OUTPUT" ]
+then
+  echo "Error: $OUTPUT not found.  You must run $0 from the top-level repository directory."
+  exit 1
+fi
+
+## Generate a list of newsletters a week apart starting from particular
+## date and issue number
+_seq_news() {
+  start_date="$1"
+  start_issue="$2"
+  count="$(( $3 - 1 ))"
+  for i in $( seq 0 $count )
+  do
+    issue_number=$(( start_issue + i ))
+    issue_date=$( date +%Y/%m/%d -d "$start_date +$((i*7)) days")
+    echo '{% assign news'$issue_number' = "/en/newsletters/'$issue_date'/" %}'
+    echo "[Newsletter #${issue_number}]: {{news${issue_number}}}"
+  done
+}
+
+## Write all stdout to the output file.  stderr will still be printed to the controling console
+exec > $OUTPUT
+echo '''{% comment %}<!-- WARNING: DO NOT MANUALLY EDIT THIS FILE.
+                        Edit _contrib/update-newsletter-index-variables instead -->{% endcomment %}'''
+
+## Original PoC newsletter
+_seq_news 2018-06-08 0 1
+## Start regular publication
+_seq_news 2018-06-26 1 26
+## Christmas special
+_seq_news 2018-12-28 27 1
+## Resume regular publication
+_seq_news 2019-01-08 28 52

--- a/_includes/linkers/newsletters.md
+++ b/_includes/linkers/newsletters.md
@@ -1,0 +1,162 @@
+{% comment %}<!-- WARNING: DO NOT MANUALLY EDIT THIS FILE.
+                        Edit _contrib/update-newsletter-index-variables instead -->{% endcomment %}
+{% assign news0 = "/en/newsletters/2018/06/08/" %}
+[Newsletter #0]: {{news0}}
+{% assign news1 = "/en/newsletters/2018/06/26/" %}
+[Newsletter #1]: {{news1}}
+{% assign news2 = "/en/newsletters/2018/07/03/" %}
+[Newsletter #2]: {{news2}}
+{% assign news3 = "/en/newsletters/2018/07/10/" %}
+[Newsletter #3]: {{news3}}
+{% assign news4 = "/en/newsletters/2018/07/17/" %}
+[Newsletter #4]: {{news4}}
+{% assign news5 = "/en/newsletters/2018/07/24/" %}
+[Newsletter #5]: {{news5}}
+{% assign news6 = "/en/newsletters/2018/07/31/" %}
+[Newsletter #6]: {{news6}}
+{% assign news7 = "/en/newsletters/2018/08/07/" %}
+[Newsletter #7]: {{news7}}
+{% assign news8 = "/en/newsletters/2018/08/14/" %}
+[Newsletter #8]: {{news8}}
+{% assign news9 = "/en/newsletters/2018/08/21/" %}
+[Newsletter #9]: {{news9}}
+{% assign news10 = "/en/newsletters/2018/08/28/" %}
+[Newsletter #10]: {{news10}}
+{% assign news11 = "/en/newsletters/2018/09/04/" %}
+[Newsletter #11]: {{news11}}
+{% assign news12 = "/en/newsletters/2018/09/11/" %}
+[Newsletter #12]: {{news12}}
+{% assign news13 = "/en/newsletters/2018/09/18/" %}
+[Newsletter #13]: {{news13}}
+{% assign news14 = "/en/newsletters/2018/09/25/" %}
+[Newsletter #14]: {{news14}}
+{% assign news15 = "/en/newsletters/2018/10/02/" %}
+[Newsletter #15]: {{news15}}
+{% assign news16 = "/en/newsletters/2018/10/09/" %}
+[Newsletter #16]: {{news16}}
+{% assign news17 = "/en/newsletters/2018/10/16/" %}
+[Newsletter #17]: {{news17}}
+{% assign news18 = "/en/newsletters/2018/10/23/" %}
+[Newsletter #18]: {{news18}}
+{% assign news19 = "/en/newsletters/2018/10/30/" %}
+[Newsletter #19]: {{news19}}
+{% assign news20 = "/en/newsletters/2018/11/06/" %}
+[Newsletter #20]: {{news20}}
+{% assign news21 = "/en/newsletters/2018/11/13/" %}
+[Newsletter #21]: {{news21}}
+{% assign news22 = "/en/newsletters/2018/11/20/" %}
+[Newsletter #22]: {{news22}}
+{% assign news23 = "/en/newsletters/2018/11/27/" %}
+[Newsletter #23]: {{news23}}
+{% assign news24 = "/en/newsletters/2018/12/04/" %}
+[Newsletter #24]: {{news24}}
+{% assign news25 = "/en/newsletters/2018/12/11/" %}
+[Newsletter #25]: {{news25}}
+{% assign news26 = "/en/newsletters/2018/12/18/" %}
+[Newsletter #26]: {{news26}}
+{% assign news27 = "/en/newsletters/2018/12/28/" %}
+[Newsletter #27]: {{news27}}
+{% assign news28 = "/en/newsletters/2019/01/08/" %}
+[Newsletter #28]: {{news28}}
+{% assign news29 = "/en/newsletters/2019/01/15/" %}
+[Newsletter #29]: {{news29}}
+{% assign news30 = "/en/newsletters/2019/01/22/" %}
+[Newsletter #30]: {{news30}}
+{% assign news31 = "/en/newsletters/2019/01/29/" %}
+[Newsletter #31]: {{news31}}
+{% assign news32 = "/en/newsletters/2019/02/05/" %}
+[Newsletter #32]: {{news32}}
+{% assign news33 = "/en/newsletters/2019/02/12/" %}
+[Newsletter #33]: {{news33}}
+{% assign news34 = "/en/newsletters/2019/02/19/" %}
+[Newsletter #34]: {{news34}}
+{% assign news35 = "/en/newsletters/2019/02/26/" %}
+[Newsletter #35]: {{news35}}
+{% assign news36 = "/en/newsletters/2019/03/05/" %}
+[Newsletter #36]: {{news36}}
+{% assign news37 = "/en/newsletters/2019/03/12/" %}
+[Newsletter #37]: {{news37}}
+{% assign news38 = "/en/newsletters/2019/03/19/" %}
+[Newsletter #38]: {{news38}}
+{% assign news39 = "/en/newsletters/2019/03/26/" %}
+[Newsletter #39]: {{news39}}
+{% assign news40 = "/en/newsletters/2019/04/02/" %}
+[Newsletter #40]: {{news40}}
+{% assign news41 = "/en/newsletters/2019/04/09/" %}
+[Newsletter #41]: {{news41}}
+{% assign news42 = "/en/newsletters/2019/04/16/" %}
+[Newsletter #42]: {{news42}}
+{% assign news43 = "/en/newsletters/2019/04/23/" %}
+[Newsletter #43]: {{news43}}
+{% assign news44 = "/en/newsletters/2019/04/30/" %}
+[Newsletter #44]: {{news44}}
+{% assign news45 = "/en/newsletters/2019/05/07/" %}
+[Newsletter #45]: {{news45}}
+{% assign news46 = "/en/newsletters/2019/05/14/" %}
+[Newsletter #46]: {{news46}}
+{% assign news47 = "/en/newsletters/2019/05/21/" %}
+[Newsletter #47]: {{news47}}
+{% assign news48 = "/en/newsletters/2019/05/28/" %}
+[Newsletter #48]: {{news48}}
+{% assign news49 = "/en/newsletters/2019/06/04/" %}
+[Newsletter #49]: {{news49}}
+{% assign news50 = "/en/newsletters/2019/06/11/" %}
+[Newsletter #50]: {{news50}}
+{% assign news51 = "/en/newsletters/2019/06/18/" %}
+[Newsletter #51]: {{news51}}
+{% assign news52 = "/en/newsletters/2019/06/25/" %}
+[Newsletter #52]: {{news52}}
+{% assign news53 = "/en/newsletters/2019/07/02/" %}
+[Newsletter #53]: {{news53}}
+{% assign news54 = "/en/newsletters/2019/07/09/" %}
+[Newsletter #54]: {{news54}}
+{% assign news55 = "/en/newsletters/2019/07/16/" %}
+[Newsletter #55]: {{news55}}
+{% assign news56 = "/en/newsletters/2019/07/23/" %}
+[Newsletter #56]: {{news56}}
+{% assign news57 = "/en/newsletters/2019/07/30/" %}
+[Newsletter #57]: {{news57}}
+{% assign news58 = "/en/newsletters/2019/08/06/" %}
+[Newsletter #58]: {{news58}}
+{% assign news59 = "/en/newsletters/2019/08/13/" %}
+[Newsletter #59]: {{news59}}
+{% assign news60 = "/en/newsletters/2019/08/20/" %}
+[Newsletter #60]: {{news60}}
+{% assign news61 = "/en/newsletters/2019/08/27/" %}
+[Newsletter #61]: {{news61}}
+{% assign news62 = "/en/newsletters/2019/09/03/" %}
+[Newsletter #62]: {{news62}}
+{% assign news63 = "/en/newsletters/2019/09/10/" %}
+[Newsletter #63]: {{news63}}
+{% assign news64 = "/en/newsletters/2019/09/17/" %}
+[Newsletter #64]: {{news64}}
+{% assign news65 = "/en/newsletters/2019/09/24/" %}
+[Newsletter #65]: {{news65}}
+{% assign news66 = "/en/newsletters/2019/10/01/" %}
+[Newsletter #66]: {{news66}}
+{% assign news67 = "/en/newsletters/2019/10/08/" %}
+[Newsletter #67]: {{news67}}
+{% assign news68 = "/en/newsletters/2019/10/15/" %}
+[Newsletter #68]: {{news68}}
+{% assign news69 = "/en/newsletters/2019/10/22/" %}
+[Newsletter #69]: {{news69}}
+{% assign news70 = "/en/newsletters/2019/10/29/" %}
+[Newsletter #70]: {{news70}}
+{% assign news71 = "/en/newsletters/2019/11/05/" %}
+[Newsletter #71]: {{news71}}
+{% assign news72 = "/en/newsletters/2019/11/12/" %}
+[Newsletter #72]: {{news72}}
+{% assign news73 = "/en/newsletters/2019/11/19/" %}
+[Newsletter #73]: {{news73}}
+{% assign news74 = "/en/newsletters/2019/11/26/" %}
+[Newsletter #74]: {{news74}}
+{% assign news75 = "/en/newsletters/2019/12/03/" %}
+[Newsletter #75]: {{news75}}
+{% assign news76 = "/en/newsletters/2019/12/10/" %}
+[Newsletter #76]: {{news76}}
+{% assign news77 = "/en/newsletters/2019/12/17/" %}
+[Newsletter #77]: {{news77}}
+{% assign news78 = "/en/newsletters/2019/12/24/" %}
+[Newsletter #78]: {{news78}}
+{% assign news79 = "/en/newsletters/2019/12/31/" %}
+[Newsletter #79]: {{news79}}

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -56,81 +56,8 @@ place, put links here. -->{% endcomment %}
 [BOLT8]: https://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md
 [BOLT11]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
 
-{% comment %}<!-- old newsletters (variables & links) in date order earliest to latest -->{% endcomment %}
-{% assign news0 = "/en/newsletters/2018/06/08/" %}
-[newsletter #0]: {{news0}}
-{% assign news1 = "/en/newsletters/2018/06/26/" %}
-[newsletter #1]: {{news1}}
-{% assign news2 = "/en/newsletters/2018/07/03/" %}
-[newsletter #2]: {{news2}}
-{% assign news3 = "/en/newsletters/2018/07/10/" %}
-[newsletter #3]: {{news3}}
-{% assign news4 = "/en/newsletters/2018/07/17/" %}
-[newsletter #4]: {{news4}}
-{% assign news5 = "/en/newsletters/2018/07/24/" %}
-[newsletter #5]: {{news5}}
-{% assign news6 = "/en/newsletters/2018/07/31/" %}
-[newsletter #6]: {{news6}}
-{% assign news7 = "/en/newsletters/2018/08/07/" %}
-[newsletter #7]: {{news7}}
-{% assign news8 = "/en/newsletters/2018/08/14/" %}
-[newsletter #8]: {{news8}}
-{% assign news9 = "/en/newsletters/2018/08/21/" %}
-[newsletter #9]: {{news9}}
-{% assign news10 = "/en/newsletters/2018/08/28/" %}
-[newsletter #10]: {{news10}}
-{% assign news11 = "/en/newsletters/2018/09/04/" %}
-[newsletter #11]: {{news11}}
-{% assign news12 = "/en/newsletters/2018/09/11/" %}
-[newsletter #12]: {{news12}}
-{% assign news13 = "/en/newsletters/2018/09/18/" %}
-[newsletter #13]: {{news13}}
-{% assign news16 = "/en/newsletters/2018/10/09/" %}
-[newsletter #16]: {{news16}}
-{% assign news17 = "/en/newsletters/2018/10/16/" %}
-[newsletter #17]: {{news17}}
-{% assign news18 = "/en/newsletters/2018/10/23/" %}
-[newsletter #18]: {{news18}}
-{% assign news19 = "/en/newsletters/2018/10/30/" %}
-[newsletter #19]: {{news19}}
-{% assign news20 = "/en/newsletters/2018/11/06/" %}
-[newsletter #20]: {{news20}}
-{% assign news21 = "/en/newsletters/2018/11/13/" %}
-[newsletter #21]: {{news21}}
-{% assign news22 = "/en/newsletters/2018/11/20/" %}
-[newsletter #22]: {{news22}}
-{% assign news23 = "/en/newsletters/2018/11/27/" %}
-[newsletter #23]: {{news23}}
-{% assign news25 = "/en/newsletters/2018/12/11/" %}
-[newsletter #25]: {{news25}}
-{% assign news26 = "/en/newsletters/2018/12/18/" %}
-[newsletter #26]: {{news26}}
-{% assign news27 = "/en/newsletters/2018/12/28/" %}
-[newsletter #27]: {{news27}}
-{% assign news30 = "/en/newsletters/2019/01/22/" %}
-[newsletter #30]: {{news30}}
-{% assign news31 = "/en/newsletters/2019/01/29/" %}
-[newsletter #31]: {{news31}}
-{% assign news33 = "/en/newsletters/2019/02/12/" %}
-[newsletter #33]: {{news33}}
-{% assign news34 = "/en/newsletters/2019/02/19/" %}
-[newsletter #34]: {{news34}}
-{% assign news36 = "/en/newsletters/2019/03/05/" %}
-[newsletter #36]: {{news36}}
-{% assign news37 = "/en/newsletters/2019/03/12/" %}
-[newsletter #37]: {{news37}}
-{% assign news38 = "/en/newsletters/2019/03/19/" %}
-[newsletter #38]: {{news38}}
-{% assign news39 = "/en/newsletters/2019/03/26/" %}
-[newsletter #39]: {{news39}}
-{% assign news40 = "/en/newsletters/2019/04/02/" %}
-[newsletter #40]: {{news40}}
-{% assign news41 = "/en/newsletters/2019/04/09/" %}
-[newsletter #41]: {{news41}}
-{% assign news42 = "/en/newsletters/2019/04/16/" %}
-[newsletter #42]: {{news42}}
-{% assign news44 = "/en/newsletters/2019/04/30/" %}
-[newsletter #44]: {{news44}}
+{% comment %}<!-- links old newsletters -->{% endcomment %}
+{% include linkers/newsletters.md %}
 
 {% comment %}
 <!--REQUIRES PERIODIC UPDATE: update rpc_version below to latest

--- a/_includes/specials/bech32/01-intro.md
+++ b/_includes/specials/bech32/01-intro.md
@@ -1,0 +1,102 @@
+Bech32 native segwit addresses were first publicly [proposed][bech32
+proposed] almost exactly two years ago, becoming the [BIP173][]
+standard.  This was followed by the segwit soft fork's lock-in on 24
+August 2017.  Yet, seventeen months after lock-in, some popular wallets
+and services still don't support sending bitcoins to bech32 addresses.
+Developers of other wallets and services are tired of waiting and want
+to default to receiving payments to bech32 addresses so that they can
+achieve additional fee savings and improved privacy.  Bitcoin Optech
+would like to help this process along so, from now until the two-year
+anniversary of segwit lock-in, each of our newsletters will include a
+short section with resources to help get bech32 sending support fully
+deployed.
+
+Note, we are only directly advocating bech32 **sending** support.  This
+allows the people you pay to use segwit but doesn't require you to
+implement segwit yourself.  (If you want to use segwit yourself to save
+fees or access its other benefits, that's great!  We just encourage you
+to implement bech32 sending support first so that the people you pay can
+begin taking advantage of it immediately while you upgrade the rest of
+your code and infrastructure to fully support segwit.)  To that end,
+this week's section focuses on showing exactly how small the differences
+are between sending to a legacy address and sending to a bech32 address.
+
+### Sending to a legacy address
+
+For a P2PKH legacy address that you already support such as
+1B6FkNg199ZbPJWG5zjEiDekrCc2P7MVyC, your base58check library will decode
+that to a 20-byte commitment:
+
+     6eafa604a503a0bb445ad1f6daa80f162b5605d6
+
+This commitment is inserted into a scriptPubKey template:
+
+<pre>OP_DUP OP_HASH160 OP_PUSH20 <b>6eafa604a503a0bb445ad1f6daa80f162b5605d6</b> OP_EQUALVERIFY OP_CHECKSIG</pre>
+
+Converting the opcodes to hex, this looks like:
+
+    76a9146eafa604a503a0bb445ad1f6daa80f162b5605d688ac
+
+This is inserted into the scriptPubKey part of an output that also
+includes the length of the script (25 bytes) and the amount being paid:
+
+<pre>     amount                           scriptPubKey
+|--------------|  |------------------------------------------------|
+00e1f5050000000019<b>76a9146eafa604a503a0bb445ad1f6daa80f162b5605d688ac</b>
+                |
+    size: 0x19 -> 25 bytes</pre>
+
+This output can then be added to the transaction, which is then signed
+and broadcast.
+
+### Sending to a bech32 address
+
+For an equivalent bech32 P2WPKH address such as
+bc1qd6h6vp99qwstk3z668md42q0zc44vpwkk824zh, you can use one of the
+[reference libraries][bech32 ref libs] to decode the address to a pair
+of values:
+
+    0 6eafa604a503a0bb445ad1f6daa80f162b5605d6
+
+These two values are also inserted into a scriptPubKey template.  The
+first value is the witness script version byte that's used to add a
+value to the stack using one of the opcodes from `OP_0` to `OP_16`.
+The second is the commitment that's also pushed onto the stack:
+
+<pre><b>OP_0</b> OP_PUSH20 <b>6eafa604a503a0bb445ad1f6daa80f162b5605d6</b></pre>
+
+Converting the opcodes to hex, this looks like:
+
+    00146eafa604a503a0bb445ad1f6daa80f162b5605d6
+
+Then, just as before, this is inserted into the scriptPubKey part of an
+output:
+
+<pre>     amount                        scriptPubKey
+|--------------|  |------------------------------------------|
+00e1f5050000000016<b>00146eafa604a503a0bb445ad1f6daa80f162b5605d6</b>
+                |
+    size: 0x16 -> 22 bytes</pre>
+
+The output is added to the transaction.  The transaction is then signed
+and broadcast.
+
+For bech32 P2WSH (the segwit equivalent of P2SH) or for future segwit
+witness versions, you don't need to do anything special.  The witness
+script version may be a different number, requiring you to use the
+corresponding `OP_0` to `OP_16` opcode, and the commitment may be a
+different length (from 2 to 40 bytes), but nothing else about the output
+changes.  Because length variations are allowed, ensure your fee
+estimation software considers the actual size of the scriptPubKey rather
+than using a constant someone previously calculated based on P2PKH or
+P2SH sizes.
+
+What you see above is the entire change you need to make on
+the backend of your software in order to enable sending to bech32
+addresses.  For most platforms, it should be a very easy change.  See
+[BIP173][] and the [reference implementations][bech32 ref libs] for a
+set of test vectors you can use to ensure your implementation works
+correctly.
+
+[bech32 proposed]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-March/013749.html
+[bech32 ref libs]: https://github.com/sipa/bech32/tree/master/ref

--- a/_includes/specials/bech32/02-stats.md
+++ b/_includes/specials/bech32/02-stats.md
@@ -1,0 +1,53 @@
+As described [last week][bech32 easy], implementing just segwit
+spending should be easy.  Yet we suspect some managers might wonder
+whether there are enough people using segwit to justify their team
+spending development effort on it.  This week, we look at sites that
+track various segwit adoption statistics so that you can decide whether
+it's popular enough that your wallet or service might become an outlier
+by failing to support it soon.
+
+Optech tracks statistics about segwit use on our [dashboard][optech
+dashboard]; another site tracking related statistics is [P2SH.info][].
+We see an average of about 200 outputs per block are sent to native
+segwit addresses (bech32).  Those outputs are then spent in about 10% of all
+Bitcoin transactions.  That makes payments involving native segwit addresses
+more popular than almost all altcoins.
+
+![Screenshot of Optech Dashboard segwit usage stats](/img/posts/2019-03-segwit-usage.png)
+
+However, many wallets want to use segwit but still need to deal with
+services that don't yet have bech32 sending support.  These wallets can
+generate a P2SH address that references their segwit details, which is
+less efficient than using bech32 but more efficient than not using
+segwit at all.  Because these are normal P2SH addresses, we can't tell
+just by looking at transaction outputs which P2SH addresses are
+pre-segwit P2SH outputs and which contain a nested segwit
+commitment, and so we don't know the actual number of payments to
+nested-segwit addresses.  However, when one of these outputs is spent,
+the spender reveals whether the output was segwit. The above statistics
+sites report that currently about 37% of transactions contain at least
+one spend from a nested-segwit output.  That corresponds to about 1,400
+outputs per block on average.
+
+Any wallet that supports P2SH nested segwit addresses also likely
+supports bech32 native addresses, so the number of transactions made by
+wallets that want to take advantage of bech32 sending support is
+currently over 45% and rising.
+
+To further gauge segwit popularity, you might also want to know which
+notable Bitcoin wallets and services support it.  For that, we recommend
+the community-maintained [bech32 adoption][] page on the Bitcoin Wiki or
+the [when segwit][] page maintained by BRD wallet.
+
+The statistics and compatibility data show that segwit is already well
+supported and frequently used, but that there are a few notable holdouts
+that haven't yet provided support.  It's our hope that our campaign and
+other community efforts will help convince the stragglers to catch up on
+bech32 sending support so that all wallets that want to take advantage
+of native segwit can do so in the next few months.
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[optech dashboard]: https://dashboard.bitcoinops.org/
+[p2sh.info]: https://p2sh.info/
+[bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
+[when segwit]: https://whensegwit.com/

--- a/_includes/specials/bech32/03-python-ref.md
+++ b/_includes/specials/bech32/03-python-ref.md
@@ -1,0 +1,94 @@
+In a [previous week][bech32 easy], we discussed how small the
+differences are between creating the output for a legacy address versus
+a native segwit address.  In that section we simply pointed you towards
+the [bech32 reference libraries][] and told you that you'd get two
+values back.  In this week, we walkthrough the exact steps of using the
+Python reference library so you can see how little work this is.  We
+start by importing the library:
+
+```python3
+>>> import segwit_addr
+```
+
+Bech32 addresses have a Human-Readable Part (HRP) that indicates what
+network the address is for.  These are the first few characters of the
+address and are separated from the data part of the address by the
+delimiter `1`.  For example, Bitcoin testnet uses `tb` and an example
+testnet address is tb1q3w[...]g7a.  We'll set the Bitcoin mainnet HRP of
+`bc` in our code so that we can later ensure that the addresses we parse
+are for the network we expect.
+
+```python3
+>>> HRP='bc'
+```
+
+Finally, we have a few addresses we want to check---one that should work
+and two that should fail.  (See [BIP173][] for a complete set of
+[reference test vectors][bip173 test vectors].)
+
+```python3
+>>> good_address='bc1qd6h6vp99qwstk3z668md42q0zc44vpwkk824zh'
+>>> typo_address='bc1qd6h6vp99qwstk3z669md42q0zc44vpwkk824zh'
+>>> wrong_network_address='tb1q3wrc5yq9c300jxlfeg7ae76tk9gsx044ucyg7a'
+```
+
+Now we can simply attempt to decode each of these addresses
+
+```python3
+>>> segwit_addr.decode(HRP, good_address)
+(0, [110, 175, 166, 4, 165, 3, 160, 187, 68, 90, 209,
+     246, 218, 168, 15, 22, 43, 86, 5, 214])
+
+>>> segwit_addr.decode(HRP, typo_address)
+(None, None)
+
+>>> segwit_addr.decode(HRP, wrong_network_address)
+(None, None)
+```
+
+If we get back a None for the first value (the witness version), the
+address is invalid on our chosen network.  If that happens, you want to throw an
+exception up the stack so that whatever process is interfacing with the
+user can get them to provide you with a correct address.  If you
+actually get a number and an array, the decode succeeded, the checksum
+was valid, and the length was within the allowed range.
+
+The witness version must be a number between 0 and 16, so you'll want to
+check that (e.g. `0 <= x <= 16`) and then convert it into the
+corresponding opcodes `OP_0` through `OP_16`.  For `OP_0`, this is 0x00;
+for `OP_1` through `OP_16`, this is 0x51 through 0x60.  You then need to
+add a push byte for the data depending on its length (0x02 through 0x28
+for 2 to 40 bytes), and then append the data as a series of bytes.
+Pieter Wuille's [code][segwit addr to bytes] does this quite succinctly:
+
+```python3
+>>> witver, witprog = segwit_addr.decode(HRP, good_address)
+>>> bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog).hex()
+'00146eafa604a503a0bb445ad1f6daa80f162b5605d6'
+```
+
+That's your entire scriptPubKey.  You can use that in the output of a
+transaction and send it.  Note that bech32 scriptPubKeys can vary in
+size from 4 to 42 vbytes, so you need to consider the actual size of the
+scriptPubKey in your fee estimation code.
+
+Your code doesn't need to be written in Python.  Reference libraries
+are also provided for C, C++, Go, Haskell, JavaScript, Ruby, and Rust.
+Further, [BIP173][] describes bech32 well enough that any decent
+programmer should be able to implement it from scratch in their preferred
+language without requiring anything beyond what most programming
+languages provide in their builtins and standard library.
+
+**Other bech32 sending support updates:** BitGo [announced][bitgo
+segwit] that their API now supports sending to bech32 addresses; see
+their announcement for additional details about bech32 receiving support.
+The Gemini exchange also [apparently][gemini reddit] added bech32
+sending support this week, and users report that Gemini defaults to accepting
+deposits to bech32 addresses as well.
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[bech32 reference libraries]: https://github.com/sipa/bech32/tree/master/ref
+[segwit addr to bytes]: https://github.com/sipa/bech32/blob/master/ref/python/tests.py#L30
+[bitgo segwit]: https://blog.bitgo.com/native-segwit-addresses-via-bitgos-api-4946f2007be9
+[gemini reddit]: https://www.reddit.com/r/Bitcoin/comments/b66n0v/psa_gemini_is_full_on_with_native_segwit_and_uses/
+[bip173 test vectors]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Test_vectors

--- a/_includes/specials/bech32/04-ecc.md
+++ b/_includes/specials/bech32/04-ecc.md
@@ -1,0 +1,134 @@
+In [last week's newsletter][Newsletter #40], we used the Python
+reference library for bech32 to decode an address into a scriptPubKey
+that you could pay.  However, sometimes the user provides an address
+containing a typo.  The code we suggested would detect the typo and
+ensure you didn't pay a wrong address, but bech32 is also able to help
+detect the location of typos for your users.  This week, we'll
+demonstrate this capability using the [Javascript sample code][].
+
+The code is written using Node.js-style module inclusion syntax, so the
+first step is to compile it into code we can use in the browser.  For
+that, we install a [browserify][] tool:
+
+```bash
+sudo apt install node-browserify-lite
+```
+
+Then we compile it into a standalone file:
+
+```bash
+browserify-lite ./segwit_addr_ecc.js --outfile bech32-demo.js --standalone segwit_addr_ecc
+```
+
+Followed by including it in our HTML:
+
+```html
+<script src="bech32-demo.js"></script>
+```
+
+For convenience, we've included that file on the [web
+version][Newsletter #41] of this newsletter, so you can follow along
+with the rest of this example by simply opening the developer console in
+your web browser.  Let's start by checking a valid address.  Recall from
+last week that we provide the network identifier when checking an
+address (`bc` for Bitcoin mainnet):
+
+```text
+>> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'bc')
+error: null
+program: Array(20) [ 117, 30, 118, … ]
+version: 0
+```
+
+We see above that, just like last week, we get back the witness version
+and the witness program.  The presence of the version field, plus the
+lack of an error, indicate that this program decoded without any
+checksum failure.
+
+Now we replace one character in the above address with a typo and try
+checking that:
+
+```text
+>> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r4zarvary0c5xw7kv8f3t4', 'bc')
+error: "Invalid"
+pos: Array [ 21 ]
+```
+
+This time we get back the description of the error (the address is
+invalid because it doesn't match its checksum) and a position.  If we
+place the addresses above each other with each position marked, we see
+that this "21" identifies the location of the specific error:
+
+```text
+                   1x        2x
+         0123456789012345678901
+>> good='bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+>> typo='bc1qw508d6qejxtdg4y5r4zarvary0c5xw7kv8f3t4'
+                              ^
+```
+
+What if we make an additional replacement to the typo address and try
+again?
+
+```text
+>> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r4zarvary0c5yw7kv8f3t4', 'bc')
+error: "Invalid"
+pos: Array [ 32, 21 ]
+```
+
+We get two locations.  Once again, when we compare the addresses to
+each other, we see this has identified both incorrect characters:
+
+```text
+                   1x        2x        3x
+         012345678901234567890123456789012
+>> good='bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+>> typo='bc1qw508d6qejxtdg4y5r4zarvary0c5yw7kv8f3t4'
+                              ^          ^
+```
+
+Pieter Wuille's [interactive demo][] of this Javascript code includes
+a few lines of additional code (view source on that page to see the
+function) that uses the position of the typo characters to emphasize
+them in red:
+
+![Screenshot of the bech32 interactive demo with the typo address above](/img/posts/2019-04-bech32-demo.png)
+
+There's a limit to how many errors the `check()` function can specifically identify.
+After that it can still tell that an address contains an error, but it
+can't identify where to look in the address for the error.  In that
+case, it'll still return the address as invalid but it won't return the
+position details:
+
+```text
+>> segwit_addr_ecc.check('bc1qw508z6qejxtdg4y5r4zarvary0c5yw7kv8f3t4', 'bc')
+error: "Invalid"
+pos: null
+```
+
+In the case where there are other problems with the address, the `error`
+field will be set to a more descriptive message that may or may not
+include a position of the error.  For example:
+
+```text
+>> segwit_addr_ecc.check('bc1zw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4yolo', 'bc')
+error: "Invalid character"
+pos: Array [ 43 ]
+```
+
+You can review the [source][bech32 errors] for a complete list of
+errors.
+
+Although we spent a lot of time looking at errors in this mini tutorial,
+we've hopefully shown how easy it is to provide nice interactive
+feedback to users entering bech32 addresses on a web-based platform.  We
+encourage you to play around with the [interactive demo][] to get an
+idea of what your users might see if you make use of this bech32 address
+feature.
+
+<script src="/misc/bech32-demo.js"></script>
+[bech32 easy]: {{news38}}#bech32-sending-support
+[browserify]: http://browserify.org/
+[javascript sample code]: https://github.com/sipa/bech32/tree/master/ecc/javascript
+[interactive demo]: http://bitcoin.sipa.be/bech32/demo/demo.html
+[bech32 errors]: https://github.com/sipa/bech32/blob/master/ecc/javascript/segwit_addr_ecc.js#L54

--- a/_includes/specials/bech32/05-fee-savings.md
+++ b/_includes/specials/bech32/05-fee-savings.md
@@ -1,0 +1,62 @@
+One reason your users and customers may want you to implement bech32
+sending support is because it'll allow the receivers of those payments
+to save on fees when they re-spend that money.  This week, we'll look at
+how much money they'll save and discuss how their savings could also
+help you save money.
+
+For the legacy P2PKH address format implemented in the first version of
+Bitcoin, the scriptSig that authorizes a spend is typically 107 vbytes.
+For P2SH-wrapped segwit P2WPKH, this same information is moved to a
+witness data field that only consumes 1/4 as many vbytes (27 vbytes) but
+whose P2SH overhead adds 23 vbytes for a total of 50 vbytes.  For native
+segwit P2WPKH, there's no P2SH overhead, so 27 vbytes is all that's used.
+
+This means you could argue that P2SH-P2WPKH saves over 50% compared to
+P2PKH, and that P2WPKH saves another almost 50% compared to P2SH-P2WPKH
+or 75% compared to P2PKH alone.  However, spending transactions contain
+more than just scriptSigs and witness data, so the way we usually
+compare savings is by looking at prototype transactions.  For example,
+we imagine a typical transaction containing a single input and two
+outputs (one to the receiver; one as change back to the spender).  In
+that case:
+
+- Spending P2PKH has a total transaction size of
+  220 vbytes
+- Spending P2SH-P2WPKH has a size of 167 vbytes (24% savings)
+- Spending P2WPKH output has a size of 141 vbytes (16% savings vs
+  P2SH-P2WPKH or 35% vs P2PKH)
+
+To compare simple multisig transactions (those that just use a single
+`OP_CHECKMULTSIG` opcode), things get more complex because k-of-n
+multisig inputs vary in size depending on the number of signatures (k)
+and the number of public keys (n).  So, for simplicity's sake, we'll
+just plot the sizes of legacy P2SH-multisig compared to wrapped P2SH-P2WSH
+multisig (up to the maximum 15-of-15 supported by legacy P2SH).  We can
+see that switching to P2SH-P2WSH can save from about 40% (1-of-2
+multisig) to about 70% (15-of-15).
+
+![Plot of multisig transaction sizes with P2SH and P2SH-P2WSH](/img/posts/2019-04-segwit-multisig-size-p2sh-to-p2sh-p2wsh.png)
+
+We can then compare P2SH-P2WSH to native P2WSH to see the additional
+constant-sized savings of about 35 bytes per transaction or about 5% to
+15%.
+
+![Plot of multisig transaction sizes with P2SH-P2WSH and P2WSH](/img/posts/2019-04-segwit-multisig-size-p2sh-p2wsh-to-p2wsh.png)
+
+The scripts described above account for almost all scripts being used
+with addresses that aren't native segwit.  (Users of more complex
+scripts, such as those used in LN, are mostly using native segwit today.)
+Those less efficient script types currently consume a majority fraction
+of block capacity (total block weight).  Switching to native segwit in
+order to reduce a transaction's weight allows you to reduce its fee by
+the same percentage without changing how long it'll take to confirm---all other
+things being equal.
+
+But all other things aren't equal.  Because the transactions use less
+block weight, there's more weight available for other transactions.  If
+the supply of available block weight increases and demand remains constant, we
+expect prices to go down (unless they're already at the default minimum
+relay fee).  This means more people spending native segwit inputs lowers
+the fee not just for those spenders but for everyone who creates
+transactions---including wallets and services that support sending to
+bech32 addresses.

--- a/_includes/specials/bech32/06-stackexchange.md
+++ b/_includes/specials/bech32/06-stackexchange.md
@@ -1,0 +1,41 @@
+This week we look at some of the [top-voted bech32 questions and
+answers][top bech32 qa] from the Bitcoin StackExchange.  This includes
+everything since bech32 was first announced about two years ago.
+
+{% assign bse = "https://bitcoin.stackexchange.com/a/" %}
+
+- [Will a Schnorr soft fork introduce a new address
+  format?]({{bse}}82952)  Although upgrading to bech32 sending support
+  should be easy, you probably don't want to repeat that work for
+  Bitcoin's next upgrade or the upgrade after that.  Pieter Wuille
+  answers this question by explaining how an upgrade to Schnorr-based
+  public keys and signatures can still use bech32 addresses.  (Optech
+  will be covering this issue in greater detail in a future section.)
+
+- [Is it safe to translate a bech32 P2WPKH address into a legacy P2PKH
+  address?]({{bse}}62207) If you read [Newsletter #38][bech32 easy],
+  you'll notice that the difference between a P2WPKH and P2PKH address
+  for the same underlying public key is only a few characters in a
+  scriptPubKey, making it possible to automatically convert one into the
+  other.  This answer by Andrew Chow and its accompanying comments
+  explains why that's a bad idea that could cause users to lose funds.
+
+- [Why does the bech32 decode function require specifying the address's
+  Human Readable Part (HRP) instead of extracting it
+  automatically?]({{bse}}83454) The HRP is separated from the rest of
+  the address by a `1`, so it seems like the decoder could ignore that
+  part all on its own.  Pieter Wuille explains that calling the decoder
+  with the expected HRP ensures that you don't accidentally pay bitcoin
+  to an address meant for testnet, litecoin, or some other network.
+  Gregory Maxwell also corrects an additional assumption of the asker.
+
+- [What block explorers recognize bech32 addresses?]({{bse}}66458)
+  More than two years after bech32 was first proposed and a year after
+  this question was first asked, several popular block explorers don't
+  support search or display of bech32 addresses.  The answer to this
+  question suggests anyone who wants to learn the bech32 status of
+  various block explorers should check the [bech32 adoption][] Bitcoin
+  Wiki page.
+
+[top bech32 qa]: https://bitcoin.stackexchange.com/search?tab=votes&q=bech32
+[bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption

--- a/_includes/specials/bech32/07-altbech32.md
+++ b/_includes/specials/bech32/07-altbech32.md
@@ -1,0 +1,51 @@
+It's said that "imitation is the most sincere form of flattery."  In
+this week's section, we take a quick look at a few other systems that
+are using variations on bech32.  If you're already going to need to
+implement something that's basically bech32 for another project, it's
+probably worth your time to implement it for Bitcoin too.
+
+- **LN invoices** use the bech32 format with an extended Human-Readable
+  Part (HRP) and without bech32's normal 90-character limit.  See
+  [BOLT11][] for the full specification.  Example:
+  `lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp`
+
+- **Bitcoin Cash new-style addresses** use the bech32 format with the
+  HRP `bitcoincash` and the separator `:`.  Instead of the version byte
+  encoding a segwit witness version, as in Bitcoin, it indicates whether
+  the hash encoded by the address should be used with P2PKH or P2SH.  See
+  [spec-cashaddr][] for the full specification.  Example:
+  `bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a`
+
+- **Backup seeds:** In June 2018, Jonas Schnelli proposed Bech32X, a
+  scheme to encode Bitcoin private keys, extended private keys (xprivs),
+  and extended public keys (xpubs) using bech32 for error correction.
+  See the full [draft specification][bech32x].  Example:
+  `pk1lmll7u25wppjn5ghyhgm7kndgjwgphae8lez0gra436mj7ygaptggl447a4xh7`
+
+- **Elements-based sidechains:** sidechains based on
+  [ElementsProject.org][], such as [Blockstream Liquid][], use both
+  bech32 address and a variation of them called "blech32" addresses.
+  Blech32 addresses are intended for use with that platform's
+  [confidential assets][] and will soon be supported by the Esplora
+  block explorer for the Liquid sidechain.  We're
+  unaware of a specification document for blech32, but [this
+  code][blech32 py] is labeled as the reference implementation and is
+  cited elsewhere in the project as, "See liquid_addr.py for compact
+  difference from bech32." Example of a blech32 address:
+  `lq1qqf8er278e6nyvuwtgf39e6ewvdcnjupn9a86rzpx655y5lhkt0walu3djf9cklkxd3ryld97hu8h3xepw7sh2rlu7q45dcew5`
+
+- **Output script descriptors:** although less directly related to
+  bech32, checksums based on the same Bose-Chaudhuri-Hocquenghem (BCH) codes used in bech32 were
+  added to the [output script descriptors][] supported by Bitcoin Core.
+  See Pieter Wuille's [detailed comment][descriptors checksum].
+  Example:
+  `wpkh([f6bb4c63/0'/0'/28']02bf9d38386db60191f2f785cbf7ba90d01bed5958efb7b449a552b89da7550177)#efkksxw6`
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[descriptors checksum]: https://github.com/bitcoin/bitcoin/blob/fd637be8d21a606e98c037b40b268c4a1fae2244/src/script/descriptor.cpp#L24
+[spec-cashaddr]: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
+[bech32x]: https://gist.github.com/jonasschnelli/68a2a5a5a5b796dc9992f432e794d719
+[elementsproject.org]: https://elementsproject.org/
+[blockstream liquid]: https://blockstream.com/liquid/
+[confidential assets]: https://elementsproject.org/features/confidential-transactions
+[blech32 py]: https://github.com/ElementsProject/elements/commit/9cb2fa051fcbe0fe66f15e6b88d224d1935376f4#diff-265badc7e18059096c32a61b0eada470

--- a/_includes/specials/bech32/08-upgradability.md
+++ b/_includes/specials/bech32/08-upgradability.md
@@ -1,0 +1,56 @@
+What do bip-taproot and bip-tapscript mean for people who have
+implemented bech32 sending support or who are planning to implement it?
+In particular, if you haven't implemented segwit sending support yet,
+should you wait to implement it until the new features have been
+activated?  In this weekly section, we'll show why you shouldn't wait
+and how implementing sending support now won't cost you any extra effort
+in the future.
+
+The designers of segwit and bech32 had a general idea what future
+protocol improvements would look like, so they engineered segwit
+scriptPubKeys and the bech32 address format to be forward compatible
+with those expected improvements.  For example an address supporting
+Taproot might look like this:
+
+```text
+bc1pqzkqvpm76ewe20lcacq740p054at9sv7vxs0jn2u0r90af0k63332hva8pt
+```
+
+You'll notice that looks just like other bech32 addresses you've
+seen---because it is.  You can use the exact same code we provided in
+[Newsletter #40][] (using the bech32 reference library for Python) to decode
+it.
+
+```python
+>> import segwit_addr
+>> address='bc1pqzkqvpm76ewe20lcacq740p054at9sv7vxs0jn2u0r90af0k63332hva8pt'
+>> witver, witprog = segwit_addr.decode('bc', address)
+>> witver
+1
+>> bytes(witprog).hex()
+'00ac06077ed65d953ff8ee01eabc2fa57ab2c19e61a0f94d5c78cafea5f6d46315'
+```
+
+The differences here from the decoded bech32 addresses we've shown in
+previous newsletters are that this hypothetical Taproot address uses a
+witness version of `1` instead of `0` (meaning the scriptPubKey will
+start with `OP_1` instead of `OP_0`) and the witness program is one
+byte longer than a P2WSH witness program.  However, these don't matter
+to your software if you're just spending.  We can use the exact same
+example code from [Newsletter #40][news40 bech32] to create the
+appropriate scriptPubKey for you to pay:
+
+```python
+>> bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog).hex()
+'512100ac06077ed65d953ff8ee01eabc2fa57ab2c19e61a0f94d5c78cafea5f6d46315'
+```
+
+This means anyone who implements bech32 support in the generic way
+described in Newsletter #40 shouldn't need to do anything special in
+order to support future script upgrades.  In short, the work you invest
+into providing bech32 sending support now is something you won't need to
+repeat when future expected changes to the Bitcoin protocol are
+deployed.
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[news40 bech32]: {{news40}}#bech32-sending-support

--- a/_includes/specials/bech32/09-qrcode.md
+++ b/_includes/specials/bech32/09-qrcode.md
@@ -1,0 +1,43 @@
+[BIP173][] forbids bech32 addresses from using mixed case.  The
+preferred way to write a bech32 address is in all lowercase, but there's
+one case where all uppercase makes sense: QR codes.  Take a look at the
+following two QR codes for the same address with the only difference
+being lowercase versus uppercase:
+
+![bech32 uppercase](/img/posts/2019-05-bech32-qr-uc.png)
+{:.center}
+
+This is a deliberate design feature of bech32.  QR codes can be created
+in several modes that support different character sets.
+The binary mode character set is used for legacy addresses because they
+require mixed case.  However, Bech32 addresses for Bitcoin[^only-bc] can
+be represented using only numbers and capital letters, so they can use
+the smaller uppercase alphanumeric character set.  Because this set is
+smaller, it uses fewer bits to encode each character in a QR code,
+allowing the resultant code to be less complex.
+
+Bitcoin addresses are often used in [BIP21][] URIs.  BIP21 technically
+requires base58check formatting, but at least some wallets that support
+native segwit addresses (such as Bitcoin Core) allow them to be used
+with bech32.  Although the preferred form of BIP21's scheme identifier
+`bitcoin:` is lowercase, it can also be uppercased as allowed by both
+BIP21 and [RFC3986][].  This also produces a less complex image
+(although in this case, our QR encoding library gave both images the
+same dimensions).
+
+![bech32 uppercase](/img/posts/2019-05-bip21-bech32-qr-uc.png)
+{:.center}
+
+Unfortunately, the `?` and `&` needed for passing additional parameters
+in a BIP21 URI are not part of the QR code uppercase character set, so
+only binary mode can be used.  Additionally, BIP21 specifies that query
+parameter names such as `amount` and `label` are case sensitive, so
+uppercase versions of them aren't expected to work anyway.
+
+Still, anywhere you want to display just an address in a QR code, you
+should consider using all-uppercase for bech32 addresses and [bech32-like
+addresses][News 44 bech32].
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[rfc3986]: https://tools.ietf.org/html/rfc3986#section-3.1
+[news 44 bech32]: {{news44}}#bech32-sending-support

--- a/_includes/specials/bech32/10-snooze-lose.md
+++ b/_includes/specials/bech32/10-snooze-lose.md
@@ -1,0 +1,40 @@
+Up until this point in our series encouraging wallets and services to
+support sending to bech32 native segwit addresses, we've focused
+almost exclusively on technical information.  Today, this section
+expresses an opinion: the longer you delay implementing bech32 sending
+support, the worse some of your users and potential users will think of
+your software or service.
+
+> "They can only pay legacy addresses."<br>
+> "Oh.  Let's look for another service that supports current technology."
+
+Services that only support legacy addresses are likely to become a cue
+to users that minimal development effort is being put into maintaining
+their Bitcoin integration.  We expect that it'll send the same signal to
+users as a website in 2019 that's covered in Shockwave/Adobe Flash
+elements and that claims it's best viewed in Internet Explorer 7 (or
+see an even more [imaginative comparison][nullc bank analogy] written by Gregory
+Maxwell.)
+
+Bech32 sending is not some experimental new technology that still needs
+testing---native segwit unspent outputs currently hold [over 200,000
+bitcoins][].  Bech32 sending is also something that's easy to implement
+(see Newsletters [#38][news38 bech32] and [#40][news40 bech32]).  Most
+importantly, as more and more wallets and services upgrade to bech32
+*receiving* by default, it's going to become obvious which other
+services haven fallen behind by not providing sending support.
+
+If you haven't implemented bech32 sending support yet, we suggest you
+try to get it implemented by 24 August 2019 (the two-year anniversary of
+segwit activation).  Not long after that, Bitcoin Core's next release is
+expected to begin defaulting to bech32 receiving addresses in its GUI
+and perhaps also its API methods (see Newsletters [#40][Newsletter #40]
+and [#42][Newsletter #42]).  We expect other wallets to do the
+same---except for the ones that have already made bech32 their default
+(or even their only supported address format).
+
+[bech32 easy]: {{news38}}#bech32-sending-support
+[nullc bank analogy]: https://old.reddit.com/r/Bitcoin/comments/9iw1p2/hey_guys_its_time_to_make_bech32_standard_on/e6onq8t/
+[over 200,000 bitcoins]: https://p2sh.info/dashboard/db/p2wpkh-statistics?orgId=1
+[news38 bech32]: {{news38}}#bech32-sending-support
+[news40 bech32]: {{news40}}#bech32-sending-support

--- a/_posts/en/2019-03-19-bech32-sending-support.md
+++ b/_posts/en/2019-03-19-bech32-sending-support.md
@@ -1,0 +1,87 @@
+---
+title: Bech32 Sending Support
+permalink: /en/bech32-sending-support/
+name: 2019-03-19-bech32-sending-support
+type: posts
+layout: post
+lang: en
+
+excerpt: >
+  Copies of all published parts of our 24-part weekly series on bech32 sending
+  support from March 19th to August 28th, 2019.
+
+---
+<style>
+/* put a little extra space between the H2s to maybe help
+ * readers understand each of these was originally published independently
+ * of the others */
+h2:not(:first-of-type) { margin-top: 3em; }
+</style>
+
+{% include references.md %}
+
+On this page are copies of all published parts of our 24-part weekly series
+on bech32 sending support, from March 19th to August 28th, 2019.
+
+1. toc
+{:toc}
+
+## Introduction to Bech32 Sending Support
+
+*Originally published in [Newsletter #38][].*
+
+{% include specials/bech32/01-intro.md %}
+
+## Bech32 usage statistics
+
+*Originally published in [Newsletter #39][].*
+
+{% include specials/bech32/02-stats.md %}
+
+## Using the bech32 reference libraries
+
+*Originally published in [Newsletter #40][].*
+
+{% include specials/bech32/03-python-ref.md %}
+
+## Locating typos in bech32 addresses
+
+*Originally published in [Newsletter #41][].*
+
+{% include specials/bech32/04-ecc.md %}
+
+## Fee savings with native segwit
+
+*Originally published in [Newsletter #42][].*
+
+{% include specials/bech32/05-fee-savings.md %}
+
+## Top bech32 questions from the Bitcoin StackExchange
+
+*Originally published in [Newsletter #43][].*
+
+{% include specials/bech32/06-stackexchange.md %}
+
+## Other addresses formats based on bech32
+
+*Originally published in [Newsletter #44][].*
+
+{% include specials/bech32/07-altbech32.md %}
+
+## Automatic bech32 support for future soft forks
+
+*Originally published in [Newsletter #45][].*
+
+{% include specials/bech32/08-upgradability.md %}
+
+## Creating more efficient QR codes with bech32 addresses
+
+*Originally published in [Newsletter #46][].*
+
+{% include specials/bech32/09-qrcode.md %}
+
+## Bech32 support as a proxy for competence
+
+*Originally publised in [Newsletter #47][].*
+
+{% include specials/bech32/10-snooze-lose.md %}

--- a/_posts/en/newsletters/2019-03-19-newsletter.md
+++ b/_posts/en/newsletters/2019-03-19-newsletter.md
@@ -15,6 +15,8 @@ provided are a new weekly section about adoption of bech32 sending
 support and the normal list of notable changes in popular Bitcoin
 infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 RC2:** The second Release Candidate
@@ -154,105 +156,7 @@ infrastructure projects.
 
 *Week 1 of 24*
 
-Bech32 native segwit addresses were first publicly [proposed][bech32
-proposed] almost exactly two years ago, becoming the [BIP173][]
-standard.  This was followed by the segwit soft fork's lock-in on 24
-August 2017.  Yet, seventeen months after lock-in, some popular wallets
-and services still don't support sending bitcoins to bech32 addresses.
-Developers of other wallets and services are tired of waiting and want
-to default to receiving payments to bech32 addresses so that they can
-achieve additional fee savings and improved privacy.  Bitcoin Optech
-would like to help this process along so, from now until the two-year
-anniversary of segwit lock-in, each of our newsletters will include a
-short section with resources to help get bech32 sending support fully
-deployed.
-
-Note, we are only directly advocating bech32 **sending** support.  This
-allows the people you pay to use segwit but doesn't require you to
-implement segwit yourself.  (If you want to use segwit yourself to save
-fees or access its other benefits, that's great!  We just encourage you
-to implement bech32 sending support first so that the people you pay can
-begin taking advantage of it immediately while you upgrade the rest of
-your code and infrastructure to fully support segwit.)  To that end,
-this week's section focuses on showing exactly how small the differences
-are between sending to a legacy address and sending to a bech32 address.
-
-### Sending to a legacy address
-
-For a P2PKH legacy address that you already support such as
-1B6FkNg199ZbPJWG5zjEiDekrCc2P7MVyC, your base58check library will decode
-that to a 20-byte commitment:
-
-     6eafa604a503a0bb445ad1f6daa80f162b5605d6
-
-This commitment is inserted into a scriptPubKey template:
-
-<pre>OP_DUP OP_HASH160 OP_PUSH20 <b>6eafa604a503a0bb445ad1f6daa80f162b5605d6</b> OP_EQUALVERIFY OP_CHECKSIG</pre>
-
-Converting the opcodes to hex, this looks like:
-
-    76a9146eafa604a503a0bb445ad1f6daa80f162b5605d688ac
-
-This is inserted into the scriptPubKey part of an output that also
-includes the length of the script (25 bytes) and the amount being paid:
-
-<pre>     amount                           scriptPubKey
-|--------------|  |------------------------------------------------|
-00e1f5050000000019<b>76a9146eafa604a503a0bb445ad1f6daa80f162b5605d688ac</b>
-                |
-    size: 0x19 -> 25 bytes</pre>
-
-This output can then be added to the transaction, which is then signed
-and broadcast.
-
-### Sending to a bech32 address
-
-For an equivalent bech32 P2WPKH address such as
-bc1qd6h6vp99qwstk3z668md42q0zc44vpwkk824zh, you can use one of the
-[reference libraries][bech32 ref libs] to decode the address to a pair
-of values:
-
-    0 6eafa604a503a0bb445ad1f6daa80f162b5605d6
-
-These two values are also inserted into a scriptPubKey template.  The
-first value is the witness script version byte that's used to add a
-value to the stack using one of the opcodes from `OP_0` to `OP_16`.
-The second is the commitment that's also pushed onto the stack:
-
-<pre><b>OP_0</b> OP_PUSH20 <b>6eafa604a503a0bb445ad1f6daa80f162b5605d6</b></pre>
-
-Converting the opcodes to hex, this looks like:
-
-    00146eafa604a503a0bb445ad1f6daa80f162b5605d6
-
-Then, just as before, this is inserted into the scriptPubKey part of an
-output:
-
-<pre>     amount                        scriptPubKey
-|--------------|  |------------------------------------------|
-00e1f5050000000016<b>00146eafa604a503a0bb445ad1f6daa80f162b5605d6</b>
-                |
-    size: 0x16 -> 22 bytes</pre>
-
-The output is added to the transaction.  The transaction is then signed
-and broadcast.
-
-For bech32 P2WSH (the segwit equivalent of P2SH) or for future segwit
-witness versions, you don't need to do anything special.  The witness
-script version may be a different number, requiring you to use the
-corresponding `OP_0` to `OP_16` opcode, and the commitment may be a
-different length (from 2 to 40 bytes), but nothing else about the output
-changes.  Because length variations are allowed, ensure your fee
-estimation software considers the actual size of the scriptPubKey rather
-than using a constant someone previously calculated based on P2PKH or
-P2SH sizes.
-
-What you see above is the entire change you need to make on
-the backend of your software in order to enable sending to bech32
-addresses.  For most platforms, it should be a very easy change.  See
-[BIP173][] and the [reference implementations][bech32 ref libs] for a
-set of test vectors you can use to ensure your implementation works
-correctly.
+{% include specials/bech32/01-intro.md %}
 
 ## Notable code and documentation changes
 
@@ -287,7 +191,6 @@ correctly.
 - [C-Lightning #2342][] adds a new `setchannelfee` RPC that allows the
   user to set the feerates for each of their channels individually.
 
-{% include references.md %}
 {% include linkers/issues.md issues="2022,2618,2342,15555" %}
 [esplora convo]: http://www.erisian.com.au/bitcoin-core-dev/log-2019-03-08.html#l-53
 [havar github]: https://github.com/Blockstream/esplora/issues/51
@@ -300,8 +203,6 @@ correctly.
 [banlist cli]: https://people.xiph.org/~greg/banlist.cli.txt
 [banlist gui]: https://people.xiph.org/~greg/banlist.gui.txt
 [core dev irc]: http://www.erisian.com.au/meetbot/bitcoin-core-dev/2019/bitcoin-core-dev.2019-03-14-19.00.log.html#l-53
-[bech32 proposed]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-March/013749.html
-[bech32 ref libs]: https://github.com/sipa/bech32/tree/master/ref
 [ldev mv]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-March/001915.html
 [bdev mv]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016785.html
 [groups.io]: https://groups.io/

--- a/_posts/en/newsletters/2019-03-26-newsletter.md
+++ b/_posts/en/newsletters/2019-03-26-newsletter.md
@@ -13,6 +13,8 @@ are links to resources about bech32 adoption, summaries of popular
 questions and answers from Bitcoin StackExchange, and a list of notable
 code changes in popular Bitcoin infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 RC2:** The second Release Candidate
@@ -81,53 +83,7 @@ native segwit addresses.  This [doesn't require implementing
 segwit][bech32 easy] yourself, but it does allow the people you pay to
 access all of segwit's multiple benefits.*
 
-As described [last week][bech32 easy], implementing just segwit
-spending should be easy.  Yet we suspect some managers might wonder
-whether there are enough people using segwit to justify their team
-spending development effort on it.  This week, we look at sites that
-track various segwit adoption statistics so that you can decide whether
-it's popular enough that your wallet or service might become an outlier
-by failing to support it soon.
-
-Optech tracks statistics about segwit use on our [dashboard][optech
-dashboard]; another site tracking related statistics is [P2SH.info][].
-We see an average of about 200 outputs per block are sent to native
-segwit addresses (bech32).  Those outputs are then spent in about 10% of all
-Bitcoin transactions.  That makes payments involving native segwit addresses
-more popular than almost all altcoins.
-
-![Screenshot of Optech Dashboard segwit usage stats](/img/posts/2019-03-segwit-usage.png)
-
-However, many wallets want to use segwit but still need to deal with
-services that don't yet have bech32 sending support.  These wallets can
-generate a P2SH address that references their segwit details, which is
-less efficient than using bech32 but more efficient than not using
-segwit at all.  Because these are normal P2SH addresses, we can't tell
-just by looking at transaction outputs which P2SH addresses are
-pre-segwit P2SH outputs and which contain a nested segwit
-commitment, and so we don't know the actual number of payments to
-nested-segwit addresses.  However, when one of these outputs is spent,
-the spender reveals whether the output was segwit. The above statistics
-sites report that currently about 37% of transactions contain at least
-one spend from a nested-segwit output.  That corresponds to about 1,400
-outputs per block on average.
-
-Any wallet that supports P2SH nested segwit addresses also likely
-supports bech32 native addresses, so the number of transactions made by
-wallets that want to take advantage of bech32 sending support is
-currently over 45% and rising.
-
-To further gauge segwit popularity, you might also want to know which
-notable Bitcoin wallets and services support it.  For that, we recommend
-the community-maintained [bech32 adoption][] page on the Bitcoin Wiki or
-the [when segwit][] page maintained by BRD wallet.
-
-The statistics and compatibility data show that segwit is already well
-supported and frequently used, but that there are a few notable holdouts
-that haven't yet provided support.  It's our hope that our campaign and
-other community efforts will help convince the stragglers to catch up on
-bech32 sending support so that all wallets that want to take advantage
-of native segwit can do so in the next few months.
+{% include specials/bech32/02-stats.md %}
 
 ## Selected Q&A from Bitcoin StackExchange
 
@@ -250,17 +206,11 @@ answers made since our last update.*
 - [Eclair #826][] updates Eclair to be compatible with Bitcoin Core 0.17
   and upcoming 0.18, dropping support for 0.16.
 
-{% include references.md %}
 {% include linkers/issues.md issues="10973,15617,13541,2765,2691,2470,826,15555,10102" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
 [aead]: https://en.wikipedia.org/wiki/Authenticated_encryption
 [loop announced]: https://blog.lightning.engineering/posts/2019/03/20/loop.html
 [loop documentation]: https://github.com/lightninglabs/loop/blob/master/docs/architecture.md
 [sqcrypto announced]: https://twitter.com/jack/status/1108487911802966017
-[bech32 easy]: {{news38}}#bech32-sending-support
-[optech dashboard]: https://dashboard.bitcoinops.org/
-[p2sh.info]: https://p2sh.info/
-[bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
-[when segwit]: https://whensegwit.com/
 [taproot]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-January/015614.html
 [v2 transport]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016806.html

--- a/_posts/en/newsletters/2019-04-02-newsletter.md
+++ b/_posts/en/newsletters/2019-04-02-newsletter.md
@@ -13,6 +13,8 @@ to default its built-in wallet to bech32 receiving addresses in version
 sending support and notable code changes in popular Bitcoin
 infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 RC2:** The second Release Candidate
@@ -83,93 +85,7 @@ native segwit addresses.  This [doesn't require implementing
 segwit][bech32 easy] yourself, but it does allow the people you pay to
 access all of segwit's multiple benefits.*
 
-In a [previous week][bech32 easy], we discussed how small the
-differences are between creating the output for a legacy address versus
-a native segwit address.  In that section we simply pointed you towards
-the [bech32 reference libraries][] and told you that you'd get two
-values back.  In this week, we walkthrough the exact steps of using the
-Python reference library so you can see how little work this is.  We
-start by importing the library:
-
-```python3
->>> import segwit_addr
-```
-
-Bech32 addresses have a Human-Readable Part (HRP) that indicates what
-network the address is for.  These are the first few characters of the
-address and are separated from the data part of the address by the
-delimiter `1`.  For example, Bitcoin testnet uses `tb` and an example
-testnet address is tb1q3w[...]g7a.  We'll set the Bitcoin mainnet HRP of
-`bc` in our code so that we can later ensure that the addresses we parse
-are for the network we expect.
-
-```python3
->>> HRP='bc'
-```
-
-Finally, we have a few addresses we want to check---one that should work
-and two that should fail.  (See [BIP173][] for a complete set of
-[reference test vectors][bip173 test vectors].)
-
-```python3
->>> good_address='bc1qd6h6vp99qwstk3z668md42q0zc44vpwkk824zh'
->>> typo_address='bc1qd6h6vp99qwstk3z669md42q0zc44vpwkk824zh'
->>> wrong_network_address='tb1q3wrc5yq9c300jxlfeg7ae76tk9gsx044ucyg7a'
-```
-
-Now we can simply attempt to decode each of these addresses
-
-```python3
->>> segwit_addr.decode(HRP, good_address)
-(0, [110, 175, 166, 4, 165, 3, 160, 187, 68, 90, 209,
-     246, 218, 168, 15, 22, 43, 86, 5, 214])
-
->>> segwit_addr.decode(HRP, typo_address)
-(None, None)
-
->>> segwit_addr.decode(HRP, wrong_network_address)
-(None, None)
-```
-
-If we get back a None for the first value (the witness version), the
-address is invalid on our chosen network.  If that happens, you want to throw an
-exception up the stack so that whatever process is interfacing with the
-user can get them to provide you with a correct address.  If you
-actually get a number and an array, the decode succeeded, the checksum
-was valid, and the length was within the allowed range.
-
-The witness version must be a number between 0 and 16, so you'll want to
-check that (e.g. `0 <= x <= 16`) and then convert it into the
-corresponding opcodes `OP_0` through `OP_16`.  For `OP_0`, this is 0x00;
-for `OP_1` through `OP_16`, this is 0x51 through 0x60.  You then need to
-add a push byte for the data depending on its length (0x02 through 0x28
-for 2 to 40 bytes), and then append the data as a series of bytes.
-Pieter Wuille's [code][segwit addr to bytes] does this quite succinctly:
-
-```python3
->>> witver, witprog = segwit_addr.decode(HRP, good_address)
->>> bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog).hex()
-'00146eafa604a503a0bb445ad1f6daa80f162b5605d6'
-```
-
-That's your entire scriptPubKey.  You can use that in the output of a
-transaction and send it.  Note that bech32 scriptPubKeys can vary in
-size from 4 to 42 vbytes, so you need to consider the actual size of the
-scriptPubKey in your fee estimation code.
-
-Your code doesn't need to be written in Python.  Reference libraries
-are also provided for C, C++, Go, Haskell, JavaScript, Ruby, and Rust.
-Further, [BIP173][] describes bech32 well enough that any decent
-programmer should be able to implement it from scratch in their preferred
-language without requiring anything beyond what most programming
-languages provide in their builtins and standard library.
-
-**Other bech32 sending support updates:** BitGo [announced][bitgo
-segwit] that their API now supports sending to bech32 addresses; see
-their announcement for additional details about bech32 receiving support.
-The Gemini exchange also [apparently][gemini reddit] added bech32
-sending support this week, and users report that Gemini defaults to accepting
-deposits to bech32 addresses as well.
+{% include specials/bech32/03-python-ref.md %}
 
 ## Notable code and documentation changes
 
@@ -248,10 +164,8 @@ its master development branch; some may also be backported to the
   expected to be removed in a subsequent release.  See the [updated API
   documentation][eclair api docs] for details.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15555,15560,15620,15643,15519,15637,2759,894,13044" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
-[bech32 easy]: {{news38}}#bech32-sending-support
 [poly1305]: https://en.wikipedia.org/wiki/Poly1305
 [0.16.0 segwit]: https://bitcoincore.org/en/releases/0.16.0/#segwit-wallet
 [eclair api docs]: https://acinq.github.io/eclair/#introduction
@@ -260,10 +174,5 @@ its master development branch; some may also be backported to the
 [trampoline thread]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-March/001939.html
 [core meeting segwit]: http://www.erisian.com.au/meetbot/bitcoin-core-dev/2019/bitcoin-core-dev.2019-03-28-19.01.log.html#l-83
 [bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
-[bech32 reference libraries]: https://github.com/sipa/bech32/tree/master/ref
-[segwit addr to bytes]: https://github.com/sipa/bech32/blob/master/ref/python/tests.py#L30
-[bitgo segwit]: https://blog.bitgo.com/native-segwit-addresses-via-bitgos-api-4946f2007be9
-[gemini reddit]: https://www.reddit.com/r/Bitcoin/comments/b66n0v/psa_gemini_is_full_on_with_native_segwit_and_uses/
 [bolt2 delta]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection
 [p2p protocol encryption]: https://gist.github.com/jonasschnelli/c530ea8421b8d0e80c51486325587c52
-[bip173 test vectors]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Test_vectors

--- a/_posts/en/newsletters/2019-04-09-newsletter.md
+++ b/_posts/en/newsletters/2019-04-09-newsletter.md
@@ -12,6 +12,8 @@ fast initial syncing of nodes, and provides regular coverage of bech32
 sending support and notable merges in popular Bitcoin infrastructure
 projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 RC3:** The third Release Candidate
@@ -87,133 +89,7 @@ native segwit addresses.  This [doesn't require implementing
 segwit][bech32 easy] yourself, but it does allow the people you pay to
 access all of segwit's multiple benefits.*
 
-In [last week's newsletter][Newsletter #40], we used the Python
-reference library for bech32 to decode an address into a scriptPubKey
-that you could pay.  However, sometimes the user provides an address
-containing a typo.  The code we suggested would detect the typo and
-ensure you didn't pay a wrong address, but bech32 is also able to help
-detect the location of typos for your users.  This week, we'll
-demonstrate this capability using the [Javascript sample code][].
-
-The code is written using Node.js-style module inclusion syntax, so the
-first step is to compile it into code we can use in the browser.  For
-that, we install a [browserify][] tool:
-
-```bash
-sudo apt install node-browserify-lite
-```
-
-Then we compile it into a standalone file:
-
-```bash
-browserify-lite ./segwit_addr_ecc.js --outfile bech32-demo.js --standalone segwit_addr_ecc
-```
-
-Followed by including it in our HTML:
-
-```html
-<script src="bech32-demo.js"></script>
-```
-
-For convenience, we've included that file on the [web
-version][Newsletter #41] of this newsletter, so you can follow along
-with the rest of this example by simply opening the developer console in
-your web browser.  Let's start by checking a valid address.  Recall from
-last week that we provide the network identifier when checking an
-address (`bc` for Bitcoin mainnet):
-
-```text
->> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'bc')
-error: null
-program: Array(20) [ 117, 30, 118, … ]
-version: 0
-```
-
-We see above that, just like last week, we get back the witness version
-and the witness program.  The presence of the version field, plus the
-lack of an error, indicate that this program decoded without any
-checksum failure.
-
-Now we replace one character in the above address with a typo and try
-checking that:
-
-```text
->> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r4zarvary0c5xw7kv8f3t4', 'bc')
-error: "Invalid"
-pos: Array [ 21 ]
-```
-
-This time we get back the description of the error (the address is
-invalid because it doesn't match its checksum) and a position.  If we
-place the addresses above each other with each position marked, we see
-that this "21" identifies the location of the specific error:
-
-```text
-                   1x        2x
-         0123456789012345678901
->> good='bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
->> typo='bc1qw508d6qejxtdg4y5r4zarvary0c5xw7kv8f3t4'
-                              ^
-```
-
-What if we make an additional replacement to the typo address and try
-again?
-
-```text
->> segwit_addr_ecc.check('bc1qw508d6qejxtdg4y5r4zarvary0c5yw7kv8f3t4', 'bc')
-error: "Invalid"
-pos: Array [ 32, 21 ]
-```
-
-We get two locations.  Once again, when we compare the addresses to
-each other, we see this has identified both incorrect characters:
-
-```text
-                   1x        2x        3x
-         012345678901234567890123456789012
->> good='bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
->> typo='bc1qw508d6qejxtdg4y5r4zarvary0c5yw7kv8f3t4'
-                              ^          ^
-```
-
-Pieter Wuille's [interactive demo][] of this Javascript code includes
-a few lines of additional code (view source on that page to see the
-function) that uses the position of the typo characters to emphasize
-them in red:
-
-![Screenshot of the bech32 interactive demo with the typo address above](/img/posts/2019-04-bech32-demo.png)
-
-There's a limit to how many errors the `check()` function can specifically identify.
-After that it can still tell that an address contains an error, but it
-can't identify where to look in the address for the error.  In that
-case, it'll still return the address as invalid but it won't return the
-position details:
-
-```text
->> segwit_addr_ecc.check('bc1qw508z6qejxtdg4y5r4zarvary0c5yw7kv8f3t4', 'bc')
-error: "Invalid"
-pos: null
-```
-
-In the case where there are other problems with the address, the `error`
-field will be set to a more descriptive message that may or may not
-include a position of the error.  For example:
-
-```text
->> segwit_addr_ecc.check('bc1zw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4yolo', 'bc')
-error: "Invalid character"
-pos: Array [ 43 ]
-```
-
-You can review the [source][bech32 errors] for a complete list of
-errors.
-
-Although we spent a lot of time looking at errors in this mini tutorial,
-we've hopefully shown how easy it is to provide nice interactive
-feedback to users entering bech32 addresses on a web-based platform.  We
-encourage you to play around with the [interactive demo][] to get an
-idea of what your users might see if you make use of this bech32 address
-feature.
+{% include specials/bech32/04-ecc.md %}
 
 ## Notable code and documentation changes
 
@@ -297,23 +173,15 @@ their pending releases.*
     configuration option.  For pruned nodes, reindexing requires
     redownloading all pruned blocks.
 
-<script src="/misc/bech32-demo.js"></script>
-
-{% include references.md %}
 {% include linkers/issues.md issues="15555,9484,772,756,2313,15596,2885,2740,2370" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
-[bech32 easy]: {{news38}}#bech32-sending-support
 [0.14 tests]: https://bitcoincore.org/en/2017/03/08/release-0.14.0/#ibd
 [p2p protocol encryption]: https://gist.github.com/jonasschnelli/c530ea8421b8d0e80c51486325587c52
-[browserify]: http://browserify.org/
 [lnd releases]: https://github.com/lightningnetwork/lnd/releases
 [lnd issue]: https://github.com/lightningnetwork/lnd/issues/new
 [assumeutxo thread]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-April/016825.html
 [fast updatable UTXO commitments]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014337.html
 [automatic leveldb backups]: https://github.com/bitcoin/bitcoin/issues/8037
-[javascript sample code]: https://github.com/sipa/bech32/tree/master/ecc/javascript
-[interactive demo]: http://bitcoin.sipa.be/bech32/demo/demo.html
-[bech32 errors]: https://github.com/sipa/bech32/blob/master/ecc/javascript/segwit_addr_ecc.js#L54
 [round-robin]: https://en.wikipedia.org/wiki/Round-robin_scheduling
 [bitcoin core 0.5.0]: https://bitcoin.org/en/release/v0.5.0
 [sendmany wackiness]: https://github.com/bitcoin/bitcoin/pull/15595#issue-260932169

--- a/_posts/en/newsletters/2019-04-16-newsletter.md
+++ b/_posts/en/newsletters/2019-04-16-newsletter.md
@@ -11,6 +11,8 @@ for Bitcoin Core and LND, describes how helping people accept payments
 to bech32 addresses can lower fees, and lists notable code changes in
 popular Bitcoin projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 release candidates:** Bitcoin Core's
@@ -43,68 +45,7 @@ native segwit addresses.  This [doesn't require implementing
 segwit][bech32 easy] yourself, but it does allow the people you pay to
 access all of segwit's multiple benefits.*
 
-One reason your users and customers may want you to implement bech32
-sending support is because it'll allow the receivers of those payments
-to save on fees when they re-spend that money.  This week, we'll look at
-how much money they'll save and discuss how their savings could also
-help you save money.
-
-For the legacy P2PKH address format implemented in the first version of
-Bitcoin, the scriptSig that authorizes a spend is typically 107 vbytes.
-For P2SH-wrapped segwit P2WPKH, this same information is moved to a
-witness data field that only consumes 1/4 as many vbytes (27 vbytes) but
-whose P2SH overhead adds 23 vbytes for a total of 50 vbytes.  For native
-segwit P2WPKH, there's no P2SH overhead, so 27 vbytes is all that's used.
-
-This means you could argue that P2SH-P2WPKH saves over 50% compared to
-P2PKH, and that P2WPKH saves another almost 50% compared to P2SH-P2WPKH
-or 75% compared to P2PKH alone.  However, spending transactions contain
-more than just scriptSigs and witness data, so the way we usually
-compare savings is by looking at prototype transactions.  For example,
-we imagine a typical transaction containing a single input and two
-outputs (one to the receiver; one as change back to the spender).  In
-that case:
-
-- Spending P2PKH has a total transaction size of
-  220 vbytes
-- Spending P2SH-P2WPKH has a size of 167 vbytes (24% savings)
-- Spending P2WPKH output has a size of 141 vbytes (16% savings vs
-  P2SH-P2WPKH or 35% vs P2PKH)
-
-To compare simple multisig transactions (those that just use a single
-`OP_CHECKMULTSIG` opcode), things get more complex because k-of-n
-multisig inputs vary in size depending on the number of signatures (k)
-and the number of public keys (n).  So, for simplicity's sake, we'll
-just plot the sizes of legacy P2SH-multisig compared to wrapped P2SH-P2WSH
-multisig (up to the maximum 15-of-15 supported by legacy P2SH).  We can
-see that switching to P2SH-P2WSH can save from about 40% (1-of-2
-multisig) to about 70% (15-of-15).
-
-![Plot of multisig transaction sizes with P2SH and P2SH-P2WSH](/img/posts/2019-04-segwit-multisig-size-p2sh-to-p2sh-p2wsh.png)
-
-We can then compare P2SH-P2WSH to native P2WSH to see the additional
-constant-sized savings of about 35 bytes per transaction or about 5% to
-15%.
-
-![Plot of multisig transaction sizes with P2SH-P2WSH and P2WSH](/img/posts/2019-04-segwit-multisig-size-p2sh-p2wsh-to-p2wsh.png)
-
-The scripts described above account for almost all scripts being used
-with addresses that aren't native segwit.  (Users of more complex
-scripts, such as those used in LN, are mostly using native segwit today.)
-Those less efficient script types currently consume a majority fraction
-of block capacity (total block weight).  Switching to native segwit in
-order to reduce a transaction's weight allows you to reduce its fee by
-the same percentage without changing how long it'll take to confirm---all other
-things being equal.
-
-But all other things aren't equal.  Because the transactions use less
-block weight, there's more weight available for other transactions.  If
-the supply of available block weight increases and demand remains constant, we
-expect prices to go down (unless they're already at the default minimum
-relay fee).  This means more people spending native segwit inputs lowers
-the fee not just for those spenders but for everyone who creates
-transactions---including wallets and services that support sending to
-bech32 addresses.
+{% include specials/bech32/05-fee-savings.md %}
 
 ## Notable code and documentation changes
 
@@ -141,7 +82,6 @@ their pending releases.*
   to minimize exchange rate risk will need to pass a lower `expiry`
   value when using the `invoice` RPC.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15555,15711,2933,2908,2540,2554,2506,2022" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
 [lnd releases]: https://github.com/lightningnetwork/lnd/releases

--- a/_posts/en/newsletters/2019-04-23-newsletter.md
+++ b/_posts/en/newsletters/2019-04-23-newsletter.md
@@ -11,6 +11,8 @@ merge of BIP158 support into Bitcoin Core's development branch.  Also
 included are the regular sections about bech32 sending support and
 notable changes to popular Bitcoin infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Help test Bitcoin Core 0.18.0 release candidates:** Bitcoin Core's
@@ -88,44 +90,7 @@ access all of segwit's multiple benefits.*
 {% comment %}<!-- weekly reminder for harding: check Bech32 Adoption
 wiki page for changes -->{% endcomment %}
 
-This week we look at some of the [top-voted bech32 questions and
-answers][top bech32 qa] from the Bitcoin StackExchange.  This includes
-everything since bech32 was first announced about two years ago.
-
-{% assign bse = "https://bitcoin.stackexchange.com/a/" %}
-
-- [Will a Schnorr soft fork introduce a new address
-  format?]({{bse}}82952)  Although upgrading to bech32 sending support
-  should be easy, you probably don't want to repeat that work for
-  Bitcoin's next upgrade or the upgrade after that.  Pieter Wuille
-  answers this question by explaining how an upgrade to Schnorr-based
-  public keys and signatures can still use bech32 addresses.  (Optech
-  will be covering this issue in greater detail in a future section.)
-
-- [Is it safe to translate a bech32 P2WPKH address into a legacy P2PKH
-  address?]({{bse}}62207) If you read [Newsletter #38][bech32 easy],
-  you'll notice that the difference between a P2WPKH and P2PKH address
-  for the same underlying public key is only a few characters in a
-  scriptPubKey, making it possible to automatically convert one into the
-  other.  This answer by Andrew Chow and its accompanying comments
-  explains why that's a bad idea that could cause users to lose funds.
-
-- [Why does the bech32 decode function require specifying the address's
-  Human Readable Part (HRP) instead of extracting it
-  automatically?]({{bse}}83454) The HRP is separated from the rest of
-  the address by a `1`, so it seems like the decoder could ignore that
-  part all on its own.  Pieter Wuille explains that calling the decoder
-  with the expected HRP ensures that you don't accidentally pay bitcoin
-  to an address meant for testnet, litecoin, or some other network.
-  Gregory Maxwell also corrects an additional assumption of the asker.
-
-- [What block explorers recognize bech32 addresses?]({{bse}}66458)
-  More than two years after bech32 was first proposed and a year after
-  this question was first asked, several popular block explorers don't
-  support search or display of bech32 addresses.  The answer to this
-  question suggests anyone who wants to learn the bech32 status of
-  various block explorers should check the [bech32 adoption][] Bitcoin
-  Wiki page.
+{% include specials/bech32/06-stackexchange.md %}
 
 ## Notable code and documentation changes
 
@@ -259,7 +224,6 @@ backported to its pending release.*
     block as of this writing (block 572,879) has a filter that contains
     8,599 elements---far too much for us to print elegantly.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15555,14121,15839,14897,15776,15834,15557,885,2541,2545,2546,951,927,2382" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
 [bech32 easy]: {{news38}}#bech32-sending-support
@@ -275,7 +239,5 @@ backported to its pending release.*
 [eclair plugin doc]: https://github.com/ACINQ/eclair#plugins
 [lnd 0.6-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.6-beta
 [lightning loop]: https://github.com/lightninglabs/loop
-[top bech32 qa]: https://bitcoin.stackexchange.com/search?tab=votes&q=bech32
-[bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
 [rbf usability study]: /en/rbf-in-the-wild/
 [gcs]:  https://en.wikipedia.org/wiki/Golomb_coding#Rice_coding

--- a/_posts/en/newsletters/2019-04-30-newsletter.md
+++ b/_posts/en/newsletters/2019-04-30-newsletter.md
@@ -11,6 +11,8 @@ regular sections on bech32 sending support, selected questions and
 answers from the Bitcoin StackExchange, and notable changes in popular
 Bitcoin infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 *None at the time of writing.*  Note: if the Bitcoin Core release team
@@ -42,48 +44,7 @@ access all of segwit's multiple benefits.*
 {% comment %}<!-- weekly reminder for harding: check Bech32 Adoption
 wiki page for changes -->{% endcomment %}
 
-It's said that "imitation is the most sincere form of flattery."  In
-this week's section, we take a quick look at a few other systems that
-are using variations on bech32.  If you're already going to need to
-implement something that's basically bech32 for another project, it's
-probably worth your time to implement it for Bitcoin too.
-
-- **LN invoices** use the bech32 format with an extended Human-Readable
-  Part (HRP) and without bech32's normal 90-character limit.  See
-  [BOLT11][] for the full specification.  Example:
-  `lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp`
-
-- **Bitcoin Cash new-style addresses** use the bech32 format with the
-  HRP `bitcoincash` and the separator `:`.  Instead of the version byte
-  encoding a segwit witness version, as in Bitcoin, it indicates whether
-  the hash encoded by the address should be used with P2PKH or P2SH.  See
-  [spec-cashaddr][] for the full specification.  Example:
-  `bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a`
-
-- **Backup seeds:** In June 2018, Jonas Schnelli proposed Bech32X, a
-  scheme to encode Bitcoin private keys, extended private keys (xprivs),
-  and extended public keys (xpubs) using bech32 for error correction.
-  See the full [draft specification][bech32x].  Example:
-  `pk1lmll7u25wppjn5ghyhgm7kndgjwgphae8lez0gra436mj7ygaptggl447a4xh7`
-
-- **Elements-based sidechains:** sidechains based on
-  [ElementsProject.org][], such as [Blockstream Liquid][], use both
-  bech32 address and a variation of them called "blech32" addresses.
-  Blech32 addresses are intended for use with that platform's
-  [confidential assets][] and will soon be supported by the Esplora
-  block explorer for the Liquid sidechain.  We're
-  unaware of a specification document for blech32, but [this
-  code][blech32 py] is labeled as the reference implementation and is
-  cited elsewhere in the project as, "See liquid_addr.py for compact
-  difference from bech32." Example of a blech32 address:
-  `lq1qqf8er278e6nyvuwtgf39e6ewvdcnjupn9a86rzpx655y5lhkt0walu3djf9cklkxd3ryld97hu8h3xepw7sh2rlu7q45dcew5`
-
-- **Output script descriptors:** although less directly related to
-  bech32, checksums based on the same Bose-Chaudhuri-Hocquenghem (BCH) codes used in bech32 were
-  added to the [output script descriptors][] supported by Bitcoin Core.
-  See Pieter Wuille's [detailed comment][descriptors checksum].
-  Example:
-  `wpkh([f6bb4c63/0'/0'/28']02bf9d38386db60191f2f785cbf7ba90d01bed5958efb7b449a552b89da7550177)#efkksxw6`
+{% include specials/bech32/07-altbech32.md %}
 
 ## Selected Q&A from Bitcoin StackExchange
 
@@ -190,16 +151,7 @@ backported to its pending release.*
   node handles network gossip with the aim to reduce unnecessary
   traffic.
 
-{% include references.md %}
 {% include linkers/issues.md issues="14039,15846,950" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
-[bech32 easy]: {{news38}}#bech32-sending-support
-[descriptors checksum]: https://github.com/bitcoin/bitcoin/blob/fd637be8d21a606e98c037b40b268c4a1fae2244/src/script/descriptor.cpp#L24
-[spec-cashaddr]: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
-[bech32x]: https://gist.github.com/jonasschnelli/68a2a5a5a5b796dc9992f432e794d719
-[elementsproject.org]: https://elementsproject.org/
-[blockstream liquid]: https://blockstream.com/liquid/
-[confidential assets]: https://elementsproject.org/features/confidential-transactions
-[blech32 py]: https://github.com/ElementsProject/elements/commit/9cb2fa051fcbe0fe66f15e6b88d224d1935376f4#diff-265badc7e18059096c32a61b0eada470
 [dust convo]: https://github.com/bitcoin/bitcoin/pull/2577#issuecomment-17738577
 [bitcoincore.org]: https://bitcoincore.org/

--- a/_posts/en/newsletters/2019-05-07-newsletter.md
+++ b/_posts/en/newsletters/2019-05-07-newsletter.md
@@ -11,6 +11,8 @@ recently-released Bitcoin Core 0.18.0, briefly mentions two proposed BIPs, descr
 are forward compatible with expected protocol improvements, and
 summarizes notable changes in popular Bitcoin infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 - **Consider upgrading to Bitcoin Core 0.18.0:** released last week, the
@@ -166,59 +168,7 @@ access all of segwit's multiple benefits.*
 {% comment %}<!-- weekly reminder for harding: check Bech32 Adoption
 wiki page for changes -->{% endcomment %}
 
-What do bip-taproot and bip-tapscript mean for people who have
-implemented bech32 sending support or who are planning to implement it?
-In particular, if you haven't implemented segwit sending support yet,
-should you wait to implement it until the new features have been
-activated?  In this weekly section, we'll show why you shouldn't wait
-and how implementing sending support now won't cost you any extra effort
-in the future.
-
-The designers of segwit and bech32 had a general idea what future
-protocol improvements would look like, so they engineered segwit
-scriptPubKeys and the bech32 address format to be forward compatible
-with those expected improvements.  For example an address supporting
-Taproot might look like this:
-
-```text
-bc1pqzkqvpm76ewe20lcacq740p054at9sv7vxs0jn2u0r90af0k63332hva8pt
-```
-
-You'll notice that looks just like other bech32 addresses you've
-seen---because it is.  You can use the exact same code we provided in
-[Newsletter #40][] (using the bech32 reference library for Python) to decode
-it.
-
-```python
->> import segwit_addr
->> address='bc1pqzkqvpm76ewe20lcacq740p054at9sv7vxs0jn2u0r90af0k63332hva8pt'
->> witver, witprog = segwit_addr.decode('bc', address)
->> witver
-1
->> bytes(witprog).hex()
-'00ac06077ed65d953ff8ee01eabc2fa57ab2c19e61a0f94d5c78cafea5f6d46315'
-```
-
-The differences here from the decoded bech32 addresses we've shown in
-previous newsletters are that this hypothetical Taproot address uses a
-witness version of `1` instead of `0` (meaning the scriptPubKey will
-start with `OP_1` instead of `OP_0`) and the witness program is one
-byte longer than a P2WSH witness program.  However, these don't matter
-to your software if you're just spending.  We can use the exact same
-example code from [Newsletter #40][news40 bech32] to create the
-appropriate scriptPubKey for you to pay:
-
-```python
->> bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog).hex()
-'512100ac06077ed65d953ff8ee01eabc2fa57ab2c19e61a0f94d5c78cafea5f6d46315'
-```
-
-This means anyone who implements bech32 support in the generic way
-described in Newsletter #40 shouldn't need to do anything special in
-order to support future script upgrades.  In short, the work you invest
-into providing bech32 sending support now is something you won't need to
-repeat when future expected changes to the Bitcoin protocol are
-deployed.
+{% include specials/bech32/08-upgradability.md %}
 
 ## Notable code and documentation changes
 
@@ -253,10 +203,8 @@ deployed.
   open to start sending LN payments.  The plugin is based on an [earlier
   PR][C-Lightning #1888] to the main C-Lightning codebase.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15487,15764,15323,15141,1888" %}
 [0.18.0]: https://bitcoincore.org/bin/bitcoin-core-0.18.0/
-[bech32 easy]: {{news38}}#bech32-sending-support
 [snap package]: https://snapcraft.io/bitcoin-core
 [0.19 release schedule]: https://github.com/bitcoin/bitcoin/issues/15940
 [c-lightning plugin repository]: https://github.com/lightningd/plugins
@@ -265,7 +213,6 @@ deployed.
 [psbt documentation]: https://github.com/bitcoin/bitcoin/blob/master/doc/psbt.md
 [bitcoincore.org download]: https://bitcoincore.org/en/download/
 [gitian sigs]: https://github.com/bitcoin-core/gitian.sigs
-[news40 bech32]: {{news40}}#bech32-sending-support
 [wasabi hwi]: https://github.com/zkSNACKs/WalletWasabi/pull/1341
 [tap post]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-May/016914.html
 [taproot]: https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki

--- a/_posts/en/newsletters/2019-05-14-newsletter.md
+++ b/_posts/en/newsletters/2019-05-14-newsletter.md
@@ -11,6 +11,8 @@ Taproot proposal, news about a small potential change to the BIP174 PSBT
 format, and our regular sections about bech32 sending support and
 notable changes in popular infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 *None this week.*
@@ -522,45 +524,7 @@ access all of segwit's multiple benefits.*
 {% comment %}<!-- weekly reminder for harding: check Bech32 Adoption
 wiki page for changes -->{% endcomment %}
 
-[BIP173][] forbids bech32 addresses from using mixed case.  The
-preferred way to write a bech32 address is in all lowercase, but there's
-one case where all uppercase makes sense: QR codes.  Take a look at the
-following two QR codes for the same address with the only difference
-being lowercase versus uppercase:
-
-![bech32 uppercase](/img/posts/2019-05-bech32-qr-uc.png)
-{:.center}
-
-This is a deliberate design feature of bech32.  QR codes can be created
-in several modes that support different character sets.
-The binary mode character set is used for legacy addresses because they
-require mixed case.  However, Bech32 addresses for Bitcoin[^only-bc] can
-be represented using only numbers and capital letters, so they can use
-the smaller uppercase alphanumeric character set.  Because this set is
-smaller, it uses fewer bits to encode each character in a QR code,
-allowing the resultant code to be less complex.
-
-Bitcoin addresses are often used in [BIP21][] URIs.  BIP21 technically
-requires base58check formatting, but at least some wallets that support
-native segwit addresses (such as Bitcoin Core) allow them to be used
-with bech32.  Although the preferred form of BIP21's scheme identifier
-`bitcoin:` is lowercase, it can also be uppercased as allowed by both
-BIP21 and [RFC3986][].  This also produces a less complex image
-(although in this case, our QR encoding library gave both images the
-same dimensions).
-
-![bech32 uppercase](/img/posts/2019-05-bip21-bech32-qr-uc.png)
-{:.center}
-
-Unfortunately, the `?` and `&` needed for passing additional parameters
-in a BIP21 URI are not part of the QR code uppercase character set, so
-only binary mode can be used.  Additionally, BIP21 specifies that query
-parameter names such as `amount` and `label` are case sensitive, so
-uppercase versions of them aren't expected to work anyway.
-
-Still, anywhere you want to display just an address in a QR code, you
-should consider using all-uppercase for bech32 addresses and [bech32-like
-addresses][News 44 bech32].
+{% include specials/bech32/09-qrcode.md %}
 
 ## Notable code and documentation changes
 
@@ -628,10 +592,7 @@ the fault of the newsletter author.
     code about uppercase always providing smaller QR codes for
     non-Bitcoin bech32 addresses.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15730,15930,2524,15939" %}
-[bech32 easy]: {{news38}}#bech32-sending-support
-[rfc3986]: https://tools.ietf.org/html/rfc3986#section-3.1
 [anyprevout post]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-May/016929.html
 [psbt path]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-April/016894.html
 [taproot post]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-May/016914.html
@@ -644,4 +605,3 @@ the fault of the newsletter author.
 [scriptless scripts]: http://diyhpl.us/wiki/transcripts/layer2-summit/2018/scriptless-scripts/
 [discrete log contracts]: https://adiabat.github.io/dlc.pdf
 [example implementation]: https://github.com/sipa/bitcoin/commits/taproot
-[news 44 bech32]: {{news44}}#bech32-sending-support

--- a/_posts/en/newsletters/2019-05-21-newsletter.md
+++ b/_posts/en/newsletters/2019-05-21-newsletter.md
@@ -11,6 +11,8 @@ a few technical talks from the Magical Crypto Friends conference, and
 includes our regular sections on bech32 sending support and notable
 changes to popular Bitcoin infrastructure projects.
 
+{% include references.md %}
+
 ## Action items
 
 *None this week.*
@@ -124,40 +126,7 @@ you pay to access all of segwit's benefits.*
 {% comment %}<!-- weekly reminder for harding: check Bech32 Adoption
 wiki page for changes -->{% endcomment %}
 
-Up until this point in our series encouraging wallets and services to
-support sending to bech32 native segwit addresses, we've focused
-almost exclusively on technical information.  Today, this section
-expresses an opinion: the longer you delay implementing bech32 sending
-support, the worse some of your users and potential users will think of
-your software or service.
-
-> "They can only pay legacy addresses."<br>
-> "Oh.  Let's look for another service that supports current technology."
-
-Services that only support legacy addresses are likely to become a cue
-to users that minimal development effort is being put into maintaining
-their Bitcoin integration.  We expect that it'll send the same signal to
-users as a website in 2019 that's covered in Shockwave/Adobe Flash
-elements and that claims it's best viewed in Internet Explorer 7 (or
-see an even more [imaginative comparison][nullc bank analogy] written by Gregory
-Maxwell.)
-
-Bech32 sending is not some experimental new technology that still needs
-testing---native segwit unspent outputs currently hold [over 200,000
-bitcoins][].  Bech32 sending is also something that's easy to implement
-(see Newsletters [#38][news38 bech32] and [#40][news40 bech32]).  Most
-importantly, as more and more wallets and services upgrade to bech32
-*receiving* by default, it's going to become obvious which other
-services haven fallen behind by not providing sending support.
-
-If you haven't implemented bech32 sending support yet, we suggest you
-try to get it implemented by 24 August 2019 (the two-year anniversary of
-segwit activation).  Not long after that, Bitcoin Core's next release is
-expected to begin defaulting to bech32 receiving addresses in its GUI
-and perhaps also its API methods (see Newsletters [#40][Newsletter #40]
-and [#42][Newsletter #42]).  We expect other wallets to do the
-same---except for the ones that have already made bech32 their default
-(or even their only supported address format).
+{% include specials/bech32/10-snooze-lose.md %}
 
 ## Notable code and documentation changes
 
@@ -208,14 +177,8 @@ same---except for the ones that have already made bech32 their default
   method that deletes all invoices that expired before the specified
   time.
 
-{% include references.md %}
 {% include linkers/issues.md issues="15006,15870,14802,14047,2631,2627,15512,14032" %}
-[bech32 easy]: {{news38}}#bech32-sending-support
 [mcf transcripts]: https://diyhpl.us/wiki/transcripts/magicalcryptoconference/2019/
-[nullc bank analogy]: https://old.reddit.com/r/Bitcoin/comments/9iw1p2/hey_guys_its_time_to_make_bech32_standard_on/e6onq8t/
-[over 200,000 bitcoins]: https://p2sh.info/dashboard/db/p2wpkh-statistics?orgId=1
-[news38 bech32]: {{news38}}#bech32-sending-support
-[news40 bech32]: {{news40}}#bech32-sending-support
 [v2 transport protocol]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016806.html
 [anyprevout list]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-May/001992.html
 [mcf vids]: https://www.youtube.com/playlist?list=PLWqtMh0tDnEGBHDS8CalOpkVZhlIgRlAC

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -145,3 +145,5 @@ div.xoverflow {
 .wrapper{
     overflow-wrap: break-word;
 }
+
+ol li ol { list-style-type: lower-latin; }


### PR DESCRIPTION
Closes #128 

This moves each bech32 sending support section into a separate includable file and then includes each of them in two different places: first, in the newsletter that originally included them; second, in a blog post backdated to the start of our series.  I think this makes the combined content highly accessible, as it's all easily searchable using find-in-page.

This required moving links around and also moving where we included references.md in some previous newsletters (because it contains variable definitions, it must appear before we use those variables, which means including it before the subsequently-included bech32 sections.  However, it can't go at the very top of the file, since that breaks the automatic first-paragraph summary used on the newsletter index page.)

A separate commit in this PR also adds a script that automates most of the work of creating the link reference definitions for old newsletters.  Manually creating those links was annoying for me, even if it only took 30 seconds a week.

When making a change like this that makes a lot of backend changes but minimal frontend changes, my preferred testing method is comparing diffs of the rendered site.  E.g.:

    git checkout 4c551cc0    ## before these changes
    make
    cp -a _site _old_site
    git checkout <this PR>
    make
    diff -ruN _old_site _site | colordiff | less -R

I think that looks good.  (You can drop the -N from diff to suppress new files so that you only see the changes to existing files, which is a minimal diff.)