### PR TITLE
Scripted diff: add 'slug:' front matter to all posts

### DIFF
--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -2,6 +2,7 @@
 title: 'Announcing Bitcoin Optech'
 permalink: /en/announcing-bitcoin-optech/
 name: 2018-07-20-announcing-bitcoin-optech
+slug: 2018-07-20-announcing-bitcoin-optech
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2018-07-30-xapo-consolidation.md
+++ b/_posts/en/2018-07-30-xapo-consolidation.md
@@ -2,6 +2,7 @@
 title: 'Field Report: Consolidation of 4 Million UTXOs at Xapo'
 permalink: /en/xapo-utxo-consolidation/
 name: 2018-07-30-xapo-utxo-consolidation
+slug: 2018-07-30-xapo-utxo-consolidation
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2018-09-04-dashboard-announcement.md
+++ b/_posts/en/2018-09-04-dashboard-announcement.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Dashboard'
 permalink: /en/dashboard-announcement/
 name: 2018-09-04-dashboard-announcement
+slug: 2018-09-04-dashboard-announcement
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -2,6 +2,7 @@
 title: '2018 Annual Report'
 permalink: /en/2018-optech-annual-report/
 name: 2018-12-28-2018-optech-annual-report
+slug: 2018-12-28-2018-optech-annual-report
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/en/2019-02-11-rbf-in-the-wild.md
@@ -2,6 +2,7 @@
 title: 'RBF in the Wild'
 permalink: /en/rbf-in-the-wild/
 name: 2019-02-11-rbf-in-the-wild
+slug: 2019-02-11-rbf-in-the-wild
 type: posts
 layout: post
 lang: en

--- a/_posts/en/2019-03-19-bech32-sending-support.md
+++ b/_posts/en/2019-03-19-bech32-sending-support.md
@@ -2,6 +2,7 @@
 title: Bech32 Sending Support
 permalink: /en/bech32-sending-support/
 name: 2019-03-19-bech32-sending-support
+slug: 2019-03-19-bech32-sending-support
 type: posts
 layout: post
 lang: en

--- a/_posts/en/newsletters/2018-06-08-newsletter.md
+++ b/_posts/en/newsletters/2018-06-08-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #0'
 permalink: /en/newsletters/2018/06/08/
 name: 2018-06-08-newsletter
+slug: 2018-06-08-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-06-26-newsletter.md
+++ b/_posts/en/newsletters/2018-06-26-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #1'
 permalink: /en/newsletters/2018/06/26/
 name: 2018-06-26-newsletter
+slug: 2018-06-26-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-07-03-newsletter.md
+++ b/_posts/en/newsletters/2018-07-03-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #2'
 permalink: /en/newsletters/2018/07/03/
 name: 2018-07-03-newsletter
+slug: 2018-07-03-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-07-10-newsletter.md
+++ b/_posts/en/newsletters/2018-07-10-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #3'
 permalink: /en/newsletters/2018/07/10/
 name: 2018-07-10-newsletter
+slug: 2018-07-10-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-07-17-newsletter.md
+++ b/_posts/en/newsletters/2018-07-17-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #4'
 permalink: /en/newsletters/2018/07/17/
 name: 2018-07-17-newsletter
+slug: 2018-07-17-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-07-24-newsletter.md
+++ b/_posts/en/newsletters/2018-07-24-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #5'
 permalink: /en/newsletters/2018/07/24/
 name: 2018-07-24-newsletter
+slug: 2018-07-24-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-07-31-newsletter.md
+++ b/_posts/en/newsletters/2018-07-31-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #6'
 permalink: /en/newsletters/2018/07/31/
 name: 2018-07-31-newsletter
+slug: 2018-07-31-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-08-07-newsletter.md
+++ b/_posts/en/newsletters/2018-08-07-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #7'
 permalink: /en/newsletters/2018/08/07/
 name: 2018-08-07-newsletter
+slug: 2018-08-07-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-08-14-newsletter.md
+++ b/_posts/en/newsletters/2018-08-14-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #8'
 permalink: /en/newsletters/2018/08/14/
 name: 2018-08-14-newsletter
+slug: 2018-08-14-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-08-21-newsletter.md
+++ b/_posts/en/newsletters/2018-08-21-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #9'
 permalink: /en/newsletters/2018/08/21/
 name: 2018-08-21-newsletter
+slug: 2018-08-21-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-08-28-newsletter.md
+++ b/_posts/en/newsletters/2018-08-28-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #10'
 permalink: /en/newsletters/2018/08/28/
 name: 2018-08-28-newsletter
+slug: 2018-08-28-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-09-04-newsletter.md
+++ b/_posts/en/newsletters/2018-09-04-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #11'
 permalink: /en/newsletters/2018/09/04/
 name: 2018-09-04-newsletter
