### PR TITLE
Layout: add breadcrumbs to pages >1 level deep

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ defaults:
       path: ""  ## all pages
     values:
       image: https://bitcoinops.org/img/logos/optech-notext.png
+      breadcrumbs: true
   - scope:
       path: "_topics"
     values:

--- a/_data/localization/es.yml
+++ b/_data/localization/es.yml
@@ -1,0 +1,2 @@
+home: página principal
+newsletters: boletines

--- a/_data/localization/ja.yml
+++ b/_data/localization/ja.yml
@@ -1,2 +1,0 @@
-home: FIXME
-newsletters: FIXME

--- a/_data/localization/ja.yml
+++ b/_data/localization/ja.yml
@@ -1,0 +1,2 @@
+home: FIXME
+newsletters: FIXME

--- a/_includes/linkers/breadcrumbs.md
+++ b/_includes/linkers/breadcrumbs.md
@@ -1,0 +1,15 @@
+{% capture _breadcrumb %}
+{%- assign _paths = include.path | split: '/' -%}
+{%- assign _paths_size = _paths | size -%}
+{%- if page.breadcrumbs == true and _paths_size > 3 -%}
+  {:.center}
+  /&nbsp;[{{site.data.localization[page.lang].home | default: "home"}}](/)&nbsp;/&nbsp;
+  {%- for _path in _paths -%}
+    {%- assign _full_path = _full_path | append: _path | append: "/" -%}
+    {%- comment -%}<!-- skip first two iterations, which are (empty) and "<language_code>" -->{%- endcomment -%}
+    {%- if forloop.index > 2 %}
+      {%- unless forloop.last -%}[{{site.data.localization[page.lang][_path] | default: _path}}]({{_full_path}})&nbsp;/&nbsp;{%- endunless -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}
+{% endcapture %}{{_breadcrumb | markdownify}}

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -15,6 +15,9 @@ layout: default
         {% endfor %}
       </div>
     {% endif %}
+    {% assign year = page.date | date: "%Y" %}
+    {% assign path = "/" | append: page.lang | append: "/newsletters/" | append: year | append: "/" %}
+    {% include linkers/breadcrumbs.md path=path %}
     <h1 class="post-title">{{ page.title | escape }}</h1>
     <p class="post-meta">
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,6 +7,7 @@ layout: default
 
 <article class="post">
 
+  {% include linkers/breadcrumbs.md path=page.url %}
   {% if page.title %}
   <header class="post-header">
     <h1 class="post-title">{{ page.title | escape }}</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,6 +16,7 @@ layout: default
         {% endfor %}
       </div>
     {% endif %}
+    {% include linkers/breadcrumbs.md path=page.url %}
     <h1 class="post-title">{{ page.title | escape }}</h1>
     <p class="post-meta">
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">


### PR DESCRIPTION
- [x] Need translation of `home` (as in homepage) and `newsletters` to Japanese or Spanish to demonstrate how to use the string translation feature

This PR adds breadcrumbs to pages that are more than one level removed from the home page, e.g. "/ home / newsletters /" to a newsletter entry:

![2020-01-29-05_24_00_340400769](https://user-images.githubusercontent.com/61096/73352868-1122ac00-4260-11ea-934b-862c6fdf098d.png)

Features:
- Can be disabled by putting: `breadcrumbs: false` in the page metadata (YAML header)
- Breadcrumbs can be automatically derived from the page URL, e.g. `/en/topics/anchor-outputs/` automatically gets the breadcrumb "/ home / topics /"
    - We can also tweak the breadcrumb if desired, e.g. a newsletter URL is `/en/newsletters/2020/01/22/` but we don't currently have year or month index pages, so instead of creating "/ home / newsletters / 2020 / 01 /", we simply tweak the breadcrumb to create "/ home / newsletters /".  At some later point (maybe issue 100?), I think we probably want to split up our index by year, at which point we can extended the breadcrumb to "/ home / newsletters / 2020 /"
- The text for the breadcrumbs can be translated; that way we can continue using URLs that differ only by their `/<lang>/` part but readers of the localized content will get localized paths.  See the Japanese newsletter pages for an example (initially using "FIXME")

I think these breadcrumbs benefit the site now, but I developed them as part of porting the Scaling Workbook content to the site, where I think they're especially beneficial at helping to make a book's worth of content more navigable.