### PR TITLE
Grammar: remove hyphen from "Partially-Signed"

### DIFF
--- a/_posts/en/newsletters/2018-06-08-newsletter.md
+++ b/_posts/en/newsletters/2018-06-08-newsletter.md
@@ -44,7 +44,7 @@ A new maintenance release of Bitcoin Core is coming soon with a change to relay 
 
 ## News
 
-- **[BIP174][BIP174] discussion and review ongoing:** this BIP creates a standardized format for wallets to reliably share information related to unsigned and partially-signed transactions. This is expected to be implemented in Bitcoin Core and may also be implemented in other wallets, allowing software wallets, hardware wallets, and offline (cold) wallets to easily interact with each other for both single-signature and multi-signature transactions. This BIP has the potential to become an industry standard and so all major wallet providers are encouraged to investigate the specification.
+- **[BIP174][BIP174] discussion and review ongoing:** this BIP creates a standardized format for wallets to reliably share information related to unsigned and partially signed transactions. This is expected to be implemented in Bitcoin Core and may also be implemented in other wallets, allowing software wallets, hardware wallets, and offline (cold) wallets to easily interact with each other for both single-signature and multi-signature transactions. This BIP has the potential to become an industry standard and so all major wallet providers are encouraged to investigate the specification.
 
   The [proposed implementation of BIP174][PR12136] was previously added to Bitcoin Core’s [high priority review queue][high priority] and received significant discussion this week, with at least one bug being found and one protocol developer suggesting that parts of the proposal can be split up.
 

--- a/_posts/en/newsletters/2018-07-03-newsletter.md
+++ b/_posts/en/newsletters/2018-07-03-newsletter.md
@@ -8,7 +8,7 @@ layout: newsletter
 lang: en
 version: 1
 excerpt: >
-  Continued discussion over graftroot safety, BIP174 Partially-Signed
+  Continued discussion over graftroot safety, BIP174 Partially Signed
   Bitcoin Transactions (PSBT) officially marked as proposed, and
   discussion of Dandelion transaction relay.
 

--- a/_posts/en/newsletters/2018-07-10-newsletter.md
+++ b/_posts/en/newsletters/2018-07-10-newsletter.md
@@ -189,7 +189,7 @@ to pursue later." ([source][pwuille comment])
       address sweeping, e.g. finding funds that you own and bringing
       them into one of your current wallets.
 
-    - [BIP174][] Partially-Signed Bitcoin Transactions (PSBTs) support,
+    - [BIP174][] Partially Signed Bitcoin Transactions (PSBTs) support,
       a protocol for exchanging information about Bitcoin transactions
       between wallets to facilitate better interoperability between
       multisig wallets, hot/cold wallets, coinjoins, and other

--- a/_posts/en/newsletters/2018-07-24-newsletter.md
+++ b/_posts/en/newsletters/2018-07-24-newsletter.md
@@ -9,7 +9,7 @@ lang: en
 version: 1
 ---
 This week's newsletter includes information about a new language to describe
-output scripts, an update on Bitcoin Core's support for partially-signed
+output scripts, an update on Bitcoin Core's support for partially signed
 Bitcoin transactions, and news on several other notable Bitcoin Core merges.
 
 ## Action items
@@ -78,7 +78,7 @@ Bitcoin transactions, and news on several other notable Bitcoin Core merges.
   make the wallet just be a list of these descriptors plus associated
   metadata."
 
-- **BIP174 Partially-Signed Bitcoin Transaction (PSBT) support merged:** this
+- **BIP174 Partially Signed Bitcoin Transaction (PSBT) support merged:** this
   provides a standardized format that multiple wallets can use to
   communicate information about transactions that need to be signed,
   so that hot wallets can get signatures from cold wallets or hardware

