### PR TITLE
Compatibility template changes to standardize rbf/segwit sections

### DIFF
--- a/_includes/templates/compatibility/rbf.md
+++ b/_includes/templates/compatibility/rbf.md
@@ -1,15 +1,15 @@
 ## Replace-by-Fee (RBF) {#rbf}
 
-{% assign tested = tool.rbf.tested. %}
-**Tested**: {% if tested.version != "n/a" %} *version {{tested.version}}* {% endif %} on *{{tested.platforms}}*
-
-**Tested on**: *{{tested.date}}*
-
 **What is Replace-by-Fee (RBF)?** An unconfirmed transaction can be replaced by another version of the
 same transaction that spends the same inputs.  Most full nodes support
 this if the earlier transaction enables [BIP125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) signaling and the
 replacement transaction increases the amount of fee paid.  In terms of
 block chain space used, this is the most efficient form of fee bumping.
+
+{% assign tested = tool.rbf.tested. %}
+**Tested**: {% if tested.version != "n/a" %} *version {{tested.version}}* {% endif %} on *{{tested.platforms}}*
+
+**Tested on**: *{{tested.date}}*
 
 ### Receiving support
 

--- a/_includes/templates/compatibility/segwit.md
+++ b/_includes/templates/compatibility/segwit.md
@@ -1,6 +1,6 @@
 ## Segwit Addresses {#segwit}
 
-Transactions that spend bitcoins secured by segregated witness (segwit) use less
+**What are segwit addresses?** Transactions that spend bitcoins secured by segregated witness (segwit) use less
 block weight than equivalent non-segwit (legacy) transactions, allowing
 segwit transactions to pay less total fee to achieve the same feerate as legacy transactions.
 


### PR DESCRIPTION
@dongcarl [pointed out](https://github.com/bitcoinops/bitcoinops.github.io/pull/179#issuecomment-522720655) inconsistencies between the RBF/segwit sections in the template. This PR helps bring them into the same layout.