### PR TITLE
Style: make all h1s centered

### DIFF
--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -2,7 +2,6 @@
 layout: default
 --- 
 <link rel="stylesheet" href="/assets/css/main.css">
-<link rel="stylesheet" href="/assets/css/post.css">
 <article class="newsletter">
   <header class="post-header">
     <h1 class="post-title">{{ page.title | escape }}</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,6 @@
 layout: default
 ---
 <link rel="stylesheet" href="/assets/css/main.css">
-<link rel="stylesheet" href="/assets/css/post.css">
 
 <article class="post">
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -20,6 +20,10 @@ hr {
     margin-bottom: 20px;
 }
 
+h1 {
+    text-align: center;
+}
+
 h2 {
     margin-top: 1em;
     // A subhead always starts a new row of content, so clear any

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -1,3 +1,0 @@
-h1 {
-    text-align: center;
-}


### PR DESCRIPTION
Suggested [here](https://github.com/bitcoinops/bitcoinops.github.io/pull/167#discussion_r333611118)

I tested by quickly clicking around a site preview and looking at various page titles to make sure they looked reasonably good.  The only page I didn't really like was About, I think because it's title is so short.  I think it's ok to just live with that slight ugliness in order to get nice, centered titles on all other pages.