### PR TITLE
2019 06 change twitter to website link

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -24,77 +24,77 @@ sponsors:
 members:
   -
     name: Alto Financial
-    twitter: AltoFinancial
+    website: https://twitter.com/AltoFinancial
     logo: alto.svg
   -
     name: Anchorage
-    twitter: Anchorage
+    website: https://twitter.com/Anchorage
     logo: anchorage.png
   -
     name: BitGo
-    twitter: BitGo
+    website: https://twitter.com/BitGo
     logo: bitgo.png
   -
     name: BitMEX
-    twitter: BitMEXdotcom
+    website: https://twitter.com/BitMEXdotcom
     logo: bitmex.png
   -
     name: Bitrefill
-    twitter: bitrefill
+    website: https://twitter.com/bitrefill
     logo: bitrefill.svg
   -
     name: Bitso
-    twitter: Bitso
+    website: https://twitter.com/Bitso
     logo: bitso.svg
   -
     name: Bitstamp
-    twitter: Bitstamp
+    website: https://twitter.com/Bitstamp
     logo: bitstamp.png
   -
     name: BRD
-    twitter: brdhq
+    website: https://twitter.com/brdhq
     logo: BRD.png
   -
     name: Casa
-    twitter: CasaHODL
+    website: https://twitter.com/CasaHODL
     logo: casa.png
   -
     name: Coinbase
-    twitter: Coinbase
+    website: https://twitter.com/Coinbase
     logo: coinbase.png
   -
     name: Conio
-    twitter: conio
+    website: https://twitter.com/conio
     logo: conio.png
   -
     name: CryptoGarage
-    twitter: cryptogarageinc
+    website: https://twitter.com/cryptogarageinc
     logo: CryptoGarage.png
   -
     name: Electrum
-    twitter: ElectrumWallet
+    website: https://twitter.com/ElectrumWallet
     logo: electrum.png
   -
     name: Kraken
-    twitter: krakenfx
+    website: https://twitter.com/krakenfx
     logo: kraken.png
   -
     name: Ledger
-    twitter: LedgerHQ
+    website: https://twitter.com/LedgerHQ
     logo: ledger.png
   -
     name: Paxos
-    twitter: PaxosGlobal
+    website: https://twitter.com/PaxosGlobal
     logo: paxos.png
   -
     name: Purse
-    twitter: PurseIO
+    website: https://twitter.com/PurseIO
     logo: purse.png
   -
     name: Square
-    twitter: Square
+    website: https://twitter.com/Square
     logo: square.png
   -
     name: Xapo
-    twitter: xapo
+    website: https://twitter.com/xapo
     logo: xapo.png

--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -24,7 +24,7 @@ sponsors:
 members:
   -
     name: Alto Financial
-    website: https://twitter.com/AltoFinancial
+    website: https://alto.financial
     logo: alto.svg
   -
     name: Anchorage

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -12,7 +12,7 @@
 	{% unless member.logo contains 'https://' %}{% capture logo %}/img/members/{{member.logo}}{% endcapture %}{% endunless %}
 	<li>
 		<div class="member">
-		<a href="https://twitter.com/{{ member.twitter }}"><img src="{{ logo }}" width="150" alt="{{ member.name }}" title="{{ member.name }}"></a>
+		<a href="{{ member.website }}"><img src="{{ logo }}" width="150" alt="{{ member.name }}" title="{{ member.name }}"></a>
 		</div>
 	</li>
 	{% endfor %}


### PR DESCRIPTION
Alto Financial have asked (reasonably) for their image to link to their website instead of twitter profile.

Update members include page to take full URL instead of twitter handle.