### PR TITLE
Eliminate duplicate anchors from all pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,15 @@ test-after-build:
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 
+	## Check for duplicate anchors
+	! find _site/ -name '*.html' | while read file ; do \
+	  cat $$file \
+	  | egrep -o "(id|name)=[\"'][^\"']*[\"']" \
+	  | sed -E "s/^(id|name)=//; s/[\"']//g" \
+	  | sort | uniq -d \
+	  | sed "s|.*|Duplicate anchor in $$file: #&|" ; \
+	done | grep .
+
 	## Check for broken links
 	bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site
 

--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -1,7 +1,7 @@
 <!-- Begin MailChimp Signup Form -->
 <link href="/assets/css/mailchimp.css" rel="stylesheet" type="text/css">
 <div id="mc_embed_signup">
-<form action="https://bitcoinops.us18.list-manage.com/subscribe/post?u=70c3f85e5d13ffec674f30af8&amp;id=adc93c9774" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<form action="https://bitcoinops.us18.list-manage.com/subscribe/post?u=70c3f85e5d13ffec674f30af8&amp;id=adc93c9774" method="post" id="main-mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
 	<label for="mce-EMAIL">Subscribe to our newsletter</label>
 	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>

--- a/_posts/en/newsletters/2019-12-28-newsletter.md
+++ b/_posts/en/newsletters/2019-12-28-newsletter.md
@@ -64,32 +64,32 @@ words can express for all that you've done to help Bitcoin.
     - [BIP127 proof of reserves](#bip127)
 - February
     - [Bitcoin Core compatible with HWI](#core-hwi)
-    - [Miniscript](#miniscript)
+    - <a href="#miniscript">Miniscript</a>
 - March
     - [Consensus cleanup soft fork proposal](#cleanup)
-    - [Signet](#signet)
+    - <a href="#signet">Signet</a>
     - [Lightning Loop](#loop)
 - April
-    - [AssumeUTXO](#assumeutxo)
+    - <a href="#assumeutxo">AssumeUTXO</a>
     - [Trampoline payments](#trampoline)
 - May
-    - [Taproot](#taproot)
+    - <a href="#taproot">Taproot</a>
     - [SIGHASH_ANYPREVOUT](#anyprevout)
     - [OP_CHECKTEMPLATEVERIFY](#ctv)
 - June
     - [Erlay and other P2P relay improvements](#erlay-and-other-p2p-improvements)
-    - [Watchtowers](#watchtowers)
+    - <a href="#watchtowers">Watchtowers</a>
 - July
     - [Reproducible builds](#reproducibility)
 - August
     - [Vaults without covenants](#vaults)
 - September
-    - [SNICKER](#snicker)
+    - <a href="#snicker">SNICKER</a>
     - [LN vulnerability](#ln-cve)
 - October
     - [LN anchor outputs](#anchor-outputs)
 - November
-    - [Bech32 mutability](#bech32-mutability)
+    - <a href="#bech32-mutability">Bech32 mutability</a>
     - [Bitcoin Core OpenSSL removal](#openssl)
     - [Bitcoin Core BIP70 removal](#bip70)
 - December
@@ -583,7 +583,7 @@ before seeing deployment on the network.
   to use several different models of hardware wallets for secure key
   storage and signing.
 
-- [Lightning Loop][] released in March (with loop-in support added in
+- <a href="/en/newsletters/2019/03/26/#loop-announced">Lightning Loop</a> released in March (with loop-in support added in
   June) provides a non-custodial service that allows users to add or
   remove funds from their LN channels without closing existing channels
   or opening new channels.

--- a/workshops.md
+++ b/workshops.md
@@ -12,7 +12,7 @@ and the specific scaling challenges that they are facing.
 If you have any requests or suggestions for future workshop events, please
 [contact us][optech email].
 
-## Workshop #5 - Schnorr and Taproot Seminars {#taproot-workshop}
+## Workshop #5 - Schnorr and Taproot Seminars {#uk-taproot-workshop}
 
 Bitcoin Optech will host a third seminar workshop on the Schnorr and Taproot
 soft fork proposals in London on 5th February 2020.


### PR DESCRIPTION
In https://github.com/bitcoinops/bitcoinops.github.io/pull/318#pullrequestreview-343402308 , @bitschmidty noted that several links were linking to the table of contents rather than the actual content.  This occurred because we had multiple elements set to the same anchor, e.g the table of contents anchor was `<a id="miniscript">` and the actual section about miniscript was `<div id="miniscript">`.

In this PR, all duplicate instances of duplicate anchors are removed by renaming all but one of the elements.  Additionally, a test is added to the Makefile to prevent the problem from recurring.