### PR TITLE
Plugins: use shortest match in auto-anchors.rb

### DIFF
--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -11,12 +11,8 @@ Jekyll::Hooks.register :documents, :pre_render do |post|
   ## Don't process documents if YAML headers say: "auto_id: false"
   if post.data["auto_id"] != false
     post.content.gsub!(/^ *- .*/) do |string|
-      ## List items surrounded in bold
-      title = string.match(/\*\*.*?\*\*/).to_s
-      ## List items surrounded in italics
-      title.empty? && title = string.match(/\*.*?\*/).to_s
-      ## List items that are hyperlinks
-      title.empty? && title = string.match(/\[.*?\][(\[]/).to_s
+      ## Find shortest match for **bold**, *italics*, or [markdown][links]
+      title = string.match(/\*\*.*?\*\*|\*.*?\*|\[.*?\][(\[]/).to_s
 
       if title.empty?
         ## No match, pass item through unchanged


### PR DESCRIPTION
Closes #325 

"I think we really want to prefer [using] the first bold string, italics string or link in the list element for the anchor id."  --@jnewbery

Tested by:

1. Running on the otherwise-broken a0a10288208d1925906d62522acd0f154e1b090b (tests passed)
2. Diffing the HTML site output before and after this commit (based on latest master).  This change only introduces three changed anchors, and all of them are good changes IMO.