### PR TITLE
[build] Don't jekyll clean for previews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: test-before-build build test-after-build
 production: all production-test
 
-preview:
+clean:
 	bundle exec jekyll clean
+
+preview:
 	bundle exec jekyll serve --future --drafts --unpublished --incremental
 
 build:


### PR DESCRIPTION
The Makefile for this project was copied from bitcoin.org, where
incremental builds didn't work because of their custom plugins.
Therefore, the build was cleaned for every preview.

We don't have complicated plugins so we can just do an incremental build
for local previews.

Also add a `make clean` target.

This brings preview build times down from ~14s to <1s for me.