### PR TITLE
Topics: combine related entries on date index

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -247,3 +247,7 @@ div.localization
 {
   text-align: right;
 }
+
+.pc125 {
+  font-size: 125%;
+}

--- a/en/topic-dates.md
+++ b/en/topic-dates.md
@@ -11,23 +11,43 @@ produce code blocks -->{% endcomment %}
 {% capture raw_mentions %}
 {%- for topic in site.topics -%}
   {%- for mention in topic.optech_mentions -%}
-    {{mention.date}} <a href="{{topic.url}}">{{topic.title}}</a>&#8212;{{mention.title}}&nbsp;<a href="{{mention.url}}">🔗</a>ENDMENTION
+    {{mention.date}}DIVIDER<a class="pc125" href="{{mention.url}}">🔗</a>DIVIDER{{mention.title}}DIVIDER<a href="{{topic.url}}">{{topic.title}}</a>ENDMENTION
   {%- endfor -%}
 {%- endfor -%}
 {% endcapture %}
 {% assign mentions = raw_mentions | split: 'ENDMENTION' | sort | reverse %}
 
-{% for mention in mentions %}
-  {% assign mention_date = mention | truncate: 10, '' %}
-  {% assign year_month = mention | truncate: 7, '' %}
-  {% if year_month != lastym %}
+{%- for mention in mentions -%}
+  {%- assign mention_part = mention | split: "DIVIDER" -%}
+  {%- assign mention_date = mention_part[0] -%}
+  {%- assign mention_link = mention_part[1] -%}
+  {%- assign mention_title = mention_part[2] -%}
+  {%- assign mention_topic = mention_part[3] -%}
+
+  {%- if mention_link == old_mention_link -%}
+    {%- assign combined_topics = combined_topics | append: ', ' | append: mention_topic -%}
+    {%- capture item -%}<li><p>{{mention_title}}&nbsp;{{mention_link}}<br>{{combined_topics}}</p></li>{%- endcapture -%}
+  {%- else -%}
+    {%- comment -%}<!-- New URL, new item - so output old item and reset topic collector -->{%- endcomment -%}
+    {{item}}
+    {%- assign combined_topics = mention_topic -%}
+    {%- capture item -%}<li><p>{{mention_title}}&nbsp;{{mention_link}}<br>{{mention_topic}}</p></li>{%- endcapture -%}
+  {%- endif -%}
+
+  {%- assign year_month = mention_date | truncate: 7, '' -%}
+  {%- if year_month != lastym -%}
     {% if lastym != nil %}</ul>{% endif %}
     <h3>{{mention_date | date: '%B %Y'}}</h3>
     <ul>
-  {% endif %}
-<li>{{mention | slice: 11, 99999999 | markdownify | remove: "<p>" | remove: "</p>" | strip }}</li>
-{% assign lastym = year_month %}
+  {%- endif -%}
+
+  {% assign old_mention_link = mention_link %}
+  {% assign lastym = year_month %}
 {% endfor %}
+{% comment %}<!-- The loop doesn't display a mention until the next
+mention is seen, so we will always have an undisplayed mention at the
+end of the loop.  Display it now.  Also close our final list -->{% endcomment %}
+{{item}}
 </ul>
 
 </div>


### PR DESCRIPTION
Instead of showing the same entry for each topic it belongs to, e.g.:

    - Tapscript—Bitcoin Optech schnorr/taproot workshop
    - Taproot—Bitcoin Optech schnorr/taproot workshop
    - Schnorr signatures—Bitcoin Optech schnorr/taproot workshop

This PR combines related entries into a single item, e.g.:

    - Bitcoin Optech schnorr/taproot workshop
      Tapscript, Taproot, Schnorr signatures

I think it's already the case that the date index looks a little bit silly with duplicated entries.  As we increase the number of topics, I expect more entries to be part of multiple topics and so duplication will increase.  I think the solution in this PR will help keep the date index concise and non-ridiculous looking.

The solution combines entries that have the same date and the same URL, using the title of the last-seen entry as the title of the combined entries.  I think that's fine---our current descriptions seem to be generic enough that they can apply to each affected topic.  However, if anyone thinks we need the safety of requiring all mentions being combined use the same title, that would be easy to add, e.g. `if (x.title != y.title) abort_build`

The associated topics are printed separated by commas on the line following the entry title.  I tried several formats; this adds a fair amount of whitespace but looked best to me---but I'm happy to take suggestions on alternative formats.

Screenshot of topic index before this change (15 entries for October):

![2019-12-01-02_45_50_498106403](https://user-images.githubusercontent.com/61096/69911133-c4982d00-13e4-11ea-9b06-28b5819d7d2c.png)

Screenshot after this change (9 entries for October but all the same topics linked):

![2019-12-01-02_46_37_651847616](https://user-images.githubusercontent.com/61096/69911136-d974c080-13e4-11ea-9d91-b5a3a597b1d6.png)
