### PR TITLE
news52: fix rpc setwalletflag

### DIFF
--- a/_posts/en/newsletters/2019-06-26-newsletter.md
+++ b/_posts/en/newsletters/2019-06-26-newsletter.md
@@ -123,7 +123,7 @@ endcomment %}
 [libsecp256k1][libsecp256k1 repo], and [Bitcoin Improvement Proposals
 (BIPs)][bips repo].*
 
-- [Bitcoin Core #13756][] adds a `setwalletflags` RPC that can be used
+- [Bitcoin Core #13756][] adds a `setwalletflag` RPC that can be used
   to toggle flags for the wallet, including a new `avoid_reuse` flag
   that (when enabled) will prevent the wallet from spending bitcoins
   received to an address that the wallet has already used for spending.


### PR DESCRIPTION
Git grepping returns no instance of "setwalletflags" in Bitcoin Core.

According to git blame, the `setwalletflag` RPC was added in https://github.com/bitcoin/bitcoin/commit/f904723e0d5883309cb0dd14b826bc45c5e776fb and named as such from the start.