### PR TITLE
Workshops: add NYC and SF taproot/schnorr workshops

### DIFF
--- a/workshops.md
+++ b/workshops.md
@@ -9,26 +9,40 @@ together to discuss approaches and challenges in implementing scaling
 technologies. Each workshop will be tailored to the member companies attending
 and the specific scaling challenges that they are facing.
 
-- Topics are discussed in a roundtable format in which every participant has an
-  equal opportunity to engage.
-
-- Each topic has a moderator and notetaker. The moderator is responsible
-  for a brief introduction of a topic and keeping discussion on track and on
-  time.
-
-- We want participants to be comfortable to speak freely. Notes and action
-  items are distributed to participants but not beyond. Participants are
-  free to share discussion details internally at their companies and publicly,
-  but should refrain from attributing any particular statement to a given
-  individual (Chatham House Rules).
-
 If you have any requests or suggestions for future workshop events, please
 [contact us][optech email].
 
+## Workshops #3 & #4 - Schnorr and Taproot Seminars {#taproot-workshop}
+
+- San Francisco, September 24 2019
+- New York, September 27 2019
+
+*Schnorr signatures* and *Taproot* are proposed changes to the Bitcoin
+protocol that promise greatly improved privacy, fungibility, scalability and
+functionality. These seminar format workshops will include a mixture of
+presentations, coding exercises and discussions, and will give engineers at
+member companies an understanding of how these new technologies work and how
+they can be applied to their products and services. They will also give
+engineers an opportunity to take part in the feedback process while these
+technologies are still in the proposal stage.
+
+#### Topics
+
+Optech will present each of the following topics, and then engineers will
+get experience writing code that implements:
+
+- [Schnorr signatures](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki)
+- [MuSig](https://blockstream.com/2019/02/18/en-musig-a-new-multisignature-standard/)
+- [Taproot](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki)
+- [Tapscript](https://github.com/sipa/bips/blob/bip-schnorr/bip-tapscript.mediawiki)
+
 ## Workshop #2 - Paris, November 12-13 2018
 
-Bitcoin Optech held our second workshop in Paris on November 12-13 2018. In
-attendence were 24 engineers from Bitcoin companies and open source projects.
+Bitcoin Optech held our second roundtable workshop in Paris on November 12-13 2018.
+The format was the same as the first workshop in San Francisco.
+
+In attendence were 24 engineers from Bitcoin companies and open source
+projects.
 
 #### Topics
 
@@ -38,14 +52,27 @@ attendence were 24 engineers from Bitcoin companies and open source projects.
 - Lightning wallet integration and applications for exchanges
 - Approaches to coin selection & consolidation
 
-### Thanks
+#### Thanks
 
 Thanks to Ledger for hosting the workshop and helping with organization.
 
 ## Workshop #1 - San Francisco, July 17 2018
 
-Bitcoin Optech held our first workshop in San Francisco on July 17 2018. In
-attendence were 14 engineers from SF Bay Area Bitcoin companies and open
+Bitcoin Optech held our first roundtable workshop in San Francisco on July 17 2018:
+
+- Topics were discussed in a roundtable format in which every participant had an
+  equal opportunity to engage.
+
+- Each topic had a moderator and notetaker. The moderator was responsible for a
+  brief introduction of a topic and keeping discussion on track and on time.
+
+- To make sure that participants were comfortable to speak freely, notes and
+  action items were distributed to participants but not beyond. Participants
+  were free to share discussion details internally at their companies and
+  publicly, but did not attribute any particular statement to a given individual
+  (Chatham House Rules).
+
+In attendence were 14 engineers from SF Bay Area Bitcoin companies and open
 source projects.
 
 #### Topics
@@ -54,7 +81,7 @@ source projects.
 - Fee estimation, RBF, CPFP best practices
 - Optech community and communication
 
-### Thanks
+#### Thanks
 
 Thanks to Square for hosting the workshop and Coinbase for helping with
 organization.


### PR DESCRIPTION
This PR adds both NYC and SF taproot/schnorr workshops to the workshops page.

I have included them as separate workshops even though the topics are the same. That way we can separately detail the attendees as well as thank associated companies for hosting in the respective venues.