+slug: 2018-09-04-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-09-11-newsletter.md
+++ b/_posts/en/newsletters/2018-09-11-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #12'
 permalink: /en/newsletters/2018/09/11/
 name: 2018-09-11-newsletter
+slug: 2018-09-11-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #13'
 permalink: /en/newsletters/2018/09/18/
 name: 2018-09-18-newsletter
+slug: 2018-09-18-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #14'
 permalink: /en/newsletters/2018/09/25/
 name: 2018-09-25-newsletter
+slug: 2018-09-25-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-10-02-newsletter.md
+++ b/_posts/en/newsletters/2018-10-02-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #15'
 permalink: /en/newsletters/2018/10/02/
 name: 2018-10-02-newsletter
+slug: 2018-10-02-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-10-09-newsletter.md
+++ b/_posts/en/newsletters/2018-10-09-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #16: Scaling Bitcoin Special'
 permalink: /en/newsletters/2018/10/09/
 name: 2018-10-09-newsletter
+slug: 2018-10-09-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-10-16-newsletter.md
+++ b/_posts/en/newsletters/2018-10-16-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #17"
 permalink: /en/newsletters/2018/10/16/
 name: 2018-10-16-newsletter
+slug: 2018-10-16-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-10-23-newsletter.md
+++ b/_posts/en/newsletters/2018-10-23-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #18"
 permalink: /en/newsletters/2018/10/23/
 name: 2018-10-23-newsletter
+slug: 2018-10-23-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-10-30-newsletter.md
+++ b/_posts/en/newsletters/2018-10-30-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #19"
 permalink: /en/newsletters/2018/10/30/
 name: 2018-10-30-newsletter
+slug: 2018-10-30-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-11-06-newsletter.md
+++ b/_posts/en/newsletters/2018-11-06-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #20"
 permalink: /en/newsletters/2018/11/06/
 name: 2018-11-06-newsletter
+slug: 2018-11-06-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-11-13-newsletter.md
+++ b/_posts/en/newsletters/2018-11-13-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #21"
 permalink: /en/newsletters/2018/11/13/
 name: 2018-11-13-newsletter
+slug: 2018-11-13-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-11-20-newsletter.md
+++ b/_posts/en/newsletters/2018-11-20-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #22"
 permalink: /en/newsletters/2018/11/20/
 name: 2018-11-20-newsletter
+slug: 2018-11-20-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-11-27-newsletter.md
+++ b/_posts/en/newsletters/2018-11-27-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #23"
 permalink: /en/newsletters/2018/11/27/
 name: 2018-11-27-newsletter
+slug: 2018-11-27-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-12-04-newsletter.md
+++ b/_posts/en/newsletters/2018-12-04-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #24"
 permalink: /en/newsletters/2018/12/04/
 name: 2018-12-04-newsletter
+slug: 2018-12-04-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-12-11-newsletter.md
+++ b/_posts/en/newsletters/2018-12-11-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #25"
 permalink: /en/newsletters/2018/12/11/
 name: 2018-12-11-newsletter
+slug: 2018-12-11-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-12-18-newsletter.md
+++ b/_posts/en/newsletters/2018-12-18-newsletter.md
@@ -2,6 +2,7 @@
 title: "Bitcoin Optech Newsletter #26"
 permalink: /en/newsletters/2018/12/18/
 name: 2018-12-18-newsletter
+slug: 2018-12-18-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #27: 2018 Year-in-Review Special'
 permalink: /en/newsletters/2018/12/28/
 name: 2018-12-28-newsletter
+slug: 2018-12-28-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-01-08-newsletter.md
+++ b/_posts/en/newsletters/2019-01-08-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #28'
 permalink: /en/newsletters/2019/01/08/
 name: 2019-01-08-newsletter
+slug: 2019-01-08-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-01-15-newsletter.md
+++ b/_posts/en/newsletters/2019-01-15-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #29'
 permalink: /en/newsletters/2019/01/15/
 name: 2019-01-15-newsletter
+slug: 2019-01-15-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-01-22-newsletter.md
+++ b/_posts/en/newsletters/2019-01-22-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #30'
 permalink: /en/newsletters/2019/01/22/
 name: 2019-01-22-newsletter
+slug: 2019-01-22-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-01-29-newsletter.md
+++ b/_posts/en/newsletters/2019-01-29-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #31'
 permalink: /en/newsletters/2019/01/29/
 name: 2019-01-29-newsletter
+slug: 2019-01-29-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-02-05-newsletter.md
+++ b/_posts/en/newsletters/2019-02-05-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #32'
 permalink: /en/newsletters/2019/02/05/
 name: 2019-02-05-newsletter
+slug: 2019-02-05-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-02-12-newsletter.md
+++ b/_posts/en/newsletters/2019-02-12-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #33'
 permalink: /en/newsletters/2019/02/12/
 name: 2019-02-12-newsletter
