### PR TITLE
Update miniscript, rpc references

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -40,8 +40,7 @@
 [libsecp256k1]: https://github.com/bitcoin-core/secp256k1
 [libsecp256k1 repo]: https://github.com/bitcoin-core/secp256k1
 [lnd repo]: https://github.com/lightningnetwork/lnd/
-{% comment %}<!-- TODO: switch miniscript link to some sort of overview page when available -->{% endcomment %}
-[miniscript]: http://bitcoin.sipa.be/miniscript/
+[miniscript]: /en/topics/miniscript/
 [musig]: https://eprint.iacr.org/2018/068
 {% assign _link_descriptors = 'https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md' %}
 [output script descriptor]: {{_link_descriptors}}
@@ -82,7 +81,7 @@ place, put links here. -->{% endcomment %}
 <!--REQUIRES PERIODIC UPDATE: update rpc_version below to latest
 version of BitcoinCore.org's RPC docs-->
 {% endcomment %}
-{% assign rpc_prefix = "https://bitcoincore.org/en/doc/0.18.0/rpc" %}
+{% assign rpc_prefix = "https://bitcoincore.org/en/doc/0.20.0/rpc" %}
 [rpc abandontransaction]: {{rpc_prefix}}/wallet/abandontransaction/
 [rpc fundrawtransaction]: {{rpc_prefix}}/rawtransactions/fundrawtransaction/
 [rpc generatetoaddress]: {{rpc_prefix}}/generating/generatetoaddress/

--- a/_posts/en/newsletters/2019-08-28-newsletter.md
+++ b/_posts/en/newsletters/2019-08-28-newsletter.md
@@ -83,7 +83,7 @@ popular Bitcoin infrastructure projects.
   created that  supports the protocol additions, making the upgrade easy
   for both wallets and users even if they use complex scripts.
 
-  For more information, see the [miniscript website][miniscript], [C++
+  For more information, see our [miniscript topic page][miniscript], [C++
   miniscript implementation][miniscript code], [Rust
   implementation][miniscript rust], code for a [Bitcoin Core
   integration][core miniscript], and Pieter Wuille's talk about an


### PR DESCRIPTION
1. updates miniscript link to miniscript topic
2. updates rpc base url to 0.20

If there is a cleaner way to do # 1, please opine, @harding 