### PR TITLE
test: Add travis check ensuring PNGs are optimized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ branches:
 before_install:
   - gem update --system
   - gem install bundler
+  - sudo apt install optipng

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ test-before-build:
 	## Check that all slugs are unique
 	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
 
+	## Check that newly added or modifyed PNGs are optimized
+	_contrib/travis-check-png-optimized.sh
+
 test-after-build:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .

--- a/_contrib/travis-check-png-optimized.sh
+++ b/_contrib/travis-check-png-optimized.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+## Finds newly added or modified PNG files in the branch and checks if each file is optimized.
+## If not optimized, it fails with an error code of 1.
+
+## This check might be run on a system where optipng is not installed (e.g. Netlify). If so, the check should not fail.
+if ! which optipng > /dev/null; then
+	echo "Skipping check since optipng is not istalled."
+	exit 0
+fi
+
+## Travis is not aware of the origin/master branch. Needs to be added and fetched first.
+## As per https://github.com/travis-ci/travis-ci/issues/6069#issuecomment-266546552
+if [ "$TRAVIS" = "true" ]; then
+	git remote set-branches --add origin master
+	git fetch
+fi
+
+EXITCODE=0
+CHANGEDFILES=$(git diff --name-only --diff-filter=AM origin/master HEAD)
+
+for FILE in $CHANGEDFILES; do
+	if echo "$FILE" | grep -q ".png$"; then 
+		echo checking "$FILE"
+		OPTIPNGOUTPUT=$(optipng -simulate "$FILE" 2>&1)
+		if ! echo "$OPTIPNGOUTPUT" | grep -q "is already optimized"; then
+			echo "The file $FILE is not optimized. To optimize use 'optipng -o7 $FILE'."
+			EXITCODE=1
+		fi
+	fi
+done
+
+exit $EXITCODE


### PR DESCRIPTION
This adds a check to the `test-before-build` section of the Makefile that tests if a **newly added or changed** PNG is optimized.  <s>The check only runs (i.e. takes time) for PRs on Travis and not locally.</s> Existing PNGs are not checked to keep Travis build time as short as possible.

<s>Thus reviewing this PR could be a bit tricky.</s> To showcase functionality I've created a PR (https://github.com/0xB10C/bitcoinops.github.io/pull/2) on my travis-enabled fork that adds two PNGs. One optimized and one unoptimized. The Travis [build fails](https://travis-ci.com/0xB10C/bitcoinops.github.io/builds/123239599) on the unoptimized PNG. <s> A diligent reviewer could use a similar setup. </s>

```
## Check that newly added or modifyed PNGs are optimized
sh _contrib/travis-check-png-optimized.sh
checking img/optimized.png
checking img/unoptimized.png
The file img/unoptimized.png is not optimized. To optimize use 'optipng -o7 img/unoptimized.png'.
```

edit: This should only be merged after #195 