### PR TITLE
[Topics] Change date index layout, add stats, add internal page links

### DIFF
--- a/en/topic-categories.md
+++ b/en/topic-categories.md
@@ -5,10 +5,6 @@ layout: page
 ---
 {% include linkers/topic-pages.md %}
 
-<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
-as HTML rather than Markdown so indentation over 4 characters doesn't
-produce code blocks -->{% endcomment %}
-
 {% capture raw_categories %}
 {%- for topic in site.topics -%}
   {%- if topic.categories == empty -%}
@@ -20,6 +16,17 @@ produce code blocks -->{% endcomment %}
 {%- endfor -%}
 {% endcapture %}
 {% assign categories = raw_categories | split: "|" | sort_natural | uniq %}
+
+<div class="center" markdown="1">
+{{ categories | size }} categories for {{site.topics | size}} unique
+topics, with many topics appearing in multiple categories.
+
+{% for category in categories %} [{{category | replace: ' ', '&nbsp;'}}](#{{category | slugify}})&nbsp;{% unless forloop.last %}\|{% endunless %}{% endfor %}
+</div>
+
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
 
 {% for category in categories %}
   <h3 id="{{category | slugify}}">{{category}}</h3>

--- a/en/topic-dates.md
+++ b/en/topic-dates.md
@@ -4,10 +4,6 @@ permalink: /en/topic-dates/
 layout: page
 ---
 {% include linkers/topic-pages.md %}
-<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
-as HTML rather than Markdown so indentation over 4 characters doesn't
-produce code blocks -->{% endcomment %}
-
 {% capture raw_mentions %}
 {%- for topic in site.topics -%}
   {%- for mention in topic.optech_mentions -%}
@@ -17,6 +13,9 @@ produce code blocks -->{% endcomment %}
 {% endcapture %}
 {% assign mentions = raw_mentions | split: 'ENDMENTION' | sort | reverse %}
 
+{% capture list %}
+{% assign months = 0 %}
+{% assign number_of_unique_mentions = 0 %}
 {%- for mention in mentions -%}
   {%- assign mention_part = mention | split: "DIVIDER" -%}
   {%- assign mention_date = mention_part[0] -%}
@@ -29,6 +28,7 @@ produce code blocks -->{% endcomment %}
     {%- capture item -%}<li><p>{{mention_title}}&nbsp;{{mention_link}}<br>{{combined_topics}}</p></li>{%- endcapture -%}
   {%- else -%}
     {%- comment -%}<!-- New URL, new item - so output old item and reset topic collector -->{%- endcomment -%}
+    {% assign number_of_unique_mentions = number_of_unique_mentions | plus: 1 %}
     {{item}}
     {%- assign combined_topics = mention_topic -%}
     {%- capture item -%}<li><p>{{mention_title}}&nbsp;{{mention_link}}<br>{{mention_topic}}</p></li>{%- endcapture -%}
@@ -36,8 +36,10 @@ produce code blocks -->{% endcomment %}
 
   {%- assign year_month = mention_date | truncate: 7, '' -%}
   {%- if year_month != lastym -%}
+    {% assign months = months | plus: 1 %}
     {% if lastym != nil %}</ul>{% endif %}
-    <h3>{{mention_date | date: '%B %Y'}}</h3>
+    {% capture monthyear %}{{mention_date | date: '%B %Y'}}{% endcapture %}
+    <h3 id="{{monthyear | slugify}}">{{monthyear}}</h3>
     <ul>
   {%- endif -%}
 
@@ -47,9 +49,21 @@ produce code blocks -->{% endcomment %}
 {% comment %}<!-- The loop doesn't display a mention until the next
 mention is seen, so we will always have an undisplayed mention at the
 end of the loop.  Display it now.  Also close our final list -->{% endcomment %}
+{% assign number_of_unique_mentions = number_of_unique_mentions | plus: 1 %}
 {{item}}
 </ul>
+{% endcapture %}
 
+<div class="center" markdown="1">
+{{number_of_unique_mentions}} indexed events in {{months}} months <!-- {{mentions | size}} events including duplicates -->
+
+<!-- TODO: uncomment after January 2020 entries added: [2018](#december-2018), [2019](#december-2019) -->
+</div>
+
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
+{{list}}
 </div>
 
 {% include linkers/request-a-topic.md %}

--- a/en/topics.md
+++ b/en/topics.md
@@ -5,14 +5,6 @@ layout: page
 ---
 {% include linkers/topic-pages.md %}
 
-{:.center}
-Some topics listed multiple times under different names.  Alternative
-names are *italicized.*
-
-<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
-as HTML rather than Markdown so indentation over 4 characters doesn't
-produce code blocks -->{% endcomment %}
-
 {% comment %}<!-- Build an "ENDTOPIC"-separated string with
 Markdown-style links for each topic or topic alias.  We use
 Markdown-style links, e.g. [Name](URL), instead of HTML-style
@@ -28,10 +20,37 @@ rather than URL. -->{% endcomment %}
 {% endcapture %}
 
 {% assign topics_list = raw_topics_list | split: 'ENDTOPIC' | sort_natural %}
+{% assign number_of_topics = site.topics | size %}
+{% assign number_of_entries = topics_list | size %}
+{% assign number_of_aliases = number_of_entries | minus: number_of_topics %}
+
+<div class="center" markdown="1">
+{{number_of_topics}} topics (and
+{{number_of_aliases}} aliases in *italics* for topics with alternative
+names).
+
+{:.center}
+{% assign previous_character = '' %}
 {% for entry in topics_list %}
-  {% assign first_character = entry | remove_first: '<!--' | truncate: 1, '' | downcase %}
+  {%- assign first_character = entry | remove_first: '<!--' | truncate: 1, '' | downcase -%}{%- comment -%}close html comment for syntax hilite -->{%- endcomment -%}
+  {%- if first_character != previous_character -%}
+    {%- if previous_character != nil -%}
+      [{{first_character | upcase}}](#{{first_character}}){{' '}}
+    {%- endif -%}
+  {%- endif -%}
+  {%- assign previous_character = first_character -%}
+{% endfor %}
+</div>
+
+<div>{% comment %}<!-- enclosing in a div forces this to be interpreted
+as HTML rather than Markdown so indentation over 4 characters doesn't
+produce code blocks -->{% endcomment %}
+
+{% assign previous_character = '' %}
+{% for entry in topics_list %}
+  {% assign first_character = entry | remove_first: '<!--' | truncate: 1, '' | downcase %}{%- comment -%}close html comment for syntax hilite -->{%- endcomment %}
   {% if first_character != previous_character %}
-    {% if previous_character != nil %}</ul>{% endif %}
+    {% if previous_character != '' %}</ul>{% endif %}
     <h3 id="{{first_character}}">{{first_character | upcase}}</h3>
     <ul>
   {% endif %}


### PR DESCRIPTION
This PR makes three changes to the topic index pages

## Adds stats

Each page gets a single line subtitle with some basic statistics about that page, e.g.:

> - 44 topics (and 26 aliases in italics for topics with alternative names).
> - 212 indexed events in 18 months 
> - 17 categories for 44 unique topics, with many topics appearing in multiple categories.

## Adds internal page links

The alphabetical and category indexes get a condensed table of contents linking to the various subheads below, e.g.:

![2020-01-14-12_23_33_533985562](https://user-images.githubusercontent.com/61096/72366667-b79b7880-36c8-11ea-8cc6-749501e4a0b1.png)

A table of contents for the date index is currently commented out as it links to December 2019, which won't be added until #318 is merged (and it won't really make sense until the January 2020 topics update is merged, so I'll uncomment it in that PR).

## New layout for the date index

We just changed the layout on this page last month in #283, but looking at the huge number of entries added in #318 made me unsatisfied with it.  This new change groups entries by month (as before), then by topic---with the topics mentioned the most that month being listed first:

![2020-01-14-12_26_21_425609670](https://user-images.githubusercontent.com/61096/72366931-3db7bf00-36c9-11ea-910c-16dd19da040b.png)

A topic with two or more mentions in a month gets sub-bullet points; a topic with only one mention that month gets only one bullet point, which I think is a good balance of whitespace.

I'm not entirely satisfied with this layout either, but it's the best I've been able to think of so far.  Additionally, I note that it has to loop through every topic mention for every month.  Right now, it checks 36 months and 212 events for about 0.01 seconds per iteration (~0.36 seconds total).  If we add 200 events a year for 10 years, that means it'll take ~15 seconds to compile by 2030---assuming neither our software nor our computers speeds up in that time.  That stinks, but there are ways to optimize it (write a plugin in a real programing language) or we can use the old Bitcoin.org [hack](https://github.com/bitcoin-dot-org/bitcoin.org/blob/master/docs/setting-up-your-environment.md#fast-partial-previews-or-builds) of just disabling some things during the previews where we aren't working on them.

---

I can split this PR into several separate PRs if anyone would prefer that.