### PR TITLE
Indexes: add topics index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ build:
 	bundle exec jekyll build --future --drafts --unpublished
 
 test-before-build:
-	## Check compatibility schema against data files
-	$S ! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
+	## Check schemas against data files
+	! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
+	! find _topics/ -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/topics.yaml {} \; | grep .
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ test-after-build:
 production-test:
 	## Fail if there are any FIXMEs in site source code; add "skip-test" to the same line of source code to skip
 	! git --no-pager grep FIXME | grep -v skip-test | grep .
+
+new-topic:
+	_contrib/new-topic

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: bitcoinoptech
 github_username:  bitcoinops
+repository_name: bitcoinops.github.io
+bold: '**'
 
 # Build settings
 markdown: kramdown
@@ -47,3 +49,12 @@ defaults:
       path: ""  ## all pages
     values:
       image: https://bitcoinops.org/img/logos/optech-notext.png
+  - scope:
+      path: "_topics"
+    values:
+      layout: topic
+      permalink: /en/topics/:title/
+
+collections:
+  topics:
+    output: true

--- a/_contrib/new-topic
+++ b/_contrib/new-topic
@@ -1,0 +1,70 @@
+#!/bin/bash -eu
+
+TOPICS_DIR=_topics
+
+if ! [ -d "$TOPICS_DIR" ]
+then
+  echo "Couldn't find $TOPICS_DIR.  Are you sure you're in the repository root directory?"
+  exit 1
+fi
+
+echo -n "Name of new topic (use title case): "
+read
+topic="$REPLY"
+topic_lowercase=$( echo $topic | tr '[A-Z]' '[a-z]' )
+
+file="$TOPICS_DIR/$( echo $topic_lowercase | sed 's/ /-/g' ).md"
+if [ -f "$file" ]
+then
+  echo "$file already exists, no overwriting"
+  exit 1
+fi
+
+cat <<EOF > $file
+---
+title: ${topic}
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - TODO
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **${topic}** is ...
+
+## Optional.  Use Markdown formatting.  Multiple paragraphs.  Links allowed.
+extended_summary: |
+  This is the summary that never ends.  It goes on and on, my friend.
+  Some people started writing it not knowing what it was but...
+
+  ...they'll be writing it forever, because this is the summary that
+  never ends.  It goes on and on, my friend...
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: Test
+    - title: Example
+      link: https://example.com
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: An example page
+    url: /en/newsletters/2019/05/29/#news
+    date: 2019-05-29
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+---
+EOF
+
+echo $file

--- a/_contrib/schema-validator.rb
+++ b/_contrib/schema-validator.rb
@@ -8,7 +8,10 @@ require 'json-schema'
 
 if ARGV[1].nil?
   puts "Usage: schema-validator.rb <schema-file> <file-to-validate>"
-  puts "Schema file must be YAML; the file to validate may be YAML or TOML"
+  puts "Schema file must be YAML; the file to validate may end with:"
+  puts "  - .yaml (YAML)"
+  puts "  - .md (YAML)"
+  puts "  - .toml (TOML)"
   exit(255)
 end
 
@@ -20,7 +23,7 @@ schema = YAML.load(file)
 file.close()
 
 file = File.open(to_validate, 'r')
-if to_validate.end_with?(".yaml")
+if to_validate.end_with?(".yaml") or to_validate.end_with?(".md")
   document = YAML.load(file)
 elsif to_validate.end_with?(".toml")
   document = TOML.load_file(file)