+slug: 2019-02-12-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-02-19-newsletter.md
+++ b/_posts/en/newsletters/2019-02-19-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #34'
 permalink: /en/newsletters/2019/02/19/
 name: 2019-02-19-newsletter
+slug: 2019-02-19-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-02-26-newsletter.md
+++ b/_posts/en/newsletters/2019-02-26-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #35'
 permalink: /en/newsletters/2019/02/26/
 name: 2019-02-26-newsletter
+slug: 2019-02-26-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-03-05-newsletter.md
+++ b/_posts/en/newsletters/2019-03-05-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #36'
 permalink: /en/newsletters/2019/03/05/
 name: 2019-03-05-newsletter
+slug: 2019-03-05-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-03-12-newsletter.md
+++ b/_posts/en/newsletters/2019-03-12-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #37'
 permalink: /en/newsletters/2019/03/12/
 name: 2019-03-12-newsletter
+slug: 2019-03-12-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-03-19-newsletter.md
+++ b/_posts/en/newsletters/2019-03-19-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #38'
 permalink: /en/newsletters/2019/03/19/
 name: 2019-03-19-newsletter
+slug: 2019-03-19-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-03-26-newsletter.md
+++ b/_posts/en/newsletters/2019-03-26-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #39'
 permalink: /en/newsletters/2019/03/26/
 name: 2019-03-26-newsletter
+slug: 2019-03-26-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-04-02-newsletter.md
+++ b/_posts/en/newsletters/2019-04-02-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #40'
 permalink: /en/newsletters/2019/04/02/
 name: 2019-04-02-newsletter
+slug: 2019-04-02-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-04-09-newsletter.md
+++ b/_posts/en/newsletters/2019-04-09-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #41'
 permalink: /en/newsletters/2019/04/09/
 name: 2019-04-09-newsletter
+slug: 2019-04-09-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-04-16-newsletter.md
+++ b/_posts/en/newsletters/2019-04-16-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #42'
 permalink: /en/newsletters/2019/04/16/
 name: 2019-04-16-newsletter
+slug: 2019-04-16-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-04-23-newsletter.md
+++ b/_posts/en/newsletters/2019-04-23-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #43'
 permalink: /en/newsletters/2019/04/23/
 name: 2019-04-23-newsletter
+slug: 2019-04-23-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-04-30-newsletter.md
+++ b/_posts/en/newsletters/2019-04-30-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #44'
 permalink: /en/newsletters/2019/04/30/
 name: 2019-04-30-newsletter
+slug: 2019-04-30-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-05-07-newsletter.md
+++ b/_posts/en/newsletters/2019-05-07-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #45'
 permalink: /en/newsletters/2019/05/07/
 name: 2019-05-07-newsletter
+slug: 2019-05-07-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-05-14-newsletter.md
+++ b/_posts/en/newsletters/2019-05-14-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #46'
 permalink: /en/newsletters/2019/05/14/
 name: 2019-05-14-newsletter
+slug: 2019-05-14-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-05-21-newsletter.md
+++ b/_posts/en/newsletters/2019-05-21-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #47'
 permalink: /en/newsletters/2019/05/21/
 name: 2019-05-21-newsletter
+slug: 2019-05-21-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-05-29-newsletter.md
+++ b/_posts/en/newsletters/2019-05-29-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #48'
 permalink: /en/newsletters/2019/05/29/
 name: 2019-05-29-newsletter
+slug: 2019-05-29-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-06-05-newsletter.md
+++ b/_posts/en/newsletters/2019-06-05-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #49'
 permalink: /en/newsletters/2019/06/05/
 name: 2019-06-05-newsletter
+slug: 2019-06-05-newsletter
 type: newsletter
 layout: newsletter
 lang: en

--- a/_posts/en/newsletters/2019-06-12-newsletter.md
+++ b/_posts/en/newsletters/2019-06-12-newsletter.md
@@ -2,6 +2,7 @@
 title: 'Bitcoin Optech Newsletter #50'
 permalink: /en/newsletters/2019/06/12/
 name: 2019-06-12-newsletter
+slug: 2019-06-12-newsletter
 type: newsletter
 layout: newsletter
 lang: en


### PR DESCRIPTION
Closes #155 

It looks like Jekyll's slug routine isn't handling our URLs well, I don't know why.  As seen [here](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/document.rb#L385), the slug is used for part of the supposed-to-be unique id given to each page for things like Atom feeds, leading to the problem described in #155.

We aren't currently using page slugs for anything else and it's possible to set them manually, so this one line scripted diff just gives each page its own unique slug to ensure our feed contains entirely unique IDs.  There are probably better ways to do this, but I think this is acceptable for now.