### PR TITLE
About: remove incorrect Twitter link for Casares

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -4,7 +4,6 @@
 sponsors:
   -
     name: Wences Casares
-    twitter: wences
     avatar: casares.jpg
     quote: >-
       "It will take a very large ecosystem of trustworthy companies to ensure that Bitcoin succeeds and can be used by the entire world. By helping Bitcoin companies adopt the best technology and spreading knowledge and best practice among Bitcoin engineers, Bitcoin Optech is contributing to the success of the most important leap forward in the democratization of money we've ever seen."


### PR DESCRIPTION
Current link is for https://twitter.com/wences , which isn't the person we want.  I can't find an account for Xapo's Casares, so this PR just drops the link.  I checked that the page renders fine without the link.