### PR TITLE
Preview: allow setting base URI to https://bitcoinops.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,9 @@ production-test:
 
 new-topic:
 	_contrib/new-topic
+
+email: clean
+	@ echo
+	@ echo "[NOTICE] Latest Newsletter: http://localhost:4000/en/newsletters/$$(ls _posts/en/newsletters/ | tail -1 | tr "-" "/" | sed 's/newsletter.md//')"
+	@ echo
+	$(MAKE) preview JEKYLL_ENV=email

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
+  {% if jekyll.environment == 'email' -%}<base href="https://bitcoinops.org/">{% endif %}
 
   <body>
 

--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -8,8 +8,9 @@
 # - [Summary](URL): Details
 
 Jekyll::Hooks.register :documents, :pre_render do |post|
-  ## Don't process documents if YAML headers say: "auto_id: false"
-  if post.data["auto_id"] != false
+  ## Don't process documents if YAML headers say: "auto_id: false" or
+  ## we're formatting for email
+  unless post.data["auto_id"] == false || ENV['JEKYLL_ENV'] == 'email'
     post.content.gsub!(/^ *- .*/) do |string|
       ## Find shortest match for **bold**, *italics*, or [markdown][links]
       title = string.match(/\*\*.*?\*\*|\*.*?\*|\[.*?\][(\[]/).to_s


### PR DESCRIPTION
Closes #393 

Related to https://github.com/bitcoinops/bitcoinops.github.io/pull/387#pullrequestreview-390772699 and some internal discussion, I think this small change should make it possible to generate a local preview of the site content that's suitable for copy/pasting into MailChimp for sending the newsletter.

## How to use

1. Generate a preview normally, e.g. `make preview`
2. Browse to the page you will want to copy/paste
3. Kill the preview server (e.g. Ctrl-C)
4. Generate a fresh preview using the `JEKYLL_ENV=email` environment variable, e.g. `JEKYLL_ENV=email make clean preview` (note: you **need** clean for this)
5. Reload the page in your browser

All the relative links on the site should've been transformed in your browselr from, e.g., `http://localhost:4000/foo/bar` to `https://bitcoinops.org/foo/bar`.  (Note: in the source code, they'll still be relative links, so this only works for rich text copying.)

The reason the process above has you browse to the page you want before creating the `env=email` preview is that you can't browse from the main index to particular pages after you start the `email` preview (because all relative links now point away from your localhost to bitcoinops.org).

## Notes

Technically, this change is bad HTML.  This setting should be in the `<head>` section, but that's currently sourced from the Ruby gem package that provides our template and so can't be edited without copying the file into our repository.  Since this PR is just a workaround that doesn't affect our actual site content, I think it's ok to be kludgy here.

Looking through our internal process doc, I think this change also address the issue with footnote links (they'll now link to the main site rather than internally).  If not, I can look into turning them off. Besides the change in #387, is there anything else y'all can think of that we can conditionally change to make creating the newsletter easier? 