### PR TITLE
CSS: make blue :target highlight fade over 5 seconds

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -179,8 +179,14 @@ div.xoverflow {
   padding:20px
 }
 
+@keyframes highlightfade {
+    from { background: aqua; }
+    to { background: transparent; }
+}
+
 :target {
-  background-color: #daf8fa;
+    animation-name: highlightfade;
+    animation-duration: 7s;
 }
 
 td.compat_yes {


### PR DESCRIPTION
In https://github.com/bitcoinops/bitcoinops.github.io/pull/181#issuecomment-521044085 , @moneyball mentioned that he found the `:target` highlighting a bit confusing.  This maybe makes it more clear that it's just highlighting to help the user identify position by having it fade over time (currently 5 seconds, we could make it longer or shorter).