### PR TITLE
Tests: require using internal URLs for internal content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test-before-build:
 	@ ## Note: double $$ in a makefile produces a single literal $
 	! git --no-pager grep -- '^ *- \*\*[^*]*$$'
 	! git --no-pager grep -- '^ *- \[[^]]*$$'
+	## Check for unnecessarily fully qualified URLs (breaks local previews and internal link checking)
+	! git --no-pager grep -- '^\[.*]: https://bitcoinops.org' | grep -v skip-test | grep .
+	! git --no-pager grep -- '](https://bitcoinops.org' | grep -v skip-test | grep .
 
 	## Check that newly added or modifyed PNGs are optimized
 	_contrib/travis-check-png-optimized.sh

--- a/_includes/articles/towns-xapo-consolidation.md
+++ b/_includes/articles/towns-xapo-consolidation.md
@@ -15,7 +15,7 @@ last few months of 2017.
 *{{img1_label}},
 source: [Statoshi](https://statoshi.info/dashboard/db/unspent-transaction-output-set?panelId=6&fullscreen&from=1514759562608&to=1532039707168)*
 
-[newsletter 3]: https://bitcoinops.org/en/newsletters/2018/07/10/#dashboard-items
+[newsletter 3]: /en/newsletters/2018/07/10/#dashboard-items
 [Xapo]: https://www.xapo.com/
 
 The idea behind UTXO consolidation is essentially this: when your average

--- a/_includes/specials/bech32/18-support-issues.md
+++ b/_includes/specials/bech32/18-support-issues.md
@@ -36,4 +36,4 @@ sending to bech32 addresses.
 [core bech32 plan]: /en/newsletters/2019/04/02/#news
 ["strange addresses"]: https://github.com/spesmilo/electrum/issues/5382
 ["localbitcoins does not support sending to bech32"]: https://github.com/spesmilo/electrum/issues/5371
-[save money with bech32]: https://bitcoinops.org/en/bech32-sending-support/#fee-savings-with-native-segwit
+[save money with bech32]: /en/bech32-sending-support/#fee-savings-with-native-segwit

--- a/_includes/specials/bech32/21-brd.md
+++ b/_includes/specials/bech32/21-brd.md
@@ -78,6 +78,6 @@ fees are still relatively low.
 [brd pr1]: https://github.com/breadwallet/breadwallet-core/commit/2b17fe44619442c31f8a47c175f84b8992933346
 [brd pr2]: https://github.com/breadwallet/breadwallet-core/commit/fd0abb92b07e41429e1170fb56716965cc7b64ab
 [breadwallet-core]: https://github.com/breadwallet/breadwallet-core/
-[identical spk data]: https://bitcoinops.org/en/bech32-sending-support/#sending-to-a-legacy-address
-[bech32 future]: https://bitcoinops.org/en/bech32-sending-support/#automatic-bech32-support-for-future-soft-forks
+[identical spk data]: /en/bech32-sending-support/#sending-to-a-legacy-address
+[bech32 future]: /en/bech32-sending-support/#automatic-bech32-support-for-future-soft-forks
 [whensegwit]: https://whensegwit.com/

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -74,4 +74,4 @@ contributor and you'd like to be a part of this, please contact us at
 [info@bitcoinops.org](mailto:info@bitcoinops.org) or sign up for our newsletter
 on our [web site][website].
 
-[website]: https://bitcoinops.org
+[website]: /

--- a/_posts/en/2018-09-04-dashboard-announcement.md
+++ b/_posts/en/2018-09-04-dashboard-announcement.md
@@ -16,7 +16,7 @@ excerpt: >
 {:.post-meta}
 *by [Marcin Jachymiak](https://github.com/marcinja)<br>Intern at Bitcoin Optech*
 
-This summer I was an intern for [Bitcoin Optech](https://bitcoinops.org), working on a Bitcoin metrics dashboard. In this post I'll be describing the purpose of the dashboard and how it was implemented.
+This summer I was an intern for [Bitcoin Optech](/), working on a Bitcoin metrics dashboard. In this post I'll be describing the purpose of the dashboard and how it was implemented.
 
 The goal of the Optech dashboard is to show a variety of metrics of how effectively blockspace is being used. Important metrics are those that show activity like:
  - [batching](https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Payment_batching): combining the outputs of what would otherwise be many different transactions into a single transaction

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -77,12 +77,12 @@ scale.
 
 {% include references.md %}
 
-[optech team]: https://bitcoinops.org/about/
-[announcement]: https://bitcoinops.org/en/announcing-bitcoin-optech/
-[workshops]: https://bitcoinops.org/workshops/
-[newsletters]: https://bitcoinops.org/en/newsletters/
+[optech team]: /about/
+[announcement]: /en/announcing-bitcoin-optech/
+[workshops]: /workshops/
+[newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
-[dashboard blog post]: https://bitcoinops.org/en/dashboard-announcement/
+[dashboard blog post]: /en/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md
-[softfork]: https://bitcoinops.org/en/newsletters/2018/12/18/#news
+[softfork]: /en/newsletters/2018/12/18/#news

--- a/_posts/en/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/en/2019-02-11-rbf-in-the-wild.md
@@ -401,15 +401,15 @@ reach out to [mike@bitcoinops.org](mailto:mike@bitcoinops.org).
     by users of second layer protocols.
 
 {% include references.md %}
-[optech team]: https://bitcoinops.org/about/
-[announcement]: https://bitcoinops.org/en/announcing-bitcoin-optech/
-[workshops]: https://bitcoinops.org/workshops/
-[newsletters]: https://bitcoinops.org/en/newsletters/
+[optech team]: /about/
+[announcement]: /en/announcing-bitcoin-optech/
+[workshops]: /workshops/
+[newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
-[dashboard blog post]: https://bitcoinops.org/en/dashboard-announcement/
+[dashboard blog post]: /en/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md
-[softfork]: https://bitcoinops.org/en/newsletters/2018/12/18/#news
+[softfork]: /en/newsletters/2018/12/18/#news
 [lightning cpfp carve-out]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html
 [finney attack]: https://bitcoin.stackexchange.com/questions/4942/what-is-a-finney-attack
 [todd reddit gold]: https://www.coingecko.com/buzz/peter-todd-explains-how-he-double-spent-coinbase

--- a/_posts/en/newsletters/2018-07-03-newsletter.md
+++ b/_posts/en/newsletters/2018-07-03-newsletter.md
@@ -27,7 +27,7 @@ As always, please feel free to contact us if you have feedback or comments on th
 
 A reminder to companies that haven’t yet become an official member yet. We ask that you pay a nominal contribution of $5,000 to help fund our expenses.
 
-[newsletter page]: https://bitcoinops.org/en/newsletters/
+[newsletter page]: /en/newsletters/
 
 ## First Optech workshop!
 
@@ -52,7 +52,7 @@ No new action items, but follow-up related to the following previously-published
 - Upgrade to [Bitcoin Core 0.16.1][], released 15 June 2018.  Upgrade especially recommended for miners.  See [newsletter #1][]
 
 [Bitcoin Core 0.16.1]: https://bitcoincore.org/en/download/
-[newsletter #1]: https://bitcoinops.org/en/newsletters/2018/06/26/
+[newsletter #1]: /en/newsletters/2018/06/26/
 
 ### Dashboard items
 

--- a/_posts/en/newsletters/2018-07-10-newsletter.md
+++ b/_posts/en/newsletters/2018-07-10-newsletter.md
@@ -33,7 +33,7 @@ Lisbon.
   for more details
 
 [alert released]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-July/016189.html
-[newsletter #1]: https://bitcoinops.org/en/newsletters/2018/06/26/
+[newsletter #1]: /en/newsletters/2018/06/26/
 
 ## Dashboard items
 

--- a/_posts/en/newsletters/2019-12-28-newsletter.md
+++ b/_posts/en/newsletters/2019-12-28-newsletter.md
@@ -762,5 +762,5 @@ schedule on January 8th.*
 [weekly newsletters]: /en/newsletters/
 [worst case cpu usage]: /en/newsletters/2019/03/05/#legacy-transaction-verification
 [wuille sbc miniscript]: /en/newsletters/2019/02/05/#miniscript
-[xlation es]: https://bitcoinops.org/es/publications/
-[xlation ja]: https://bitcoinops.org/ja/publications/
+[xlation es]: /es/publications/
+[xlation ja]: /ja/publications/

--- a/_posts/en/newsletters/2020-01-22-newsletter.md
+++ b/_posts/en/newsletters/2020-01-22-newsletter.md
@@ -115,6 +115,6 @@ wallets and services.*
 [whatsat]: https://github.com/joostjager/whatsat
 [news72 sphinx]: /en/newsletters/2019/11/13/#possible-privacy-leak-in-the-ln-onion-format
 [river twitter thread]: https://twitter.com/philipglazman/status/1216849483184476165
-[wasabi rbf notification]: https://bitcoinops.org/en/compatibility/wasabi/#receive-notification
+[wasabi rbf notification]: /en/compatibility/wasabi/#receive-notification
 [wasabi rbf signaling]: https://github.com/zkSNACKs/WalletWasabi/pull/2405
 [news52 #13756]: /en/newsletters/2019/06/26/#bitcoin-core-13756

--- a/_posts/en/newsletters/2020-06-03-newsletter.md
+++ b/_posts/en/newsletters/2020-06-03-newsletter.md
@@ -266,7 +266,7 @@ their work hours to contribute to Optech.
 [eps]: https://github.com/chris-belcher/electrum-personal-server
 [lopp size]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017905.html
 [lopp calc]: https://jlopp.github.io/bitcoin-transaction-size-calculator/
-[optech calc]: https://bitcoinops.org/en/tools/calc-size
+[optech calc]: /en/tools/calc-size/
 [about page]: /about/
 [ivgi bwt]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017906.html
 [bwt api]: https://github.com/shesek/bwt#http-api
@@ -300,4 +300,4 @@ their work hours to contribute to Optech.
 [london vid]: https://www.youtube.com/watch?v=34jMGiCAmQM
 [revault vid]: https://www.youtube.com/watch?v=7CE4aiFxh10
 [common input ownership assumption]: https://en.bitcoin.it/wiki/Common-input-ownership_heuristic
-[news98 bitcoin core 18877]: https://bitcoinops.org/en/newsletters/2020/05/20/#bitcoin-core-18877
+[news98 bitcoin core 18877]: /en/newsletters/2020/05/20/#bitcoin-core-18877

--- a/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
@@ -391,5 +391,5 @@ implementation]を達成しました。ペイメントを複数パートに分�
 [weekly newsletters]: /en/newsletters/
 [worst case cpu usage]: /en/newsletters/2019/03/05/#legacy-transaction-verification
 [wuille sbc miniscript]: /en/newsletters/2019/02/05/#miniscript
-[xlation es]: https://bitcoinops.org/es/publications/
-[xlation ja]: https://bitcoinops.org/ja/publications/
+[xlation es]: /es/publications/
+[xlation ja]: /ja/publications/

--- a/_posts/ja/newsletters/2020-01-22-newsletter-ja.md
+++ b/_posts/ja/newsletters/2020-01-22-newsletter-ja.md
@@ -54,6 +54,6 @@ lang: ja
 [whatsat]: https://github.com/joostjager/whatsat
 [news72 sphinx]: /ja/newsletters/2019/11/13/#ln-1
 [river twitter thread]: https://twitter.com/philipglazman/status/1216849483184476165
-[wasabi rbf notification]: https://bitcoinops.org/en/compatibility/wasabi/#receive-notification
+[wasabi rbf notification]: /en/compatibility/wasabi/#receive-notification
 [wasabi rbf signaling]: https://github.com/zkSNACKs/WalletWasabi/pull/2405
 [news52 #13756]: /en/newsletters/2019/06/26/#bitcoin-core-13756

--- a/en/tools/calc-size.md
+++ b/en/tools/calc-size.md
@@ -1,4 +1,5 @@
 ---
+permalink: /en/tools/calc-size/
 title: "Transaction size calculator"
 layout: page
 breadcrumbs: false


### PR DESCRIPTION
Using internal URLs makes it easier to locally preview the site.  Additionally, our existing tests only verify the existence of internal URLs so any pages using an external domain name aren't guaranteed to resolve.

Inspired by https://github.com/bitcoinops/bitcoinops.github.io/pull/417#discussion_r437568679

The commit assigning a permalink to the the tx size calculator is needed for this change; see its commit comment for a justification.