### PR TITLE
[ci] specify xenial and install new version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: ruby
 rvm:
   - "2.5.1"
@@ -22,3 +23,8 @@ branches:
   only:
   - master
   - /.*/
+
+# xenial builds fail if you don't update bundler
+before_install:
+  - gem update --system
+  - gem install bundler


### PR DESCRIPTION
Travis build fails if xenial is used because of a bundler/lockfile version mismatch

```
$ bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
Traceback (most recent call last):
	4: from /home/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `<main>'
	3: from /home/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `eval'
	2: from /home/travis/.rvm/gems/ruby-2.5.1/bin/bundle:23:in `<main>'
	1: from /home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
/home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
The command "eval bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle} " failed. Retrying, 2 of 3.
```

netlify uses xenial and we want travis to use the same dist.

Specify that travis should use xenial and update bundler to fix the failure above.