### PR TITLE
Compat matrix: add links to subsections

### DIFF
--- a/en/compatibility.md
+++ b/en/compatibility.md
@@ -11,6 +11,9 @@ th, td { text-align: center; }
 h1, h2, h3, h4, h5, h6 { text-align: center; }
 </style>
 
+{:.center}
+[Segwit](#segwit-addresses) \| [Replace-by-Fee](#replace-by-fee-rbf)
+
 ## Segwit Addresses
 
 <table class="compatibility">


### PR DESCRIPTION
We previously added links to the segwit and RBF subsections on the individual details page, but now that the number of rows in the matrix is growing, I think we should have links to the subsections on the main matrix page too:

![2019-08-19-08_39_58_738441084](https://user-images.githubusercontent.com/61096/63290436-2204d580-c25d-11e9-80f5-0ad781f70011.png)
