### PR TITLE
fix typo in compatibility-page.md

### DIFF
--- a/_includes/templates/compatibility-page.md
+++ b/_includes/templates/compatibility-page.md
@@ -351,7 +351,7 @@ segwit transactions to pay less total fee to achieve the same feerate as legacy 
 
 ### Usability
 
-*Click on a thumbnail for a larger image or to the play its video.*
+*Click on a thumbnail for a larger image or to play its video.*
 
 {% for example in tool.segwit.examples %}{% capture /dev/null %}
   {% if example.link %}


### PR DESCRIPTION
reported by @adamjonas: https://github.com/bitcoinops/bitcoinops.github.io/commit/1d8d779a984321ab53733abfa9b39200e6b85171#r34607728