--- a/_data/schemas/topics.yaml
+++ b/_data/schemas/topics.yaml
@@ -1,0 +1,102 @@
+---
+id: https://bitcoinops.org/schema/topics
+description: The topic object
+type: object
+required:
+  - title
+  - categories
+  - excerpt
+  - optech_mentions
+additionalProperties: false
+properties:
+  title:
+    description: Title of the topic
+    type: string
+
+  categories:
+    description: Which categories should list this topic?
+    type: array
+    additionalItems: false
+    items:
+      type: string
+      enum:  ## Please keep in alphabetical order.
+        - Bandwidth Reduction
+        - Consensus Enforcement
+        - Contract Protocols
+        - Developer Tools
+        - Fee Management
+        - Lightning Network
+        - Lightweight Client Support
+        - Mining
+        - P2P Network Protocol
+        - Privacy Enhancements
+        - Privacy Problems
+        - Scripts and Addresses
+        - Security Enhancements
+        - Security Problems
+        - Soft Forks
+        - Transaction Relay Policy
+        - Wallet Collaboration Tools
+
+  aliases:
+    description: Other names for the topic?
+    type: array
+    items:
+      type: string
+
+  excerpt:
+    description: A short description of the topic
+    type: string
+    minLength: 1   ## Anything not empty
+    maxLength: 500 ## Arbitrary but suggest keeping it short in case we add the excerpts to an index at some point
+    pattern: "^\\*\\*"  ## Start excerpt with topic name in bold
+
+  extended_summary:
+    description: More details about the topic, may include links and multiple paragraphs
+    type: string
+    minLength: 1
+
+  primary_sources: &sources
+    description: Links about the topic the reader may find interesting
+    type: list
+    items:
+      type: object
+      required:
+        - title
+      additionalProperties: false
+      properties:
+        title:
+          description: Title to use for the link
+          type: string
+        link:
+          description: The link URL or reference name
+          type: string
+
+  optech_mentions:
+    description: Mentions of the topic on the Optech website
+    type: list
+    items:
+      type: object
+      required:
+        - title
+        - url
+        - date
+      additionalProperties: false
+      properties:
+        title:
+          description: Title to use for the mention
+          type: string
+          minLength: 1
+          maxLength: 75  ## Arbitrary but important to keep short for topic index
+        url:
+          description: Internal URL for the mention
+          type: string
+          pattern: "^/"
+        date:
+          description: Date of the mention
+          type: any  ## YAML auto converts things that look like dates so we can't validate here
+        feature:
+          description: Whether or not to bold the mention as especially noteworthy
+          type: boolean
+
+  see_also: *sources

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,8 +21,13 @@
 
         <div class="trigger">
             <a class="page-link" href="/about/">About</a>
+            {%- if jekyll.environment == 'future' -%}
+            <a class="page-link" href="/en/publications/">Publications</a>
+            <a class="page-link" href="/en/topics/">Topics</a>
+            {% else %}
             <a class="page-link" href="/en/blog/">Blog</a>
             <a class="page-link" href="/en/newsletters/">Newsletters</a>
+            {%- endif %}
             <a class="page-link" href="/workshops/">Workshops</a>
             <a class="page-link" href="/en/compatibility/">Compatibility</a>
             <a class="page-link" href="https://dashboard.bitcoinops.org/">Dashboard</a>

--- a/_includes/linkers/request-a-topic.md
+++ b/_includes/linkers/request-a-topic.md
@@ -1,0 +1,4 @@
+{% capture gh_base %}https://github.com/{{site.github_username}}/{{site.repository_name}}{% endcapture %}
+{:.center}
+[Request a topic]({{gh_base}}/issues/new?title={{'Topic request: ' | url_escape }}) \|
+[Report an issue]({{gh_base}}/issues/new?body={{'Source file: ' | append: page.path | url_escape }})

