### PR TITLE
Topics: add new topic for unannounced channels

### DIFF
--- a/_topics/en/unannounced-channels.md
+++ b/_topics/en/unannounced-channels.md
@@ -1,0 +1,84 @@
+---
+title: Unannounced channels
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+  - Private channels
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Lightning Network
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Unannounced channels** are LN channels that are not advertised to
+  the network for use in routing.
+
+## Optional.  Use Markdown formatting.  Multiple paragraphs.  Links allowed.
+extended_summary: |
+  Most unannounced channels are believed to belong to users that simply
+  don't intend to route payments, such as users of mobile clients that
+  aren't always online to route payments.
+
+  An alternative name is **private channels,** but there's contention
+  between experts about whether the channels [improve privacy][privacy
+  in pcns] or [not][unpublished channels delenda est], so it may be
+  preferable to use the universally accepted name "unannounced
+  channels."
+
+  [privacy in pcns]: https://arxiv.org/pdf/1909.02717.pdf "Section 4.1: endpoint uncertainty"
+  [unpublished channels delenda est]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-December/002408.html
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+#primary_sources:
+#    - title: Test
+#    - title: Example
+#      link: https://example.com
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "LND #1944 tweaks `sendtoroute` RPC to allow routing via private channels"
+    url: /en/newsletters/2018/11/13/#lnd-1944
+    date: 2018-11-13
+
+  - title: "C-Lightning #2230 adds a `private` flag to the `listpeers` RPC"
+    url: /en/newsletters/2019/01/15/#c-lightning-2230
+    date: 2019-01-15
+
+  - title: "C-Lightning #2234 adds route hints for private channels to `invoice` RPC"
+    url: /en/newsletters/2019/01/22/#c-lightning-2234
+    date: 2019-01-22
+
+  - title: "Talk about LN topology and lack of public info about unannounced channels"
+    url: /en/newsletters/2019/09/18/#lightning-network-topology
+    date: 2019-09-18
+
+  - title: "C-Lightning #3351 enhances `invoice` RPC for private channels"
+    url: /en/newsletters/2020/01/08/#c-lightning-3351
+    date: 2020-01-08
+
+  - title: "Eclair #1283 allows multipath payments to traverse unannounced channels"
+    url: /en/newsletters/2020/01/22/#eclair-1283
+    date: 2020-01-22
+
+  - title: "Breaking the link between UTXOs and unannounced channels"
+    url: /en/newsletters/2020/01/29/#breaking-the-link-between-utxos-and-unannounced-channels
+    date: 2020-01-29
+
+  - title: "C-Lightning #3600 adds blinded paths to improve unannounced channel privacy"
+    url: /en/newsletters/2020/04/08/#c-lightning-3600
+    date: 2020-04-08
+
+  - title: "C-Lighting #3623 improves unannounced channel privacy when routing payments"
+    url: /en/newsletters/2020/04/22/#c-lightning-3623
+    date: 2020-04-22
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+---


### PR DESCRIPTION
Adds a new topic.  An unresolved issue is what to call this topic: **unannounced channels** or **private channels**.  The name we choose affects the URL and I *really* don't want to break a URL (or even setup a redirect) if we change names later, so let's try to choose a good term now.

## Arguments for "unannounced"

- It's an accurate description of the key attribute of such channels
- It has no particular negative or positive connotations (AFAIK)
- It has use going back to at least [2017](https://lists.linuxfoundation.org/pipermail/lightning-dev/2017-December/000846.html) and a quick search of Lightning-Dev shows it being used by Rusty Russell, Christian Decker, and Bastien Teinturier.  ZmnSCPxj seems to use the related term "unpublished channels".  Those are all significant contributors to LN development and I like to honor contributor terminology choices when they don't get in the way of clear communication

## Arguments for "private"

- It's also an accurate description of the key attribute, although it may give the mistaken impression that private channels are resistant against surveillance (which they may not be, not any more than, say, private property is resistant against surveillance)
- It's the term used in BOLTs 4 and 11
- It seems to be the term used by everyone but the people noted above on the Lightning-Dev mailing per a quick search of the archives via my MUA

---

I originally went with "unannounced" because of [Zmn's argument against such channels](https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-December/002408.html) but @jnewbery [questioned](https://github.com/bitcoinops/bitcoinops.github.io/pull/400#discussion_r424703452) the logic there:

> I don't fully understand z-man's argument. He says that if a channel is unannounced, then the connected party in that channel knows that all payments to/from that channel are ultimately to/from the other party. He then says that all channels should be announced. But in that case, doesn't the connected party still know that all payments to/from the other party are ultimately to/from the other party if there's only one announced channel to that pubkey? To avoid that, the other party needs to have at least two channels open and route payments (otherwise the spy could send probe payments via the victim and see that it never routes and only ever terminates payments).
>
> Z-man's argument is against non-routing nodes rather than against unannounced channels.

I think I still prefer the "unannounced" name because of its lack of association with the word "privacy".  I think it's better to use bland names than give users potentially unreasonable expectations.  However, I don't have a strong opinion about which name we choose as long as it's something we can stick with long term.