### PR TITLE
Add 'make production' to check for unadressed FIXMEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache: bundler
 
 ## Build all possible jekyll pages for use with link checking.
 script:
-    - make all
+    - make production
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all: build test
+production: all production-test
 
 preview:
 	bundle exec jekyll clean
@@ -26,3 +27,9 @@ test:
 
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site
+
+## Tests to run last because they identify problems that may not be fixable during initial commit review.
+## However, these should not be still failing when the site goes to production
+production-test:
+	## Fail if there are any FIXMEs in site source code; add "skip-test" to the same line of source code to skip
+	! git --no-pager grep FIXME | grep -v skip-test | grep .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build test
+all: test-before-build build test-after-build
 production: all production-test
 
 preview:
@@ -9,21 +9,23 @@ build:
 	bundle exec jekyll clean
 	bundle exec jekyll build --future --drafts --unpublished
 
-test:
+test-before-build:
 	## Check compatibility schema against data files
 	# $S ! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
+
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .
-
-	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
-	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
-	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 
 	## Check that posts declare a slug, see issue #155 and PR #156
 	! git --no-pager grep -L "^slug: " _posts
 	## Check that all slugs are unique
 	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
+
+test-after-build:
+	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
+	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
+	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -170,12 +170,12 @@ wait until version 0.18 in about six months from now.*
   document other code comments:
 
     ```c
-    /*~ You'll find FIXMEs like this scattered through the code.
+    /*~ You'll find FIXMEs like this scattered through the code.{% comment %}skip-test{% endcomment %}
      * Sometimes they suggest simple improvements which someone like
      * yourself should go ahead an implement.  Sometimes they're deceptive
      * quagmires which will cause you nothing but grief.  You decide! */
 
-     /* FIXME: We should cache these. */
+     /* FIXME: We should cache these. */{% comment %}skip-test{% endcomment %}
      get_channel_seed(&c->id, c->dbid, &channel_seed);
      derive_funding_key(&channel_seed, &funding_pubkey, &funding_privkey);
     ```

--- a/img/posts/2019-03-merkle-ambiguity.dot
+++ b/img/posts/2019-03-merkle-ambiguity.dot
@@ -1,4 +1,4 @@
-//[version|prev_hash|merkle_root|nBits|nTime|nonce]  FIXME: confirm
+//[version|prev_hash|merkle_root|nBits|nTime|nonce]
 //                         |
 //            0xABCD...ABCD                    0xABCD...ABCD
 //                  |                                 |


### PR DESCRIPTION
This adds an extra makefile target that can be run manually before merging to check for any issues mentioned in the source code that haven't been addressed yet.  I don't know how the Netlify integration works, but if it builds by calling `make` or `make all` and fails to upload the built site if `make` returns false, then changing it to use the new `make production` would prevent it from uploading any changes adding FIXMEs to the site.

A second commit here also re-arranges the existing tests so that source-code tests are run before the site build.  As we've been adding more pages to the site, the build has increased to more than a trivial amount of time.  This allows some tests to fail without having to wait for building.