--- a/_includes/linkers/topic-pages.md
+++ b/_includes/linkers/topic-pages.md
@@ -1,0 +1,19 @@
+{% capture /dev/null %}
+{% if page.url == "/en/topics/" %}
+  {% assign _index_links = "**Alphabetically**" %}
+{% else %}
+  {% assign _index_links = "[Alphabetically](/en/topics/)" %}
+{% endif %}
+{% if page.url == "/en/topic-dates/" %}
+  {% assign _index_links = _index_links | append: " \| **By date**" %}
+{% else %}
+  {% assign _index_links = _index_links | append: " \| [By date](/en/topic-dates/)" %}
+{% endif %}
+{% if page.url == "/en/topic-categories/" %}
+  {% assign _index_links = _index_links | append: " \| **By category**" %}
+{% else %}
+  {% assign _index_links = _index_links | append: " \| [By category](/en/topic-categories/)" %}
+{% endif %}
+{% endcapture %}
+{:.center}
+{{_index_links}}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,0 +1,113 @@
+---
+layout: post
+---
+{% capture newline %}
+{% endcapture %}
+{% capture /dev/null %}
+  <!-- Get links for previous and next pages -->
+  {% assign topics_list = site.topics | natural_sort: "title" %}
+  {% capture first_link %}[{{topics_list[0].title}}]({{topics_list[0].url}}){% endcapture %}
+  {% capture last_link %}[{{topics_list[-1].title}}]({{topics_list[-1].url}}){% endcapture %}
+  {% for entry in topics_list %}
+    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
+    {% if prev_link %}
+      {% assign next_link = entry_link %}
+      {% break %}
+    {% endif %}
+    {% if entry.url == page.url %}
+      {% assign prev_link = prev_entry | default: last_link %}
+    {% endif %}
+    {% assign prev_entry = entry_link %}
+  {% endfor %}
+
+  <!-- Build natural sentence-style list of aliases for this page's topic -->
+  {% if page.aliases != nil %}
+    {% assign num_aliases = page.aliases | size %}
+    {% capture aliases %}{:.center}{{newline}}*Also covering&nbsp;{% endcapture %}
+    {% if num_aliases > 2 %}
+      {% for alias in page.aliases %}
+        {% if forloop.last %}
+          {% capture aliases %}{{aliases}}, and {{alias}}{% endcapture %}
+        {% elsif forloop.first %}
+          {% capture aliases %}{{aliases}}{{alias}}{% endcapture %}
+        {% else %}
+          {% capture aliases %}{{aliases}}, {{alias}}{% endcapture %}
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      {% capture aliases %}{{aliases}}{{page.aliases | join: ' and '}}{% endcapture %}
+    {% endif %}
+    {% assign aliases = aliases | append: '*' %}
+  {% endif %}
+
+  <!-- Build list of primary sources -->
+  {% for source in page.primary_sources %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture primary_sources %}{{primary_sources}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of internal optech mentions -->
+  {% assign references = '' %}
+  {% assign mentions = page.optech_mentions | sort: "date" | reverse %}
+  {% for mention in mentions %}
+    {% if mention.feature == true %}
+      {% assign bold = site.bold %}
+    {% else %}
+      {% assign bold='' %}
+    {% endif %}
+    {% capture references %}{{references}}{{newline}}- {{bold}}{{mention.date}} [{{mention.title}}]({{mention.url}}){{bold}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of see also entries -->
+  {% for source in page.see_also %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture see_also %}{{see_also}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Variable for use in links -->
+  {% capture gh_base %}https://github.com/{{site.github_username}}/{{site.repository_name}}{% endcapture %}
+{% endcapture %}
+
+<!-- Actual page content -->
+{% capture content %}
+  {% include references.md %}
+  {{aliases}}
+
+  {{page.excerpt}}
+
+  {{page.extended_summary}}{{newline}}{{newline}}
+
+  {%- if page.primary_sources and page.primary_sources != '' -%}
+    ## Primary code and documentation
+
+    {{primary_sources}}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.optech_mentions and page.optech_mentions != '' -%}
+    ## Optech newsletter and website mentions
+
+    {{references}}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.see_also and page.see_also != '' -%}
+    ## See also
+
+    {{see_also}}
+  {% endif %}
+
+  <br>{{newline}}{{newline}}
+<span class="float-left" markdown="1">**Previous Topic:**<br>{{prev_link}}</span>
+<span class="float-right" markdown="1">**Next Topic:**<br>{{next_link | default: first_link }}</span>
+
+  {:.center}
+  [Edit page]({{gh_base}}/edit/master/{{page.path}})<br>
+  [Report Issue]({{gh_base}}/issues/new?body={{'Source file: ' | append: page.path | url_escape }})
+{% endcapture %}{{ content | markdownify }}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,6 +11,12 @@ $compatibility-feature-no: #f8ffc0;
 .center {
     text-align: center;
 }
+.float-right {
+    float: right;
+}
+.float-left {
+    float: left;
+}
 
 .post-meta {
     text-align: center;

--- a/en/publications.md
+++ b/en/publications.md
@@ -1,0 +1,28 @@
+---
+title: Publications
+layout: page
+permalink: /en/publications/
+---
+{:.center}
+Recent publications from our [blog posts][] and [newsletters][].
+
+[blog posts]: /en/blog/
+[newsletters]: /en/newsletters/
+
+<ul class="post-list">
+  {%- for post in site.posts limit:20 -%}
+  <li>
+    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+    <span class="post-meta">{{ post.date | date: date_format }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">
+        {{ post.title | escape }}
+      </a>
+    </h3>
+    {%- if site.show_excerpts -%}
+      {{ post.excerpt }}
+    {%- endif -%}
+  </li>
+  {%- endfor -%}
+</ul>
+

--- a/en/topic-categories.md
+++ b/en/topic-categories.md
@@ -1,0 +1,37 @@
+---
+title: Topics
+permalink: /en/topic-categories/
+layout: page
+---
+{% include linkers/topic-pages.md %}
+
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
+
+{% capture raw_categories %}
+{%- for topic in site.topics -%}
+  {%- if topic.categories == empty -%}
+    {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+  {%- endif -%}
+  {%- for category in topic.categories -%}
+    {{category}}|
+  {%- endfor -%}
+{%- endfor -%}
+{% endcapture %}
+{% assign categories = raw_categories | split: "|" | sort_natural | uniq %}
+
+{% for category in categories %}
+  <h3>{{category}}</h3>
+  <ul>
+  {% for topic in site.topics %}
+    {% if topic.categories contains category %}
+      <li><a href="{{topic.url}}">{{topic.title}}</a></li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+{% endfor %}
+
+</div>
+
+{% include linkers/request-a-topic.md %}

--- a/en/topic-dates.md
+++ b/en/topic-dates.md
@@ -1,0 +1,35 @@
+---
+title: Topics
+permalink: /en/topic-dates/
+layout: page
+---
+{% include linkers/topic-pages.md %}
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
+
+{% capture raw_mentions %}
+{%- for topic in site.topics -%}
+  {%- for mention in topic.optech_mentions -%}
+    {{mention.date}} <a href="{{topic.url}}">{{topic.title}}</a>&#8212;{{mention.title}}&nbsp;<a href="{{mention.url}}">🔗</a>ENDMENTION
+  {%- endfor -%}
+{%- endfor -%}
+{% endcapture %}
+{% assign mentions = raw_mentions | split: 'ENDMENTION' | sort | reverse %}
+
+{% for mention in mentions %}
+  {% assign mention_date = mention | truncate: 10, '' %}
+  {% assign year_month = mention | truncate: 7, '' %}
+  {% if year_month != lastym %}
+    {% if lastym != nil %}</ul>{% endif %}
+    <h3>{{mention_date | date: '%B %Y'}}</h3>
+    <ul>
+  {% endif %}
+<li>{{mention | slice: 11, 99999999 | markdownify | remove: "<p>" | remove: "</p>" | strip }}</li>
+{% assign lastym = year_month %}
+{% endfor %}
+</ul>
+
+</div>
+
+{% include linkers/request-a-topic.md %}

--- a/en/topics.md
+++ b/en/topics.md
@@ -1,0 +1,45 @@
+---
+title: Topics
+permalink: /en/topics/
+layout: page
+---
+{% include linkers/topic-pages.md %}
+
+{:.center}
+Some topics listed multiple times under different names.  Alternative
+names are *italicized.*
+
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
+
+{% comment %}<!-- Build an "ENDTOPIC"-separated string with
+Markdown-style links for each topic or topic alias.  We use
+Markdown-style links, e.g. [Name](URL), instead of HTML-style
+links, e.g. <a href=URL>Name</a>, so that it's easy to sort by name
+rather than URL. -->{% endcomment %}
+{% capture raw_topics_list %}
+{%- for topic in site.topics -%}
+  <!--{{topic.title}}-->[{{topic.title}}]({{topic.url}})ENDTOPIC
+  {%- for alias in topic.aliases -%}
+    <!--{{alias}}-->*[{{alias}}]({{topic.url}})*ENDTOPIC
+  {%- endfor -%}
+{%- endfor -%}
+{% endcapture %}
+
+{% assign topics_list = raw_topics_list | split: 'ENDTOPIC' | sort_natural %}
+{% for entry in topics_list %}
+  {% assign first_character = entry | remove_first: '<!--' | truncate: 1, '' | downcase %}
+  {% if first_character != previous_character %}
+    {% if previous_character != nil %}</ul>{% endif %}
+    <h3 id="{{first_character}}">{{first_character | upcase}}</h3>
+    <ul>
+  {% endif %}
+  <li>{{entry | markdownify | remove: "<p>" | remove: "</p>" | strip }}</li>
+  {% assign previous_character = first_character %}
+{% endfor %}
+</ul>
+
+</div>
+
+{% include linkers/request-a-topic.md %}


### PR DESCRIPTION
This PR adds a page `/en/topics` that provides a hand-curated index to topics we frequently mention in our newsletters and other content.  To allow for incremental deployment of this new feature, similar to what we did with the compatibility matrix, the Topics entry only appears in in the page-top navigation if the site is built with `JEKYLL_ENV=future make preview` (or another make target using the same environment variable).

This PR currently includes 40 topics and some edits to add anchor points for them in the final two commits ("add topics" and "edit content for more anchors").  Those don't need to be reviewed in this PR, they're only attached to make it possible to see what the index pages will look like and to allow exploring the different features of the templates.  When this PR is nearing completion, I'll drop those two commits here and move them to another PR.  (I've confirmed that the site builds and passes tests without those commits.)