### PR TITLE
Posts: add missing slugs and test for their prescence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,15 @@ test:
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .
+
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
+
+	## Check that posts declare a slug, see issue #155 and PR #156
+	! git --no-pager grep -L "^slug: " _posts
+	## Check that all slugs are unique
+	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
+
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site

--- a/_posts/en/2019-06-14-exec-briefing.md
+++ b/_posts/en/2019-06-14-exec-briefing.md
@@ -5,6 +5,7 @@ name: 2019-06-14-exec-briefing
 type: posts
 layout: post
 lang: en
+slug: 2019-06-14-exec-briefing
 
 excerpt: >
   Videos and slides from the Bitcoin Optech Executive Briefing

--- a/_posts/en/newsletters/2019-06-19-newsletter.md
+++ b/_posts/en/newsletters/2019-06-19-newsletter.md
@@ -5,6 +5,7 @@ name: 2019-06-19-newsletter
 type: newsletter
 layout: newsletter
 lang: en
+slug: 2019-06-19-newsletter
 ---
 This week's newsletter requests testing on RCs for both LND and
 C-Lightning, describes using ECDH for uncoordinated LN payments,

--- a/_posts/en/newsletters/2019-06-26-newsletter.md
+++ b/_posts/en/newsletters/2019-06-26-newsletter.md
@@ -5,6 +5,7 @@ name: 2019-06-26-newsletter
 type: newsletter
 layout: newsletter
 lang: en
+slug: 2019-06-26-newsletter
 ---
 This week's newsletter announces a pending disclosure of minor
 vulnerabilities for older Bitcoin Core releases, suggests continued


### PR DESCRIPTION
I've forgotten to add slugs to several posts, breaking the fix added in #156.  This PR adds the missing slugs plus a test so that it shouldn't be possible to omit them accidentally again.