### PR TITLE
Travis Build Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ branches:
 
 # xenial builds fail if you don't update bundler
 before_install:
-  - gem update --system
-  - gem install bundler
+  - yes | gem update --system
   - sudo apt install optipng


### PR DESCRIPTION
- removes bundle install directive
- adds a 'yes |' to gem update, essentially passing 'yes' to [a prompt regarding bundle install version overwriting](https://travis-ci.org/bitcoinops/bitcoinops.github.io/builds/625881136#L245), which was freezing (and thus failing) the build previously

Tests via:

- Travis
- Netlify builds
- Netlify build output looks correct: https://deploy-preview-299--bitcoinops.netlify.com/ 
- `make production` build successfully, locally
- `make preview` runs successfully, locally

closes https://github.com/bitcoinops/bitcoinops.github.io/issues/300