### PR TITLE
Fix bullet titles and add anchors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test-before-build:
 	! git --no-pager grep -L "^slug: " _posts
 	## Check that all slugs are unique
 	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
+	## Check for things that should probably all be on one line
+	@ ## Note: double $$ in a makefile produces a single literal $
+	! git --no-pager grep -- '^ *- \*\*[^\*]*$$'
+	! git --no-pager grep -- '^ *- \[[^]]*$$'
 
 	## Check that newly added or modifyed PNGs are optimized
 	_contrib/travis-check-png-optimized.sh

--- a/_includes/specials/bech32/06-stackexchange.md
+++ b/_includes/specials/bech32/06-stackexchange.md
@@ -4,25 +4,24 @@ everything since bech32 was first announced about two years ago.
 
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 
-- [Will a Schnorr soft fork introduce a new address
-  format?]({{bse}}82952)  Although upgrading to bech32 sending support
+- [Will a Schnorr soft fork introduce a new address format?]({{bse}}82952)
+  Although upgrading to bech32 sending support
   should be easy, you probably don't want to repeat that work for
   Bitcoin's next upgrade or the upgrade after that.  Pieter Wuille
   answers this question by explaining how an upgrade to Schnorr-based
   public keys and signatures can still use bech32 addresses.  (Optech
   will be covering this issue in greater detail in a future section.)
 
