### PR TITLE
Adds localization features to blog

### DIFF
--- a/_includes/functions/localization-finder.md
+++ b/_includes/functions/localization-finder.md
@@ -1,0 +1,7 @@
+{% assign baseurl = page.permalink | remove_first: "/" | remove_first: page.lang %}
+
+{% for lang in site.languages %}
+  {% assign localization = "/" | append: lang | append:baseurl %}
+  {% assign locale = site.posts | where:"permalink", localization %}
+  {% assign localizations = localizations | concat: locale %}
+{% endfor %}

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -3,13 +3,7 @@ layout: default
 --- 
 <link rel="stylesheet" href="/assets/css/main.css">
 
-{% assign baseurl = page.permalink | remove_first: "/" | remove_first: page.lang %}
-
-{% for lang in site.languages %}
-  {% assign localization = "/" | append: lang | append:baseurl %}
-  {% assign locale = site.posts | where:"permalink", localization %}
-  {% assign localizations = localizations | concat: locale %}
-{% endfor %}
+{% include functions/localization-finder.md %}
 
 <article class="newsletter">
   <header class="post-header">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,13 +3,7 @@ layout: default
 ---
 <link rel="stylesheet" href="/assets/css/main.css">
 
-{% assign baseurl = page.permalink | remove_first: "/" | remove_first: page.lang %}
-
-{% for lang in site.languages %}
-  {% assign localization = "/" | append: lang | append:baseurl %}
-  {% assign locale = site.posts | where:"permalink", localization %}
-  {% assign localizations = localizations | concat: locale %}
-{% endfor %}
+{% include functions/localization-finder.md %}
 
 <article class="post">
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,9 +3,25 @@ layout: default
 ---
 <link rel="stylesheet" href="/assets/css/main.css">
 
+{% assign baseurl = page.permalink | remove_first: "/" | remove_first: page.lang %}
+
+{% for lang in site.languages %}
+  {% assign localization = "/" | append: lang | append:baseurl %}
+  {% assign locale = site.posts | where:"permalink", localization %}
+  {% assign localizations = localizations | concat: locale %}
+{% endfor %}
+
 <article class="post">
 
   <header class="post-header">
+    {% if localizations.size > 0 %}
+      <div class="localization">
+        <a href="{{ '/en' | append:baseurl }}">en</a>
+        {% for locale in localizations %}
+          | <a href="{{ locale.url }}">{{locale.lang}}</a>
+        {% endfor %}
+      </div>
+    {% endif %}
     <h1 class="post-title">{{ page.title | escape }}</h1>
     <p class="post-meta">
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">

--- a/en/blog/index.md
+++ b/en/blog/index.md
@@ -6,9 +6,10 @@ layout: page
 title: Posts
 ---
 
+{% assign posts_blog_en = site.posts | where:"lang","en" | where:"type","posts" %}
+
 <ul class="post-list">
-  {%- for post in site.posts -%}
-  {%- if post.type == 'posts' -%}
+  {%- for post in posts_blog_en -%}
   <li>
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <span class="post-meta">{{ post.date | date: date_format }}</span>
@@ -21,7 +22,6 @@ title: Posts
       {{ post.excerpt }}
     {%- endif -%}
   </li>
-  {%- endif -%}
   {%- endfor -%}
 </ul>
 


### PR DESCRIPTION
Changes:

- on individual blog pages, show available translations, if they exist
- filters on blog page for english posts only

Notes:

- translations will be located in _posts/[language-code]/ , similar to newsletters
- to test, add a '_posts/ja/2019-10-29-schnorr-taproot-workshop.md' file duplicating '_posts/en/2019-10-29-schnorr-taproot-workshop.md' content but changing lang to 'ja' and setting slug and name to '2019-10-21-schnorr-taproot-workshop-ja' 
- Im not happy with duplication of code on the `_layouts/post.html` template when compared to `_layouts/newsletter.html` @harding let me know if you think there is an improvement here
