### PR TITLE
Adds simple localization features

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,3 +58,6 @@ defaults:
 collections:
   topics:
     output: true
+
+languages:
+  - ja

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -10,7 +10,8 @@ layout: default
         {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
         {{ page.date | date: date_format }}
       </time>
-
+    </p>
+  </header>
   <div class="post-content">
     {{ content }}
   </div>

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -2,8 +2,25 @@
 layout: default
 --- 
 <link rel="stylesheet" href="/assets/css/main.css">
+
+{% assign baseurl = page.permalink | remove_first: "/" | remove_first: page.lang %}
+
+{% for lang in site.languages %}
+  {% assign localization = "/" | append: lang | append:baseurl %}
+  {% assign locale = site.posts | where:"permalink", localization %}
+  {% assign localizations = localizations | concat: locale %}
+{% endfor %}
+
 <article class="newsletter">
   <header class="post-header">
+    {% if localizations.size > 0 %}
+      <div class="localization">
+        <a href="{{ '/en' | append:baseurl }}">en</a>
+        {% for locale in localizations %}
+          | <a href="{{ locale.url }}">{{locale.lang}}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
     <h1 class="post-title">{{ page.title | escape }}</h1>
     <p class="post-meta">
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -242,3 +242,8 @@ div.compat-usability img
 {
   margin-right: 10px;
 }
+
+div.localization
+{
+  text-align: right;
+}

--- a/en/publications.md
+++ b/en/publications.md
@@ -9,8 +9,10 @@ Recent publications from our [blog posts][] and [newsletters][].
 [blog posts]: /en/blog/
 [newsletters]: /en/newsletters/
 
+{% assign posts_en = site.posts | where:"lang","en" %}
+
 <ul class="post-list">
-  {%- for post in site.posts limit:20 -%}
+  {%- for post in posts_en limit:20 -%}
   <li>
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <span class="post-meta">{{ post.date | date: date_format }}</span>

--- a/feed.xml
+++ b/feed.xml
@@ -33,7 +33,7 @@
     </author>
   {% endif %}
 
-  {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
+  {% assign posts = site.posts | where:"lang","en" | where_exp: "post", "post.draft != true" %}
   {% for post in posts limit: 10 %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,83 @@
+---
+---
+<?xml version="1.0" encoding="utf-8"?>
+{% if page.xsl %}
+  <?xml-stylesheet type="text/xml" href="{{ '/feed.xslt.xml' | absolute_url }}"?>
+{% endif %}
+<feed xmlns="http://www.w3.org/2005/Atom" {% if site.lang %}xml:lang="{{ site.lang }}"{% endif %}>
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" {% if site.lang %}hreflang="{{ site.lang }}" {% endif %}/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ '/' | absolute_url | xml_escape }}</id>
+
+  {% if site.title %}
+    <title type="html">{{ site.title | smartify | xml_escape }}</title>
+  {% elsif site.name %}
+    <title type="html">{{ site.name | smartify | xml_escape }}</title>
+  {% endif %}
+
+  {% if site.description %}
+    <subtitle>{{ site.description | xml_escape }}</subtitle>
+  {% endif %}
+
+  {% if site.author %}
+    <author>
+        <name>{{ site.author.name | default: site.author | xml_escape }}</name>
+      {% if site.author.email %}
+        <email>{{ site.author.email | xml_escape }}</email>
+      {% endif %}
+      {% if site.author.uri %}
+        <uri>{{ site.author.uri | xml_escape }}</uri>
+      {% endif %}
+    </author>
+  {% endif %}
+
+  {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
+  {% for post in posts limit: 10 %}
+    <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
+      <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>
+      <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
+      <published>{{ post.date | date_to_xmlschema }}</published>
+      <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
+      <id>{{ post.id | absolute_url | xml_escape }}</id>
+      <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
+
+      {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
+      {% assign post_author = site.data.authors[post_author] | default: post_author %}
+      {% assign post_author_email = post_author.email | default: nil %}
+      {% assign post_author_uri = post_author.uri | default: nil %}
+      {% assign post_author_name = post_author.name | default: post_author %}
+
+      <author>
+          <name>{{ post_author_name | default: "" | xml_escape }}</name>
+        {% if post_author_email %}
+          <email>{{ post_author_email | xml_escape }}</email>
+        {% endif %}
+        {% if post_author_uri %}
+          <uri>{{ post_author_uri | xml_escape }}</uri>
+        {% endif %}
+      </author>
+
+      {% if post.category %}
+        <category term="{{ post.category | xml_escape }}" />
+      {% endif %}
+
+      {% for tag in post.tags %}
+        <category term="{{ tag | xml_escape }}" />
+      {% endfor %}
+
+      {% if post.excerpt and post.excerpt != empty %}
+        <summary type="html">{{ post.excerpt | strip_html | normalize_whitespace | xml_escape }}</summary>
+      {% endif %}
+
+      {% assign post_image = post.image.path | default: post.image %}
+      {% if post_image %}
+        {% unless post_image contains "://" %}
+          {% assign post_image = post_image | absolute_url %}
+        {% endunless %}
+        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post_image | xml_escape }}" />
+      {% endif %}
+    </entry>
+  {% endfor %}
+</feed>

--- a/index.md
+++ b/index.md
@@ -26,9 +26,11 @@ and the open source community.
 [about]: /about
 [compatibility]: /en/compatibility/
 
+{% assign posts_en = site.posts | where:"lang","en" %}
+
 <h2>Recent newsletters and blog posts</h2>
 <ul class="post-list">
-  {%- for post in site.posts limit:3 -%}
+  {%- for post in posts_en limit:3 -%}
   <li>
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <span class="post-meta">{{ post.date | date: date_format }}</span>

--- a/newsletters.md
+++ b/newsletters.md
@@ -11,9 +11,10 @@ version: 1
 
 {% include newsletter-signup.html %}
 
+{% assign posts_newsletters_en = site.posts | where:"lang","en" | where:"type","newsletter" %}
+
 <ul class="post-list">
-  {%- for post in site.posts -%}
-  {%- if post.type == 'newsletter' -%}
+  {%- for post in posts_newsletters_en -%}
   <li>
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <span class="post-meta">{{ post.date | date: date_format }}</span>
@@ -26,7 +27,6 @@ version: 1
       {{ post.excerpt }}
     {%- endif -%}
   </li>
-  {%- endif -%}
   {%- endfor -%}
 </ul>
 


### PR DESCRIPTION
Changes:

- on individual newsletter pages, show available translations, if they exist
- filters on homepage for only english posts
- filters on newsletter page for english posts
- supports language additions
- small fix to newsletter layout html

Notes:

- translations will be located in _posts/[language-code]/newsletters/
- only handles newsletter types for now
- simple language codes (en, ja) for selecting translations. can consider flags or other visuals as well.

Testing:

- add a '_posts/ja/newslettes/2019-10-23-newsletter-ja.md'
- see example ja newsletter here: https://github.com/cryptogarageinc/bitcoinops.github.io/blob/newsletter-69/_posts/ja/newsletters/2019-10-23-newsletter-ja.md