-- [Is it safe to translate a bech32 P2WPKH address into a legacy P2PKH
-  address?]({{bse}}62207) If you read [Newsletter #38][bech32 easy],
+- [Is it safe to translate a bech32 P2WPKH address into a legacy P2PKH address?]({{bse}}62207)
+  If you read [Newsletter #38][bech32 easy],
   you'll notice that the difference between a P2WPKH and P2PKH address
   for the same underlying public key is only a few characters in a
   scriptPubKey, making it possible to automatically convert one into the
   other.  This answer by Andrew Chow and its accompanying comments
   explains why that's a bad idea that could cause users to lose funds.
 
-- [Why does the bech32 decode function require specifying the address's
-  Human Readable Part (HRP) instead of extracting it
-  automatically?]({{bse}}83454) The HRP is separated from the rest of
+- [Why does the bech32 decode function require specifying the address's Human Readable Part (HRP) instead of extracting it automatically?]({{bse}}83454)
+  The HRP is separated from the rest of
   the address by a `1`, so it seems like the decoder could ignore that
   part all on its own.  Pieter Wuille explains that calling the decoder
   with the expected HRP ensures that you don't accidentally pay bitcoin

--- a/_includes/specials/bech32/17-signmessage.md
+++ b/_includes/specials/bech32/17-signmessage.md
@@ -44,6 +44,7 @@ easily adapted to P2SH and P2WSH scripts used for multisig and other
 advanced encumbrances.  That means message signing today is universally
 limited to users of single-sig addresses.
 
+{:#bip322}
 There is a proposed standard that should allow any address type or
 script to be used to create a signed message, [BIP322][].  The protocol
 should even be forward compatible with future segwit versions, such as

--- a/_posts/en/newsletters/2018-07-31-newsletter.md
+++ b/_posts/en/newsletters/2018-07-31-newsletter.md
@@ -47,8 +47,8 @@ C-lightning projects.
 
 ## News
 
-- **"Improvements in the Bitcoin Scripting Language" by Pieter
-  Wuille:** a talk last week giving a high-level overview of several
+- **"Improvements in the Bitcoin Scripting Language" by Pieter Wuille:**
+  a talk last week giving a high-level overview of several
   possible near-term improvements to Bitcoin.  We highly recommend
   watching the [video][sfdev video], viewing the [slides][sipa slides],
   or reading the [transcript][kanzure transcript] (with references) by
@@ -97,8 +97,8 @@ and answers made there in the past month.*
   Schnorr signature scheme over Bitcoin's current ECDSA signature
   scheme.
 
-- [Why does HD key derivation stop working after a certain index in
-  BIP44 wallets?][bse 76998]: a developer testing his wallet finds that
+- [Why does HD key derivation stop working after a certain index in BIP44 wallets?][bse 76998]:
+  a developer testing his wallet finds that
   a payment sent to low-numbered key indexes works as expected, but
   payments sent to high-numbered indexes never appear in his wallets.
   An answer from Viktor T. reveals why.
@@ -111,8 +111,8 @@ and answers made there in the past month.*
   signature and why you might think you saw a signature that was 74 or
   even 75 bytes.
 
-- [If you can use almost any opcode in P2SH, why can't you use them in
-  scriptPubKeys?][bse 76541]: in this answer, Bitcoin technical writer
+- [If you can use almost any opcode in P2SH, why can't you use them in scriptPubKeys?][bse 76541]:
+  in this answer, Bitcoin technical writer
   David A. Harding explains why early versions of Bitcoin restricted the
   types of transactions that could be sent to "standard transactions"
   and why most of those restrictions are still in place even though

--- a/_posts/en/newsletters/2018-08-14-newsletter.md
+++ b/_posts/en/newsletters/2018-08-14-newsletter.md
@@ -27,8 +27,8 @@ projects.
   confirmations for deposit transactions---as well suggested best
   practices for making disclosures easy.
 
-- **Check software using the P2P protocol `getblocks` or `getheaders`
-  messages:** if you use custom software that requests blocks using
+- **Check software using the P2P protocol `getblocks` or `getheaders` messages:**
+  if you use custom software that requests blocks using
   either of these messages, ensure they don't make their requests with
   more than 101 locators.  All popular open source software has already
   been tested, but if you have internal software that speaks the P2P
@@ -99,8 +99,8 @@ source: [Optech dashboard][periodic txn data]*
     Server](https://github.com/btcpayserver/btcpayserver) is considering
     adding support for P2EP receiving.
 
-- **Bitcoin Core wallet to begin only creating low-R
-  signatures:** the DER format used to encode Bitcoin signatures
+- **Bitcoin Core wallet to begin only creating low-R signatures:**
+  the DER format used to encode Bitcoin signatures
   requires adding an entire extra byte to a signature just to indicate
   when the signature's R value is on the top-half of
   the elliptical curve used for Bitcoin.  The R value is randomly

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -16,8 +16,8 @@ merges in popular Bitcoin infrastructure projects.
 
 ## Action items
 
-- **Upgrade to Bitcoin Core 0.16.3 to fix denial-of-service
-  vulnerability:** a bug introduced in Bitcoin Core 0.14.0 and affecting
+- **Upgrade to Bitcoin Core 0.16.3 to fix denial-of-service vulnerability:**
+  a bug introduced in Bitcoin Core 0.14.0 and affecting
   all subsequent versions through to 0.16.2 will cause Bitcoin Core to
   crash when attempting to validate a block containing a transaction
   that attempts to spend the same input twice.  Such blocks would be

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -99,8 +99,8 @@ answers made since our last update.*
   some potential benefits that might be available if UDP support was
   implemented.
 
-- [How likely are you to get blacklisted by an exchange if you use
-  Wasabi wallet's CoinJoin mixing?][bse 78654] Wasabi Wallet author
+- [How likely are you to get blacklisted by an exchange if you use Wasabi wallet's CoinJoin mixing?][bse 78654]
+  Wasabi Wallet author
   Adam Ficsor explains that nothing stops exchanges from refusing funds
   mixed through Wasabi, but that several features of Wasabi (such as a
   required anonymity set of 100) can help make blocking users bad for

--- a/_posts/en/newsletters/2018-10-16-newsletter.md
+++ b/_posts/en/newsletters/2018-10-16-newsletter.md
@@ -68,8 +68,8 @@ on some of the transcripts for the event in Tokyo last week:
   Bitcoin-using businesses encounter when using Bitcoin Core and other
   open source infrastructure projects.
 
-- **[Using UTXO accumulators to reduce data storage
-  requirements][utreexo]:** Tadge Dryja describes work he's been doing
+- **[Using UTXO accumulators to reduce data storage requirements][utreexo]:**
+  Tadge Dryja describes work he's been doing
   on UTXO accumulators that are similar in function to those described
   in last week's newsletter but which have a different construction
   based on hashes.  He further describes how they could be combined with

--- a/_posts/en/newsletters/2018-10-30-newsletter.md
+++ b/_posts/en/newsletters/2018-10-30-newsletter.md
@@ -103,8 +103,8 @@ answers made since our last update.*
   by over 97% at present, but do they also speed up sync?  Bitcoin Core
   developer Gregory Maxwell answers.
 
-- [Can someone steal from you by closing their Lightning Network payment
-  channel in a certain way?][bse 80399] Several different ways to close
+- [Can someone steal from you by closing their Lightning Network payment channel in a certain way?][bse 80399]
+  Several different ways to close
   a Lightning Network payment channel are described, and C-Lightning
   developer Christian Decker explains how a program following the LN
   protocol will protect your money in each case.

--- a/_posts/en/newsletters/2018-10-30-newsletter.md
+++ b/_posts/en/newsletters/2018-10-30-newsletter.md
@@ -216,6 +216,7 @@ it to write a good description, and I doubt non-LN devs care -->{% endcomment %}
   specification for watchtowers has not been agreed upon by the multiple
   implementations of LN, so LND is only putting this feature out for
   initial testing and is restricting its use to testnet.
+  {:#lnd-1535-1512}
 
 {% include references.md %}
 {% include linkers/issues.md issues="14451,14296,14468,14150,1981,1535,1512" %}

--- a/_posts/en/newsletters/2018-11-13-newsletter.md
+++ b/_posts/en/newsletters/2018-11-13-newsletter.md
@@ -45,8 +45,8 @@ None this week.
       its available payment paths to determine which are the fastest and
       most reliable for sending payments.
 
-- **Opportunity available for providing utility functions outside of
-  Bitcoin Core:** Bitcoin Core's RPC interface currently provides over
+- **Opportunity available for providing utility functions outside of Bitcoin Core:**
+  Bitcoin Core's RPC interface currently provides over
   100 methods and there are often proposals to add even more for utility
   functions that don't require access to the internal state of the node
   or wallet.  During last week's developer IRC [meeting][core dev

--- a/_posts/en/newsletters/2018-11-27-newsletter.md
+++ b/_posts/en/newsletters/2018-11-27-newsletter.md
@@ -76,8 +76,8 @@ few spare moments of time to help answer other people's questions.  In
 this monthly feature, we highlight some of the top voted questions and
 answers made since our last update.*
 
-- [How could you create a fake signature to pretend to be
-  Satoshi?][bse 81115] Gregory Maxwell asks and answers a question about
+- [How could you create a fake signature to pretend to be Satoshi?][bse 81115]
+  Gregory Maxwell asks and answers a question about
   you could create a value that looked like an ECDSA signature corresponding
   to an arbitrary public key---such as one known to belong to Satoshi
   Nakamoto---but without having access to the private key.  Maxwell

--- a/_posts/en/newsletters/2018-12-18-newsletter.md
+++ b/_posts/en/newsletters/2018-12-18-newsletter.md
@@ -58,8 +58,8 @@ in the past week from popular Bitcoin infrastructure projects.
     minisketch] on the Lightning-Dev mailing list about using them for
     sending LN routing table updates.
 
-- **Description about what might be included in a Schnorr/Taproot soft
-  fork:** Bitcoin protocol developer Anthony Towns has [posted][towns
+- **Description about what might be included in a Schnorr/Taproot soft fork:**
+  Bitcoin protocol developer Anthony Towns has [posted][towns
   schnorr taproot] a well-written email describing what he thinks
   ought to be included in a soft fork that adds the Schnorr signature
   scheme plus Taproot-style MAST to Bitcoin.  This is not a formal

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -44,6 +44,7 @@ to single-sig transactions.
 
 </div>
 
+{:#taproot}
 Building on the idea that muSig, or something like it, could become
 possible in Bitcoin, Maxwell further described [Taproot][]---a powerful
 optimization for Merklized Alternative Script Trees[^fn-mast] ([MAST][]).  Just as
@@ -184,6 +185,7 @@ soft fork proposal.
 
 ## May
 
+<div id="dandelion" markdown="1">
 A [draft BIP][BIP156] for the Dandelion protocol was published to
 the Bitcoin-Dev mailing list in May.  Dandelion can privately relay
 transactions so that the IP address of the spender can't be reliably
@@ -199,6 +201,7 @@ they've never seen a transaction they previously helped relay.  This
 makes the nodes vulnerable to denial of service attacks that can waste
 the node's bandwidth and memory---problems which developers are still
 [working on addressing][daftuar dandelion] before adopting this protocol.
+</div>
 
 <div markdown="1" class="callout">
 ### 2018 summary<br>Notable technical conferences and other events
@@ -289,6 +292,7 @@ payment channels for LN, more private atomic swaps across chains, more
 private atomic swaps on the same chain (providing for improved
 coinjoin), and other advances that improve efficiency, privacy, or both.
 
+<div id="p2ep" markdown="1">
 Meanwhile, participants in a privacy roundtable described a method
 called Pay-to-EndPoint ([P2EP][]) that can significantly improve wallet
 resistance to block chain analysis by applying a limited form of
@@ -305,6 +309,8 @@ Bitcoin users, not just the people who use P2EP.
 {% capture today-public %}Inputs:<br>&nbsp;&nbsp;Spender (2 BTC)<br>&nbsp;&nbsp;Spender (2 BTC)<br><br>Outputs:<br>&nbsp;&nbsp;Spender or Receiver (1 BTC)<br>&nbsp;&nbsp;Spender or Receiver (3 BTC){% endcapture %}
 {% capture p2ep-private %}Inputs:<br>&nbsp;&nbsp;Alice (2 BTC)<br>&nbsp;&nbsp;Alice (2 BTC)<br>&nbsp;&nbsp;Bob (3 BTC)<br><br>Outputs:<br>&nbsp;&nbsp;Alice's change (1 BTC)<br>&nbsp;&nbsp;Bob's revenue & change (6 BTC){% endcapture %}
 {% capture p2ep-public %}Inputs:<br>&nbsp;&nbsp;Spender or Receiver (2 BTC)<br>&nbsp;&nbsp;Spender or Receiver (2 BTC)<br>&nbsp;&nbsp;Spender or Receiver (3 BTC)<br><br>Outputs:<br>&nbsp;&nbsp;Spender or Receiver (1 BTC)<br>&nbsp;&nbsp;Spender or Receiver (6 BTC){% endcapture %}
+
+</div>
 
 <div markdown="1" class="xoverflow shrink80">
 
@@ -325,6 +331,7 @@ recommended) using Tor---which can provide other benefits---but enabling
 encryption by default could help protect a larger number of users from
 eavesdropping by their ISPs.
 
+{:#untrackable-auth}
 Separately, Pieter Wuille has been working on a [draft document][untrackable auth]
 since February based on a protocol he, Gregory Maxwell, and others have been developing
 to allow optional authentication on top of encryption.  Similar to
@@ -377,6 +384,7 @@ block chain reorganizations and forks.  Bitcoin Core developers also
 [held meetings][coredevtech tokyo] to give each developer a chance to
 discuss their current initiatives with other developers.
 
+{:#splicing}
 Separately, LN protocol developer Rusty Russell proposed a method for
 [splicing][], which allows users to add or subtract funds from a channel
 without pausing payments in that channel.  This especially helps wallets
@@ -438,6 +446,7 @@ payments.
 
 ## December
 
+{:#libminisketch}
 Pieter Wuille, Gregory Maxwell, and Gleb Naumenko researched how to
 reduce the amount of data used to relay Bitcoin transactions.  Their
 initial result is [libminisketch][], a library that allows one user with

--- a/_posts/en/newsletters/2019-01-29-newsletter.md
+++ b/_posts/en/newsletters/2019-01-29-newsletter.md
@@ -69,8 +69,8 @@ from both December and January.*
   interesting discussions about automating channel selection using the
   autopilot feature of LND and his own plugin for C-Lightning.
 
-- [If I generate 20 million Bitcoin addresses an hour, how long until I
-  find a collision?]({{bse}}83818) A user generating an incredible
+- [If I generate 20 million Bitcoin addresses an hour, how long until I find a collision?]({{bse}}83818)
+  A user generating an incredible
   number of addresses using a computer with 32 cores and 128 GB of
   memory wonders how long until he creates two identical addresses with
   different private keys.  Pieter Wuille's answer and its follow-up comments describe the mathematical
@@ -80,8 +80,8 @@ from both December and January.*
   method would almost certainly find a collision only between the
   poster's own addresses---leaving other users unaffected.
 
-- [What's the hold-up implementing BIP156 Dandelion in Bitcoin
-  Core?]({{bse}}81503) Dandelion is a [proposed method][BIP156] for
+- [What's the hold-up implementing BIP156 Dandelion in Bitcoin Core?]({{bse}}81503)
+  Dandelion is a [proposed method][BIP156] for
   initially relaying newly-created transactions that can make it harder
   to determine the network address of the wallet that created the
   transaction.  This answer from Bitcoin Core developer Suhas Daftuar
@@ -91,23 +91,23 @@ from both December and January.*
   other ideas that could also improve the system (e.g. [BIP151][]
   encryption or [libminisketch][] efficient relay).
 
-- [How to use BIP174 PSBTs with a cold wallet and watching-only
-  wallet?]({{bse}}83070) It's easy to setup two copies of Bitcoin Core,
+- [How to use BIP174 PSBTs with a cold wallet and watching-only wallet?]({{bse}}83070)
+  It's easy to setup two copies of Bitcoin Core,
   one on an offline computer as a cold wallet for storing private keys
   and one on a networked computer for monitoring the wallet balance and
   broadcasting transactions.  But how would you actually use [BIP174][]
   Partially Signed Bitcoin Transactions (PSBTs) to spend money using
   these two wallets?  BIP174 author Andrew Chow explains.
 
-- [Why relay transactions from node to node---why not send them to
-  miners directly?]({{bse}}83054) It seems like the Bitcoin network could
+- [Why relay transactions from node to node---why not send them to miners directly?]({{bse}}83054)
+  It seems like the Bitcoin network could
   use a lot less bandwidth if everyone just sent their transactions to
   miners directly and then nodes only distributed blocks.  Pieter Wuille
   explains why that would be bad for privacy and the health of the
   network, plus why it wouldn't even save that much bandwidth.
 
-- [Why should miners hashing arbitrary nonces inspire trust in
-  transaction security?]({{bse}}83951)  When described as a simple
+- [Why should miners hashing arbitrary nonces inspire trust in transaction security?]({{bse}}83951)
+  When described as a simple
   guessing game, Bitcoin's proof of work doesn't sound compelling, but
   this answer from one of Bitcoin StackExchange's top 30 experts,
   Chytrik, provides a simple analogy that captures the essence of proof

--- a/_posts/en/newsletters/2019-02-12-newsletter.md
+++ b/_posts/en/newsletters/2019-02-12-newsletter.md
@@ -21,8 +21,8 @@ projects.
 
 ## News
 
-- **Tool released for generating and verifying bitcoin ownership
-  proofs:** Blockstream has [released][reserve audit tool] a tool that
+- **Tool released for generating and verifying bitcoin ownership proofs:**
+  Blockstream has [released][reserve audit tool] a tool that
   helps bitcoin custodians, such as exchanges, prove that they control a
   certain number of bitcoins without creating an onchain transaction.
   The tool works by creating an almost-valid transaction that contains

--- a/_posts/en/newsletters/2019-02-26-newsletter.md
+++ b/_posts/en/newsletters/2019-02-26-newsletter.md
@@ -95,8 +95,8 @@ answers made since our last update.*
   payments but still not receive any direct information about your
   spending or current balance via the change addresses.
 
-- [Taproot and scriptless scripts both use Schnorr, but how are they
-  different?]({{bse}}84086) In separate answers, Gregory Maxwell and
+- [Taproot and scriptless scripts both use Schnorr, but how are they different?]({{bse}}84086)
+  In separate answers, Gregory Maxwell and
   Andrew Chow each describe the differences between these two proposed
   uses of Schnorr-based signatures.  Also includes a description of
   adapter signatures, which can be used to enhance the efficiency and

--- a/_posts/en/newsletters/2019-03-05-newsletter.md
+++ b/_posts/en/newsletters/2019-03-05-newsletter.md
@@ -51,8 +51,8 @@ commits in popular Bitcoin infrastructure projects.
     appendix to this newsletter that provides additional background on
     these subjects.
 
-    - **Prevent use of `OP_CODESEPARATOR` and `FindAndDelete()` in
-      legacy transactions:** nobody is known to be using these two
+    - **Prevent use of `OP_CODESEPARATOR` and `FindAndDelete()` in legacy transactions:**
+      nobody is known to be using these two
       features of Bitcoin in legacy (non-segwit) Bitcoin transactions,
       but an attacker can abuse them to significantly increase the
       amount of computational work necessary to verify a non-standard
@@ -281,8 +281,8 @@ More information:
 - [Article about Bitcoin timestamp reliability][lopp timestamp] by
   Jameson Lopp
 
-- [Proposal to use timewarp to eliminate the need for hard
-  forks][Friedenbach proposal] by Mark Friedenbach; see also our summary
+- [Proposal to use timewarp to eliminate the need for hard forks][Friedenbach proposal]
+  by Mark Friedenbach; see also our summary
   in [Newsletter #16][] - the proposed cleanup soft fork eliminates the
   ability to use this controversial idea
 

--- a/_posts/en/newsletters/2019-03-26-newsletter.md
+++ b/_posts/en/newsletters/2019-03-26-newsletter.md
@@ -112,8 +112,8 @@ answers made since our last update.*
   MuSig have the same security as current Bitcoin
   multisig?]({{bse}}85101).
 
-- [How were the parameters for the secp256k1 curve
-  chosen?]({{bse}}85387)  This is the elliptical curve used in Bitcoin.
+- [How were the parameters for the secp256k1 curve chosen?]({{bse}}85387)
+  This is the elliptical curve used in Bitcoin.
   Some curve parameters play an important role in security, so it's
   useful to know whether those parameters were chosen wisely.  Other
   parameters don't matter much for security, but their history might be
@@ -122,8 +122,8 @@ answers made since our last update.*
   questions don't affect security, and why we might never learn any more
   about the origin of certain curve parameters.
 
-- [What addresses should I support when developing a
-  wallet?]({{bse}}84978) A developer asks whether he should support both
+- [What addresses should I support when developing a wallet?]({{bse}}84978)
+  A developer asks whether he should support both
   P2PKH (`1foo...`) addresses and P2SH-wrapped segwit (`3bar...`)
   addresses, or whether it's safe to just provide the P2SH address.
   Andrew Chow answers that just the P2SH address is enough.  Gregory

--- a/_posts/en/newsletters/2019-04-02-newsletter.md
+++ b/_posts/en/newsletters/2019-04-02-newsletter.md
@@ -56,8 +56,8 @@ infrastructure projects.
   she wouldn't know the actual path, so she'd probably end up paying
   more in fees than if she chose the route herself.
 
-- **Bitcoin Core schedules switch to default bech32 receiving
-  addresses:** since [version 0.16.0][0.16.0 segwit], Bitcoin Core's
+- **Bitcoin Core schedules switch to default bech32 receiving addresses:**
+  since [version 0.16.0][0.16.0 segwit], Bitcoin Core's
   built-in wallet has defaulted to generating P2SH-wrapped segwit
   addresses when users want to receive payments.  These addresses are
   backwards compatible with all widely-used software.  As

--- a/_posts/en/newsletters/2019-04-30-newsletter.md
+++ b/_posts/en/newsletters/2019-04-30-newsletter.md
@@ -68,8 +68,8 @@ endcomment %}
   output, depending on the game theory that if an attacker cannot steal
   money, they won’t spend money to attack.
 
-- [How was the dust limit of 546 satoshis was chosen? Why not 550
-  satoshis?]({{bse}}86068) The Bitcoin Core transaction relay policy
+- [How was the dust limit of 546 satoshis was chosen? Why not 550 satoshis?]({{bse}}86068)
+  The Bitcoin Core transaction relay policy
   sets a dust limit of 546 satoshis as the minimum amount for an output,
   which seems a peculiar amount. Raghav Sood describes how 546 is three
   times the minimum cost to create and spend a P2PKH output. A reference
@@ -83,8 +83,8 @@ endcomment %}
   provided to a payer results in a payment preimage reveal that serves
   as proof of payment.
 
-- [How can my private key be revealed if I use the same nonce while
-  generating the signature?]({{bse}}85638) Pieter Wuille provides a
+- [How can my private key be revealed if I use the same nonce while generating the signature?]({{bse}}85638)
+  Pieter Wuille provides a
   thorough answer that, if you’re familiar with the math used in
   public key cryptography, demonstrates how a private
   key is revealed in such circumstances.
@@ -98,8 +98,8 @@ endcomment %}
   expiration dates on invoices to avoid an obligation to deliver goods in the
   future at a previously offered price.
 
-- [Are there still miners or mining pools which refuse to implement
-  SegWit?]({{bse}}86208) Mark Erhardt provides extensive analysis demonstrating
+- [Are there still miners or mining pools which refuse to implement SegWit?]({{bse}}86208)
+  Mark Erhardt provides extensive analysis demonstrating
   that essentially the answer is "no." Only 0.03% non-empty blocks from
   the past year had no SegWit transactions, and the two primary miners of
   those few blocks have demonstrated in 2019 that they’re mining blocks

--- a/_posts/en/newsletters/2019-05-07-newsletter.md
+++ b/_posts/en/newsletters/2019-05-07-newsletter.md
@@ -139,8 +139,8 @@ summarizes notable changes in popular Bitcoin infrastructure projects.
       version after that (expected about a year from now).  The earlier
       date is the current target.
 
-- **Proposal for support of Schnorr signatures and Taproot script
-  commitments:** Pieter Wuille [posted][tap post] to the Bitcoin-Dev
+- **Proposal for support of Schnorr signatures and Taproot script commitments:**
+  Pieter Wuille [posted][tap post] to the Bitcoin-Dev
   mailing list a proposed [BIP for Taproot][taproot] (using Schnorr
   signatures) and a proposed [BIP for Tapscript][tapscript], a small
   variation on Bitcoin's current Script language to be used with Taproot

--- a/_posts/en/newsletters/2019-05-29-newsletter.md
+++ b/_posts/en/newsletters/2019-05-29-newsletter.md
@@ -291,8 +291,8 @@ answers made since our last update.*
 endcomment %}
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 
-- [What are the limitations for amortizing the interactive session setup
-  of MuSig?]({{bse}}87605) Richard Myers is attempting to optimize
+- [What are the limitations for amortizing the interactive session setup of MuSig?]({{bse}}87605)
+  Richard Myers is attempting to optimize
   interactive setup for a low bandwidth system, but user nickler
   emphasizes that nonces must not be reused or private keys could
   be leaked. Nickler goes on to provide suggestions to achieve

--- a/_posts/en/newsletters/2019-06-12-newsletter.md
+++ b/_posts/en/newsletters/2019-06-12-newsletter.md
@@ -38,10 +38,10 @@ changes to popular Bitcoin infrastructure projects.
       addresses, tracking when they've been paid, and finding or
       deriving the particular private keys necessary for spending.
 
-    - June 6th: discussion of the [consensus cleanup soft fork][xs
+    - <span id="cleanup-discussion" markdown="1">June 6th: discussion of the [consensus cleanup soft fork][xs
       cleanup sf] included its interaction with [bip-taproot][], whether
       parts of it should be dropped, and whether anything should be
-      added.  ([More background][bg consensus cleanup])
+      added.  ([More background][bg consensus cleanup])</span>
 
       The group asked what they could do to make the [maintainers'][xs
       maint] work easier.  Among other considerations, the maintainers
@@ -50,6 +50,7 @@ changes to popular Bitcoin infrastructure projects.
       responded to this by granting maintainer status to Ford so that he
       can be even more effective.
 
+      {:#potential-script-changes}
       [Potential script changes][xs script change] were discussed.
       Discussion of the [BIP118][] and [bip-anyprevout][] sighashes
       revolved around output tagging (see [Newsletter #34][]) and
@@ -61,25 +62,29 @@ changes to popular Bitcoin infrastructure projects.
       merkle tree instead of an accumulator and risks related to fast
       quantum computers.  ([More background][bg taproot])
 
+      {:#utreexo}
       A [Q&A session][xs utreexo] about the [Utreexo][] accumulator for the
       UTXO set highlighted some interesting details of this developing
       proposal for minimizing full node storage requirements.
 
-    - June 7th: code for the [assumeutxo][xs assumeutxo] proposal was
+    - <span id="assume-utxo-demo" markdown="1">June 7th: code for the [assumeutxo][xs assumeutxo] proposal was
       demoed and discussed, including how to make the proposal
-      compatible with other ideas. ([More background][bg assumeutxo])
+      compatible with other ideas. ([More background][bg assumeutxo])</span>
 
+      {:#hwi}
       Contributors discussed getting [hardware wallet][xs hwi] support
       via [HWI][] directly integrated into Bitcoin Core.  A particular
       concern was code separation---ensuring that code for specific
       hardware devices is maintained by the manufacturer and not Bitcoin
       Core.  ([More background][bg hwi])
 
+      {:#v2-p2p}
       The [version 2 P2P transport protocol][xs v2 p2p] and the related
       countersign protocol (see [#27][countersign blurb]) were
       discussed.  Several possible enhancements were mentioned during
       the discussion.  ([More background][bg v2 p2p])
 
+      {:#signet}
       A review of the [signet][xs signet] idea for a testnet-like chain
       where all blocks are signed by a trusted party focused on the
       various ways to distribute the signatures.  ([More background][bg

--- a/_posts/en/newsletters/2019-06-26-newsletter.md
+++ b/_posts/en/newsletters/2019-06-26-newsletter.md
@@ -102,8 +102,8 @@ endcomment %}
   considered when restoring from backup or generating addresses outside of the
   wallet.
 
-- [How do bitcoin nodes update the UTXO set when their latest blocks are
-  replaced?]({{bse}}87991) Pieter Wuille describes how "[undo files][]" are
+- [How do bitcoin nodes update the UTXO set when their latest blocks are replaced?]({{bse}}87991)
+  Pieter Wuille describes how "[undo files][]" are
   used to update the UTXO set after a block reorganization.
 
 - [Is there a reason why Bitcoin Core does not implement BIP39?]({{bse}}88237)

--- a/_posts/en/newsletters/2019-07-31-newsletter.md
+++ b/_posts/en/newsletters/2019-07-31-newsletter.md
@@ -163,13 +163,13 @@ answers made since our last update.*
   merkle root negligible, but an increase in the nonce size would require a hard
   fork.
 
-- [What is the difference between bytes and virtual bytes
-  (vbytes)?]({{bse}}89385) Ugam Kamat and Murch note the differences between
+- [What is the difference between bytes and virtual bytes (vbytes)?]({{bse}}89385)
+  Ugam Kamat and Murch note the differences between
   virtual size (vsize, denominated in vbytes) and size (denominated in bytes)
   and go on to explain the block weight limit and segwit discount.
 
-- [To what extent does asymmetric cryptography secure bitcoin
-  transactions?]({{bse}}89262) RedGrittyBrick and Pieter Wuille explain that
+- [To what extent does asymmetric cryptography secure bitcoin transactions?]({{bse}}89262)
+  RedGrittyBrick and Pieter Wuille explain that
   while asymmetric cryptography was not used in Bitcoin to prevent a bug or
   attack, it is the mechanism by which an individual's coins are secured from
   others.

--- a/_posts/en/newsletters/2019-08-28-newsletter.md
+++ b/_posts/en/newsletters/2019-08-28-newsletter.md
@@ -109,16 +109,16 @@ answers made since our last update.*
 endcomment %}
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 
-- [What are the key differences between regtest and the proposed
-  signet?]({{bse}}89640) Pieter Wuille and Andrew Chow explain that while
+- [What are the key differences between regtest and the proposed signet?]({{bse}}89640)
+  Pieter Wuille and Andrew Chow explain that while
   regtest is good for local automated integration tests, signet is more akin to
   testnet in that it allows testing of things like peer finding, propagation,
   and transaction selection. Signet allows for more control over block
   production timing than testnet and more than one signet can exist for testing
   different scenarios.
 
-- [Can hardware wallets actually display the amount of funds leaving your
-  control?]({{bse}}89508) Andrew Chow explains that since a hardware wallet is
+- [Can hardware wallets actually display the amount of funds leaving your control?]({{bse}}89508)
+  Andrew Chow explains that since a hardware wallet is
   not a full node, it needs to get its transaction amount information elsewhere.
   In the case of non-segwit inputs, often the amount is provided to the hardware
   signing device via the host computer or other wallet by sending the previous
@@ -126,8 +126,8 @@ endcomment %}
   input being signed must always be provided because it is a required part of
   the data that is signed and verified.
 
-- [How does one prove that they sent bitcoins to an unspendable
-  wallet?]({{bse}}89554) JBaczuk explains that you can prove coins
+- [How does one prove that they sent bitcoins to an unspendable wallet?]({{bse}}89554)
+  JBaczuk explains that you can prove coins
   unspendable by sending the coins to an OP_RETURN output
   or another script that always returns false, or by sending coins to an
   address derived from a contrived, non-random script hash.


### PR DESCRIPTION
This PR makes the newsletter content pass the tests described [here](https://github.com/bitcoinops/bitcoinops.github.io/pull/232#discussion_r332799560) and then adds those tests to the makefile.  By putting those bullet titles all on one line, they're automatically turned into anchors by a plugin added in a previous PR.

In a final commit, several anchors are manually added.  Content in the not-yet-added topics branches refers to those anchors.