### PR TITLE
Newsletters: add 90 (2020-03-25)

### DIFF
--- a/_posts/en/newsletters/2019-12-18-newsletter.md
+++ b/_posts/en/newsletters/2019-12-18-newsletter.md
@@ -207,11 +207,12 @@ endcomment %}
 - [C-Lightning #3309][] adds support for multipath payments as
   [described][mpp deployed] in the *news* section above.
 
-- [LND #3697][] sets the default minimum HTLC value to 0 millisatoshis
+- [LND #3697][] sets the default minimum HTLC value to 1 millisatoshis
   (msat) for new channels, down from a previous default of 1,000 msat.
   The minimum HTLC value can't be changed once a channel is opened, so
   this change allows channels using this setting to accept sub-satoshi
-  payments.
+  payments.  [Edit: a previous version of this paragraph incorrectly
+  claimed the new minimum was 0 msat; the correct value is 1 msat.]
 
 - [LND #3785][] mostly fixes the issue mentioned in [Newsletter
   #74][news74 c-lightning-3264] where C-Lightning and LND used different

--- a/_posts/en/newsletters/2020-03-25-newsletter.md
+++ b/_posts/en/newsletters/2020-03-25-newsletter.md
@@ -40,7 +40,10 @@ FIXME:bitschmidty
 [libsecp256k1][libsecp256k1 repo], [Bitcoin Improvement Proposals
 (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 
-- [Eclair #1339][] Harden requirements on htlc-minimum-msat FIXME:ajonas
+- [Eclair #1339][] prevents users from setting their htlc-minimum
+  amount to 0 milli-satoshis, which would violate [BOLT2][].<!-- "A
+  receiving node [...] receiving an `amount_msat` equal to 0 [...]
+  SHOULD fail the channel." --> The new minimum is 1 milli-satoshi.
 
 - [LND #4051][] tracks up to ten errors per peer, storing them across
   reconnections if necessary.  The latest error message is returned as
@@ -50,4 +53,4 @@ FIXME:bitschmidty
 - [BOLTs #751][] Allow More than one Address of a given type FIXME:dongcarl
 
 {% include references.md %}
-{% include linkers/issues.md issues="1339,4051,751" %}
+{% include linkers/issues.md issues="1339,3697,4051,751" %}

--- a/_posts/en/newsletters/2020-03-25-newsletter.md
+++ b/_posts/en/newsletters/2020-03-25-newsletter.md
@@ -68,7 +68,13 @@ possibility and choose the miniscript resulting in the smallest `scriptWitness` 
   part of the `ListPeers` results, making it easier to diagnose
   problems.
 
-- [BOLTs #751][] Allow More than one Address of a given type FIXME:dongcarl
+- [BOLTs #751][] updates [BOLT7][] to allow nodes to announce multiple
+  IP addresses of a given type (e.g. IPv4, IPv6, or Tor). This ensures
+  that multi-homed nodes can better inform the network of their network
+  connectivity.  Several LN implementations were already announcing or
+  allowing multiple addresses of a given type, so this change brings the
+  BOLT specification in line with what the implementations were already
+  doing.
 
 {% include references.md %}
 {% include linkers/issues.md issues="1339,3697,4051,751" %}

--- a/_posts/en/newsletters/2020-03-25-newsletter.md
+++ b/_posts/en/newsletters/2020-03-25-newsletter.md
@@ -1,0 +1,53 @@
+---
+title: 'Bitcoin Optech Newsletter #90'
+permalink: /en/newsletters/2020/03/25/
+name: 2020-03-25-newsletter
+slug: 2020-03-25-newsletter
+type: newsletter
+layout: newsletter
+lang: en
+---
+This week's newsletter summarizes several questions and answers from the
+Bitcoin StackExchange and describes notable changes to popular Bitcoin
+infrastructure projects.
+
+## Action items
+
+*None this week.*
+
+## News
+
+*No significant news about Bitcoin infrastructure development this week.*
+
+## Selected Q&A from Bitcoin StackExchange
+
+*[Bitcoin StackExchange][bitcoin.se] is one of the first places Optech
+contributors look for answers to their questions---or when we have a
+few spare moments to help curious or confused users.  In
+this monthly feature, we highlight some of the top-voted questions and
+answers posted since our last update.*
+
+{% comment %}<!-- https://bitcoin.stackexchange.com/search?tab=votes&q=created%3a1m..%20is%3aanswer -->{%
+endcomment %}
+{% assign bse = "https://bitcoin.stackexchange.com/a/" %}
+
+FIXME:bitschmidty
+
+## Notable code and documentation changes
+
+*Notable changes this week in [Bitcoin Core][bitcoin core repo],
+[C-Lightning][c-lightning repo], [Eclair][eclair repo], [LND][lnd repo],
+[libsecp256k1][libsecp256k1 repo], [Bitcoin Improvement Proposals
+(BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
+
+- [Eclair #1339][] Harden requirements on htlc-minimum-msat FIXME:ajonas
+
+- [LND #4051][] tracks up to ten errors per peer, storing them across
+  reconnections if necessary.  The latest error message is returned as
+  part of the `ListPeers` results, making it easier to diagnose
+  problems.
+
+- [BOLTs #751][] Allow More than one Address of a given type FIXME:dongcarl
+
+{% include references.md %}
+{% include linkers/issues.md issues="1339,4051,751" %}

--- a/_posts/en/newsletters/2020-03-25-newsletter.md
+++ b/_posts/en/newsletters/2020-03-25-newsletter.md
@@ -31,7 +31,25 @@ answers posted since our last update.*
 endcomment %}
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 
-FIXME:bitschmidty
+- [Why does the banscore default to 100?]({{bse}}93795) User Anonymous
+describes some history behind `banscore`, which protects nodes
+from misbehaving peers. Although some offenses result in a 100
+point increase---and thus the immediate banning of the offending peer under the default
+`banscore` setting---other offenses detailed in
+[`net_processing.cpp`][bitcoin net processing] have different scores.
+
+- [Why is block 620826's timestamp 1 second before block 620825?]({{bse}}93696)
+Andrew Chow and Raghav Sood clarify that a block header's timestamp field is not
+required to have a greater value than previous blocks. The requirements are
+instead that a new block's timestamp must be greater than the median
+timestamp of the past 11 blocks but no later than two hours after the
+present time according to the clock on the computer running the node.
+
+- [Where can I find the miniscript policy language specification?]({{bse}}93764)
+Andrew Chow and Pieter Wuille explain that there is not a specification for how
+the [miniscript][topic miniscript] policy language is compiled to miniscript and
+that both the current C++ and Rust implementations effectively try every
+possibility and choose the miniscript resulting in the smallest `scriptWitness` size.
 
 ## Notable code and documentation changes
 
@@ -54,3 +72,4 @@ FIXME:bitschmidty
 
 {% include references.md %}
 {% include linkers/issues.md issues="1339,3697,4051,751" %}
+[bitcoin net processing]: https://github.com/bitcoin/bitcoin/blob/master/src/net_processing.cpp


### PR DESCRIPTION
- [x] StackExchange section @bitschmidty 
- [x] `[Eclair #1339][]` @adamjonas 
- [x] `[BOLTs #751][]` @dongcarl 

Note, we discussed maybe bringing back the Network Activity section because of last week's moderate backlog; however, some of that was caused by the significant drop in hashrate and thus the slower block production---which will mostly change around the time we go to publish because of a retarget, so I decided not to write the section.