### PR TITLE
Compat: reactivate schema checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,6 @@ end
 group :testing do
   gem 'html-proofer'
   gem 'mdl'
+  gem 'json-schema'
+  gem 'toml'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.1)
@@ -74,6 +76,7 @@ GEM
     nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
+    parslet (1.8.2)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
@@ -88,6 +91,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thread_safe (0.3.6)
+    toml (0.2.0)
+      parslet (~> 1.8.0)
     tomlrb (1.2.8)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
@@ -101,8 +106,10 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll
+  json-schema
   mdl
   minima (~> 2.0)
+  toml
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all: build test
+production: all production-test
 
 preview:
 	bundle exec jekyll clean
@@ -26,3 +27,9 @@ test:
 
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site
+
+## Tests not run by CI because they might by dependent on resources that aren't available yet.
+## However, these should not be still failing when the site goes to production
+production-test:
+	## Fail if there are any FIXMEs in site source code; add "skip-test" to the same line of source code to skip
+	! git --no-pager grep FIXME | grep -v skip-test | grep .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build test
+all: test-before-build build test-after-build
 production: all production-test
 
 preview:
@@ -9,21 +9,23 @@ build:
 	bundle exec jekyll clean
 	bundle exec jekyll build --future --drafts --unpublished
 
-test:
+test-before-build:
 	## Check compatibility schema against data files
 	# $S ! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
+
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .
-
-	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
-	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
-	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 
 	## Check that posts declare a slug, see issue #155 and PR #156
 	! git --no-pager grep -L "^slug: " _posts
 	## Check that all slugs are unique
 	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
+
+test-after-build:
+	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
+	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
+	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 test-before-build:
 	## Check compatibility schema against data files
-	# $S ! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
+	$S ! find _data/compatibility -type f -exec bundle exec _contrib/schema-validator.rb _data/schemas/compatibility.yaml {} \; | grep .
 
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -170,12 +170,12 @@ wait until version 0.18 in about six months from now.*
   document other code comments:
 
     ```c
-    /*~ You'll find FIXMEs like this scattered through the code.
+    /*~ You'll find FIXMEs like this scattered through the code.{% comment %}skip-test{% endcomment %}
      * Sometimes they suggest simple improvements which someone like
      * yourself should go ahead an implement.  Sometimes they're deceptive
      * quagmires which will cause you nothing but grief.  You decide! */
 
-     /* FIXME: We should cache these. */
+     /* FIXME: We should cache these. */{% comment %}skip-test{% endcomment %}
      get_channel_seed(&c->id, c->dbid, &channel_seed);
      derive_funding_key(&channel_seed, &funding_pubkey, &funding_privkey);
     ```

--- a/img/posts/2019-03-merkle-ambiguity.dot
+++ b/img/posts/2019-03-merkle-ambiguity.dot
@@ -1,4 +1,4 @@
-//[version|prev_hash|merkle_root|nBits|nTime|nonce]  FIXME: confirm
+//[version|prev_hash|merkle_root|nBits|nTime|nonce]
 //                         |
 //            0xABCD...ABCD                    0xABCD...ABCD
 //                  |                                 |


### PR DESCRIPTION
Based on top of #185, ignore first two commits..

This was previously included as part of #168 but it seems to prevent Netlify from successfully building both previews and production deployments of the site so it was disabled in #174.  To debug, it'd be useful to get a copy of the Netlify build log for the preview from @adamjonas 

This runs for me locally and it previously ran successfully on Travis.