### PR TITLE
Plugins: new auto-anchor plugin for to add ids to list items

### DIFF
--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+## Automatically add id tags to list items that are formatted like one
+## of the following:
+# - **<Summary:** Details
+# - *<Summary:* Details
+# - [Summary][]: Details
+# - [Summary](URL): Details
+
+Jekyll::Hooks.register :documents, :pre_render do |post|
+  ## Don't process documents if YAML headers say: "auto_id: false"
+  if post.data["auto_id"] != false
+    post.content.gsub!(/^ *- .*/) do |string|
+      ## List items surrounded in bold
+      title = string.match(/\*\*.*\*\*/).to_s
+      ## List items surrounded in italics
+      title.empty? && title = string.match(/\*.*\*/).to_s
+      ## List items that are hyperlinks
+      title.empty? && title = string.match(/\[.*\][(\[]/).to_s
+
+      if title.empty?
+        ## No match, pass item through unchanged
+        string
+      else
+        ## Remove double-quotes from titles before attempting to slugify
+        title.gsub!('"', '')
+        ## Use Liquid/Jekyll slugify filter to choose our id
+        id_prefix = '- {:#{{ "' + title + '" | slugify }}} '
+        string.sub!(/-/, id_prefix)
+      end
+    end
+  end
+end

--- a/_posts/en/2019-06-14-exec-briefing.md
+++ b/_posts/en/2019-06-14-exec-briefing.md
@@ -11,6 +11,7 @@ excerpt: >
   Videos and slides from the Bitcoin Optech Executive Briefing
   on May 14th, 2019.
 
+auto_id: false
 ---
 {% include references.md %}
 

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -58,7 +58,7 @@ infrastructure projects.
 
     - [Additional technical information][bse 79484] by Andrew Chow (also described below)
 
-    - [CVE-2018-17144][], National Vulnerability Database (NVE) entry
+    - [CVE-2018-17144 entry][cve-2018-17144], National Vulnerability Database (NVE) entry
       being updated by Luke Dashjr
 
     We're aware of several very insightful people currently reflecting

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -204,7 +204,7 @@ the node's bandwidth and memory---problems which developers are still
 ### 2018 summary<br>Notable technical conferences and other events
 
 - [BPASE][bpase], January, Stanford University
-- [Bitcoin Core developers meetup][coredevtech nyc], March, New York
+- [Bitcoin Core developers meetup NYC][coredevtech nyc], March, New York
   City ([transcripts][coredevtech ts])
 - [L2 Summit][], May, Boston
 - [Building on Bitcoin][], July, Lisbon ([transcripts][bob ts])
@@ -212,7 +212,7 @@ the node's bandwidth and memory---problems which developers are still
   [transcripts][edge dev ts])
 - [Scaling Bitcoin Conference][], October, Tokyo. ([videos][scaling
   bitcoin vids], [transcripts][scaling bitcoin ts])
-- [Bitcoin Core developers meetup][coredevtech tokyo], October, Tokyo
+- [Bitcoin Core developers meetup Tokyo][coredevtech tokyo], October, Tokyo
   ([transcripts][coredevtech ts])
 - [Chaincode Lightning Residency][], October, New York City ([videos][ln
   residency vids])

--- a/_posts/en/newsletters/2019-03-05-newsletter.md
+++ b/_posts/en/newsletters/2019-03-05-newsletter.md
@@ -174,7 +174,7 @@ commits in popular Bitcoin infrastructure projects.
   but when multipath payments are implemented, it'll collect all
   payment parts into a single JSON object.
 
-- [C-Lightning #2382][] also allows the `sendpay` RPC to take a `bolt11`
+  The same PR also allows the `sendpay` RPC to take a `bolt11`
   field that will be saved and returned back to the user if they later
   run the `listpay`, `listsendpays`, or `waitsendpay` RPCs.
 

--- a/_posts/en/newsletters/2019-05-21-newsletter.md
+++ b/_posts/en/newsletters/2019-05-21-newsletter.md
@@ -111,7 +111,7 @@ changes to popular Bitcoin infrastructure projects.
       accept data from random peers, so non-net relay doesn't
       necessarily change the trust model.
 
-   - A [panel][mcf future ln] by Will O'Beirne, Lisa Neigut, Alex Bosworth with
+   - A [conversation][mcf future ln] between Will O'Beirne, Lisa Neigut, Alex Bosworth with
      moderation by Leigh Cuen discussing the future of LN, mostly the
      short-term and medium-term conclusion of current development
      efforts surrounding the LN 1.1 specification.  There are no hyped


### PR DESCRIPTION
For #167, @bitschmidty suggested to me that we could automatically generate ids for all list items.  This plugin implements that idea by using the summary text we have for most list items to generate the automatic identifier (slug).  The addition of automatic ids can be disabled on a page-by-page basis (or more broadly using the Jekyll config file with path globs) using a `auto_id: false` page config option.

The html proofer called from the Makefile already errors if we accidentally use the same id twice on the same page (overloading it; most browsers will only go to the first occurrence) and this PR includes a few minor content changes to deal with situations where that occurs.

One way to test this PR is to build the site with and without the plugin and then diff the HTML.  E.g.:

```bash
mv _plugins/auto-anchor.rb /tmp
make
cp -a _site _old_site
mv /tmp/auto-anchor.rb  _plugins/
make
diff -ru _old_site _site | colordiff | less -R
```

That's a rather large diff.  If that's too many changes for reviewers to feel comfortable with, one option is to set `auto_id: false` as a site-wide page default and then enable it page-by-page as we need it or with new posts that are well-reviewed.