### PR TITLE
Plugins: auto-anchor: use smallest match

### DIFF
--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -12,11 +12,11 @@ Jekyll::Hooks.register :documents, :pre_render do |post|
   if post.data["auto_id"] != false
     post.content.gsub!(/^ *- .*/) do |string|
       ## List items surrounded in bold
-      title = string.match(/\*\*.*\*\*/).to_s
+      title = string.match(/\*\*.*?\*\*/).to_s
       ## List items surrounded in italics
-      title.empty? && title = string.match(/\*.*\*/).to_s
+      title.empty? && title = string.match(/\*.*?\*/).to_s
       ## List items that are hyperlinks
-      title.empty? && title = string.match(/\[.*\][(\[]/).to_s
+      title.empty? && title = string.match(/\[.*?\][(\[]/).to_s
 
       if title.empty?
         ## No match, pass item through unchanged


### PR DESCRIPTION
The auto-anchor plugin, when it saw a list item like this:

    - [BOLTs #608][] provides a privacy update to [BOLT4][] that makes it

Was creating links with an anchor of `bolts-608-provides-a-privacy-update-to-bolt4` because it was using a greedy match operator.  This PR changes it to use the minimal-match operator `*?`  so it produces the expected anchor of `bolts-608`.

I tested this by diffing the site output before and after this commit and manually reviewing each change:

```bash
## on this branch
make build
cp -a _site _new_site
git reset --hard HEAD^
make build
diff -ru _site _new_site | colordiff | less -R
```