--- a/_posts/en/newsletters/2018-08-21-newsletter.md
+++ b/_posts/en/newsletters/2018-08-21-newsletter.md
@@ -135,7 +135,7 @@ mentioned above for easy copy/paste next week. -harding -->{% endcomment %}
   version.
 
 - [Bitcoin Core #13917][] and [Bitcoin Core #13960][] improve the
-  [BIP174][] Partially-Signed Bitcoin Transaction (PBST) handling in
+  [BIP174][] Partially Signed Bitcoin Transaction (PBST) handling in
   ambiguous situations.
 
 - [Bitcoin Core #11526][] makes it much easier to build Bitcoin Core

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -54,7 +54,7 @@ merges in popular Bitcoin infrastructure projects.
 - **[Optech Paris workshop][workshop] November 12-13:** member
   companies should [send us an email][optech email] to reserve spots for
   your engineers.  Planned topics include a comparison of two methods
-  for bumping transaction fees, discussion of partially-signed Bitcoin
+  for bumping transaction fees, discussion of partially signed Bitcoin
   transactions ([BIP174][]), an introduction to output script
   descriptors, suggestions for Lightning Network wallet integration, and
   approaches to efficient coin selection (including output

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -144,7 +144,7 @@ Bitcoin script.
 
 - [Bitcoin Core 0.17][] released in October included optional partial
   spend avoidance, the ability to dynamically create and load wallets,
-  and [BIP174][] partially-signed Bitcoin transaction support for
+  and [BIP174][] partially signed Bitcoin transaction support for
   communication between Bitcoin programs.
 
 </div>

--- a/_posts/en/newsletters/2019-01-29-newsletter.md
+++ b/_posts/en/newsletters/2019-01-29-newsletter.md
@@ -42,7 +42,7 @@ None this week.
       negotiate what protocol features they support
     - Rename the protocol to *payjoin,* as many people aren't quite sure
       what to call it right now
-    - Use [BIP174][] Partially-Signed Bitcoin Transactions (PSBTs) for
+    - Use [BIP174][] Partially Signed Bitcoin Transactions (PSBTs) for
       communicating transaction and signature data between clients and
       servers
     - Specify that transactions should use a short list of best-practice
@@ -96,7 +96,7 @@ from both December and January.*
   one on an offline computer as a cold wallet for storing private keys
   and one on a networked computer for monitoring the wallet balance and
   broadcasting transactions.  But how would you actually use [BIP174][]
-  Partially-Signed Bitcoin Transactions (PSBTs) to spend money using
+  Partially Signed Bitcoin Transactions (PSBTs) to spend money using
   these two wallets?  BIP174 author Andrew Chow explains.
 
 - [Why relay transactions from node to node---why not send them to

--- a/_posts/en/newsletters/2019-03-12-newsletter.md
+++ b/_posts/en/newsletters/2019-03-12-newsletter.md
@@ -177,7 +177,7 @@ infrastructure projects.
     with the ability to provide maximally-useful debugging information
     to random untrusted peers.
 
-- **Extension fields to Partially-Signed Bitcoin Transactions (PSBTs):**
+- **Extension fields to Partially Signed Bitcoin Transactions (PSBTs):**
   Andrew Poelstra [proposed][psbt extension] the addition of several
   fields to PSBTs to help support several new features.  He also
   proposed making one currently-required field optional.  These new

--- a/_posts/en/newsletters/2019-05-07-newsletter.md
+++ b/_posts/en/newsletters/2019-05-07-newsletter.md
@@ -31,7 +31,7 @@ summarizes notable changes in popular Bitcoin infrastructure projects.
   of this newsletter might find especially interesting include,
 
     - *More PSBT tools and refinements:* the previous major release,
-      0.17, introduced support for [BIP174][] Partially-Signed Bitcoin
+      0.17, introduced support for [BIP174][] Partially Signed Bitcoin
       Transactions (PSBTs) designed to help multiple programs or devices
       collaboratively create and sign transactions, such as multisig
       wallets, hardware wallets, and cold wallets.  The 0.18 release

--- a/_posts/en/newsletters/2019-07-10-newsletter.md
+++ b/_posts/en/newsletters/2019-07-10-newsletter.md
@@ -84,7 +84,7 @@ wiki page for changes -->{% endcomment %}
 
 - [Bitcoin Core #15427][] extends the `utxoupdatepsbt` RPC with a `descriptors` parameter
   that takes an [output script descriptor] and uses it to update a
-  [BIP174][] Partially-Signed Bitcoin Transaction (PSBT) with
+  [BIP174][] Partially Signed Bitcoin Transaction (PSBT) with
   information about the scripts (addresses) involved in the transaction.
   This is in addition to the RPC's previous behavior of adding
   information to the PSBT from the node's mempool and UTXO set.  This

--- a/_posts/en/newsletters/2019-07-17-newsletter.md
+++ b/_posts/en/newsletters/2019-07-17-newsletter.md
@@ -84,7 +84,7 @@ wiki page for changes -->{% endcomment %}
   this format.  All LN implementations monitored by Optech currently
   support TLV on at least their development branch.
 
-- [BIPs #784][] updates [BIP174][] Partially-Signed Bitcoin Transactions
+- [BIPs #784][] updates [BIP174][] Partially Signed Bitcoin Transactions
   (PSBTs) to include a [BIP32][] extended pubkey (xpub) field in the
   global section.  This is described in a new part of the BIP entitled
   "Change Detection" that describes how signing wallets can use this new

--- a/_posts/en/newsletters/2019-07-31-newsletter.md
+++ b/_posts/en/newsletters/2019-07-31-newsletter.md
@@ -182,7 +182,7 @@ answers made since our last update.*
 (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 
 - [BIPs #800][] updates [BIP174][] to note that wallets must only sign
-  with the signature hash (sighash) type requested in a Partially-Signed
+  with the signature hash (sighash) type requested in a Partially Signed
   Bitcoin Transaction (PSBT) if the wallet considers that sighash type to
   provide acceptable security.  Most wallets dealing with common
   transaction types should reject anything besides `SIGHASH_ALL`.

--- a/_posts/en/newsletters/2019-08-07-newsletter.md
+++ b/_posts/en/newsletters/2019-08-07-newsletter.md
@@ -27,7 +27,7 @@ developments.
 
 ## News
 
-- **BIP174 extensibility:** the author of the Partially-Signed Bitcoin
+- **BIP174 extensibility:** the author of the Partially Signed Bitcoin
   Transactions (PSBTs) specification, Andrew Chow, [proposed][psbt
   extensions] a few minor changes for general adoption:
 

--- a/_posts/en/newsletters/2019-08-28-newsletter.md
+++ b/_posts/en/newsletters/2019-08-28-newsletter.md
@@ -44,7 +44,7 @@ popular Bitcoin infrastructure projects.
 
   For scripts that need signatures or other data from multiple wallets,
   miniscript can guide the wallet into creating all the witness data it
-  can so that the data can be bundled into a Partially-Signed Bitcoin
+  can so that the data can be bundled into a Partially Signed Bitcoin
   Transaction (PSBT).  Other wallets can create their own PSBTs, all of
   which are given to a PSBT finalizer.  If the finalizer is miniscript
   aware, it can sort the witness data from all the provided PSBTs into a

--- a/_posts/en/newsletters/2019-09-04-newsletter.md
+++ b/_posts/en/newsletters/2019-09-04-newsletter.md
@@ -62,7 +62,7 @@ notes a few changes in popular Bitcoin infrastructure projects.
   the coinjoin.
 
   With information about the inputs and the outputs, Alice creates a
-  [BIP174][] Partially-Signed Bitcoin Transaction (PSBT) containing the
+  [BIP174][] Partially Signed Bitcoin Transaction (PSBT) containing the
   signatures for her UTXO or UTXOs.  She can then upload this PSBT to a
   public server (and she can encrypt it so that only Bob can decrypt it).
   This completes the proposer step in SNICKER.


### PR DESCRIPTION
As discussed here: https://github.com/bitcoinops/bitcoinops.github.io/pull/219#discussion_r320321053