### PR TITLE
change: link to offical BIPs for BIP340-342

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -47,9 +47,9 @@
 [bip-anyprevout]: https://github.com/ajtowns/bips/blob/bip-anyprevout/bip-anyprevout.mediawiki
 [bip-cleanup]: https://github.com/TheBlueMatt/bips/blob/cleanup-softfork/bip-XXXX.mediawiki
 [bip-coshv]: https://github.com/JeremyRubin/bips/blob/op-checkoutputshashverify/bip-coshv.mediawiki
-[bip-schnorr]: https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
-[bip-taproot]: https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki
-[bip-tapscript]: https://github.com/sipa/bips/blob/bip-schnorr/bip-tapscript.mediawiki
+[bip-schnorr]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+[bip-taproot]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+[bip-tapscript]: https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki
 [bips repo]: https://github.com/bitcoin/bips/
 [Bitcoin Core 0.16.2]: https://bitcoincore.org/en/releases/0.16.2/
 [BitcoinCore.org]: https://bitcoincore.org/

--- a/_topics/en/op_codeseparator.md
+++ b/_topics/en/op_codeseparator.md
@@ -107,8 +107,8 @@ primary_sources:
     - title: BIP143 (No FindAndDelete)
       link: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#No_FindAndDelete
 
-    - title: bip-tapscript (transaction digest)
-      link: https://github.com/sipa/bips/blob/bip-schnorr/bip-tapscript.mediawiki#Transaction_digest
+    - title: BIP341 (transaction digest)
+      link: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#common-signature-message
 
     - title: Consensus cleanup (specification)
       link: https://github.com/TheBlueMatt/bips/blob/cleanup-softfork/bip-XXXX.mediawiki#Specification


### PR DESCRIPTION
fixes https://github.com/bitcoinops/bitcoinops.github.io/issues/347

I left the following untouched as the link to the _transaction digest_ section is [no longer up to date](https://github.com/sipa/bips/commit/c0d2f93f3c3c3dcee2318ea26f946ae17de37865#diff-506cf22853a59a8c57550c1f1d9cedfb). I'll let you to decide how to follow up with this one.
https://github.com/bitcoinops/bitcoinops.github.io/blob/f3f9b7a1bc833cba0f8d31a167d6a86c0abba9ff/_topics/en/op_codeseparator.md#L110-L111
