### PR TITLE
Feed: correct validation errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,11 +20,12 @@ description: >-
   Helping Bitcoin-based businesses integrate scaling technology.
 
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://bitcoinops.org/" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: bitcoinoptech
 github_username:  bitcoinops
 repository_name: bitcoinops.github.io
 bold: '**'
+author: "Bitcoin Optech"  ## Default author name for blog posts
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Closes #350 

Corrects validation errors that turned out to be only because of missing defaults from the configuration file.  This changes the metadata on every page on the site, but besides that and the desired change to the feed.xml file, the only visible change I see is a slight tweak to the page footer (it goes from saying "Bitcoin Optech" to "Bitcoin Operations Technology Group"; I can suppress that change if desired).

Validation results on a test build of this commit: https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fdg0.dtrt.org%2Ffeed.xml

(The remaining warning only applies because the test URL is different from the production URL.)