### PR TITLE
topics: take date from URL for newsletter links

### DIFF
--- a/_data/schemas/topics.yaml
+++ b/_data/schemas/topics.yaml
@@ -84,7 +84,6 @@ properties:
       required:
         - title
         - url
-        - date
       additionalProperties: false
       properties:
         title:

--- a/_includes/functions/get-mention-date.md
+++ b/_includes/functions/get-mention-date.md
@@ -1,0 +1,9 @@
+{% if mention.url contains "/en/newsletters" %}
+  {%- assign date = mention.url | remove_first: "/en/newsletters/" | slice: 0, 10 | replace: "/", "-" -%}
+{%- else -%}
+  {%- if mention.date == nil -%}
+    {%- include ERROR_44_MISSING_DATE -%}
+  {%- else -%}
+    {%- assign date = mention.date -%}
+  {%- endif -%}
+{%- endif -%}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -52,19 +52,14 @@ layout: post
 
   <!-- Build list of internal optech mentions -->
   {% assign references = '' %}
-  {% assign mentions = page.optech_mentions | sort: "date" | reverse %}
-  {% for mention in mentions %}
+  {% for mention in page.optech_mentions %}
     {% if mention.feature == true %}
-      {% assign bold = site.bold %}
+      {% assign bold = '{:.bold}' %}
     {% else %}
       {% assign bold='' %}
     {% endif %}
-    {% if mention.url contains "/en/newsletters" %}
-      {% assign date = mention.url | remove_first: "/en/newsletters/" | slice: 0, 10 | replace: "/", "-" %}
-    {% else %}
-      {% assign date = mention.date %}
-    {% endif %}
-    {% capture references %}{{references}}{{newline}}- {{bold}}{{date}} [{{mention.title}}]({{mention.url}}){{bold}}{% endcapture %}
+    {% include functions/get-mention-date.md %}
+    {% capture references %}{{references}}{{newline}}- {{date}} [{{mention.title}}]({{mention.url}}){{bold}}ENDENTRY{% endcapture %}
   {% endfor %}
 
   <!-- Build list of see also entries -->
@@ -99,7 +94,7 @@ layout: post
   {%- if page.optech_mentions and page.optech_mentions != '' -%}
     ## Optech newsletter and website mentions
 
-    {{references}}
+    {{ references | split: 'ENDENTRY' | sort | reverse}}
   {% endif %}{{newline}}{{newline}}
 
   {%- if page.see_also and page.see_also != '' -%}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -59,7 +59,12 @@ layout: post
     {% else %}
       {% assign bold='' %}
     {% endif %}
-    {% capture references %}{{references}}{{newline}}- {{bold}}{{mention.date}} [{{mention.title}}]({{mention.url}}){{bold}}{% endcapture %}
+    {% if mention.url contains "/en/newsletters" %}
+      {% assign date = mention.url | remove_first: "/en/newsletters/" | slice: 0, 10 | replace: "/", "-" %}
+    {% else %}
+      {% assign date = mention.date %}
+    {% endif %}
+    {% capture references %}{{references}}{{newline}}- {{bold}}{{date}} [{{mention.title}}]({{mention.url}}){{bold}}{% endcapture %}
   {% endfor %}
 
   <!-- Build list of see also entries -->

--- a/_topics/en/addr-v2.md
+++ b/_topics/en/addr-v2.md
@@ -41,15 +41,12 @@ primary_sources:
 optech_mentions:
   - title: Version 2 `addr` message proposed
     url: /en/newsletters/2019/03/12/#version-2-addr-message-proposed
-    date: 2019-03-12
 
   - title: Version 2 `addr` message assigned BIP155
     url: /en/newsletters/2019/07/31/#bips-766
-    date: 2019-07-31
 
   - title: Proposed per-node signaling for address relay with v2 `addr` messages
     url: /en/newsletters/2019/11/06/#signaling-support-for-address-relay
-    date: 2019-11-06
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/anchor-outputs.md
+++ b/_topics/en/anchor-outputs.md
@@ -64,43 +64,33 @@ primary_sources:
 optech_mentions:
   - title: Simplified fee bumping for LN
     url: /en/newsletters/2018/11/27/#simplified-fee-bumping-for-ln
-    date: 2018-11-27
 
   - title: LN simplified commitments discussion
     url: /en/newsletters/2019/10/30/#ln-simplified-commitments
-    date: 2019-10-30
 
   - title: Continued discussion of LN anchor outputs
     url: /en/newsletters/2019/11/06/#continued-discussion-of-ln-anchor-outputs
-    date: 2019-11-06
 
   - title: "2019 year-in-review: anchor outputs"
     url: /en/newsletters/2019/12/28/#anchor-outputs
-    date: 2019-12-28
 
   - title: "LND #3829 updates code & documentation to simplify adding anchor outputs"
     url: /en/newsletters/2020/01/15/#lnd-3829
-    date: 2020-01-15
 
   - title: "LND #3821 adds draft anchor commitments support"
     url: /en/newsletters/2020/03/18/#lnd-3821
-    date: 2020-03-18
 
   - title: "Using anchor outputs to ensure HTLC sends can be fee bumped"
     url: /en/newsletters/2020/04/29/#settlement-transaction-anchor-outputs
-    date: 2020-04-29
 
   - title: "LND 0.10 presentation: anchor outputs"
     url: /en/newsletters/2020/05/06/#lnd-v0-10
-    date: 2020-05-06
 
   - title: "Anchor outputs may help mitigate LN fee ransom attack"
     url: /en/newsletters/2020/06/24/#ln-fee-ransom-attack
-    date: 2020-06-24
 
   - title: "Eclair #1484 adds basic support for anchor outputs"
     url: /en/newsletters/2020/07/29/#eclair-1484
-    date: 2020-07-29
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/assumeutxo.md
+++ b/_topics/en/assumeutxo.md
@@ -42,15 +42,12 @@ primary_sources:
 optech_mentions:
   - title: Assume valid discussion
     url: /en/newsletters/2019/04/09/#discussion-about-an-assumed-valid-mechanism-for-utxo-snapshots
-    date: 2019-04-09
 
   - title: CoreDev.tech demo and discussion of assumeutxo
     url: /en/newsletters/2019/06/12/#assume-utxo-demo
-    date: 2019-06-12
 
   - title: "2019 year-in-review: AssumeUTXO"
     url: /en/newsletters/2019/12/28/#assumeutxo
-    date: 2019-12-28
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/bech32.md
+++ b/_topics/en/bech32.md
@@ -38,35 +38,27 @@ optech_mentions:
 
   - title: Bech32 security update for C implementations
     url: /en/newsletters/2018/11/06#bech32-security-update-for-c-implementation
-    date: 2018-11-06
 
   - title: How does the bech32 length-extension mutation weakness work?
     url: /en/newsletters/2019/11/27/#how-does-the-bech32-length-extension-mutation-weakness-work
-    date: 2019-11-27
 
   - title: Impact of bech32 length-change mutability on v1 segwit script length
     url: /en/newsletters/2019/11/13/#taproot-review-discussion-and-related-information
-    date: 2019-11-13
 
   - title: "LND #3767 rejects malformed BOLT11 invoices with a valid bech32 checksum"
     url: /en/newsletters/2019/12/11/#lnd-3767
-    date: 2019-12-11
 
   - title: Proposed plan to deal with bech32 malleability in variable-length addresses
     url: /en/newsletters/2019/12/18/#review-bech32-action-plan
-    date: 2019-12-18
 
   - title: Analysis of bech32 error detection capability
     url: /en/newsletters/2019/12/18/#analysis-of-bech32-error-detection
-    date: 2019-12-18
 
   - title: "2019 year-in-review: bech32 mutability"
     url: /en/newsletters/2019/12/28/#bech32-mutability
-    date: 2019-12-28
 
   - title: Proposed updates to BIP173 bech32 to address mutability concerns
     url: /en/newsletters/2020/07/22/#bech32-address-updates
-    date: 2020-07-22
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/bip70-payment-protocol.md
+++ b/_topics/en/bip70-payment-protocol.md
@@ -87,31 +87,24 @@ primary_sources:
 optech_mentions:
   - title: Pay-to-EndPoint (P2EP) has elements similar to BIP70
     url: /en/newsletters/2018/08/14/#pay-to-end-point-p2ep-idea-proposed
-    date: 2018-08-14
 
   - title: "Bitcoin Core PR#14451 allows building Bitcoin-Qt without BIP70 support"
     url: /en/newsletters/2018/10/30/#bitcoin-core-14451
-    date: 2018-10-30
 
   - title: "Bitcoin Core PR#15063 allows falling back to BIP21 parsing of BIP72 URIs"
     url: /en/newsletters/2019/02/19/#bitcoin-core-15063
-    date: 2019-02-19
 
   - title: "Bitcoin Core PR#15584 disables support for BIP70 by default"
     url: /en/newsletters/2019/09/18/#bitcoin-core-15584
-    date: 2019-09-18
 
   - title: "Bitcoin Core PR#17165 removes support for BIP70 payment protocol"
     url: /en/newsletters/2019/10/30/#bitcoin-core-17165
-    date: 2019-10-30
 
   - title: "Bitcoin Core 0.19 released with BIP70 support disabled by default"
     url: /en/newsletters/2019/11/27/#deprecated-or-removed-features
-    date: 2019-11-27
 
   - title: "2019 year-in-review: Bitcoin Core BIP70 deprecation and disablement"
     url: /en/newsletters/2019/12/28/#bip70
-    date: 2019-12-28
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/block-explorers.md
+++ b/_topics/en/block-explorers.md
@@ -37,11 +37,9 @@ primary_sources:
 optech_mentions:
   - title: Modern open source block explorer
     url: /en/newsletters/2018/12/11/#modern-block-explorer-open-sourced
-    date: 2018-12-11
 
   - title: Esplora updated
     url: /en/newsletters/2019/03/19/#esplora-updated
-    date: 2019-03-19
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/channel-factories.md
+++ b/_topics/en/channel-factories.md
@@ -42,11 +42,9 @@ primary_sources:
 optech_mentions:
   - title: "2018 year-in-review: eltoo lays groundwork for channel factories"
     url: /en/newsletters/2018/12/28/#april
-    date: 2018-12-28
 
   - title: Discussion of output tagging and its effect on eltoo and channel factories
     url: /en/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
-    date: 2019-02-19
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/coin-selection.md
+++ b/_topics/en/coin-selection.md
@@ -41,27 +41,21 @@ extended_summary: |
 optech_mentions:
   - title: Coin selection simulations
     url: /en/newsletters/2018/06/26/#coin-selection-simulations
-    date: 2018-06-26
 
   - title: Coin selection groups for privacy and consolidation
     url: /en/newsletters/2018/07/17/#coin-selection-groups-discussion
-    date: 2018-07-17
 
   - title: Bitcoin Core unlikely to add coin selection RPC
     url: /en/newsletters/2018/07/24/#coin-selection-rpc-unlikely
-    date: 2018-07-24
 
   - title: Bitcoin Core PR#17290 coin selection for customized transactions
     url: /en/newsletters/2019/11/27/#bitcoin-core-17290
-    date: 2019-11-27
 
   - title: Bitcoin Core PR#13756 adds flag to avoid address reuse privacy loss
     url: /en/newsletters/2019/06/26/#bitcoin-core-13756
-    date: 2019-06-26
 
   - title: Bitcoin Core 0.19 adds wallet flag to avoid address reuse privacy loss
     url: /en/newsletters/2019/11/27/#optional-privacy-preserving-address-management
-    date: 2019-11-27
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/coinjoin.md
+++ b/_topics/en/coinjoin.md
@@ -34,51 +34,39 @@ primary_sources:
 optech_mentions:
   - title: CoinjoinXT presentation
     url: /en/newsletters/2018/07/10/#coinjoinxt-and-other-techniques-for-deniable-transfers
-    date: 2018-07-10
 
   - title: BLS signatures library possibly useful for non-interactive coinjoins
     url: /en/newsletters/2018/08/07/#library-announced-for-bls-signatures
-    date: 2018-08-07
 
   - title: Sighash updates that can help hardware wallets participate in coinjoins
     url: /en/newsletters/2018/09/04/#proposed-sighash-updates
-    date: 2018-09-04
 
   - title: Question about Wasabi coinjoin mixing and exchange blacklisting
     url: /en/newsletters/2018/09/25/#how-likely-are-you-to-get-blacklisted-by-an-exchange-if-you-use-wasabi-wallet-s-coinjoin-mixing
-    date: 2018-09-25
 
   - title: Fidelity bonds for imporoved sybil resistance in distributed coinjoin
     url: /en/newsletters/2019/07/31/#fidelity-bonds-for-improved-sybil-resistance
-    date: 2019-07-31
 
   - title: "Simple Non-Interactive Coinjoin with Keys for Encryption Reused (SNICKER)"
     url: /en/newsletters/2019/09/04/#snicker-proposed
-    date: 2019-09-04
 
   - title: "2019 year-in-review: SNICKER"
     url: /en/newsletters/2019/12/28/#snicker
-    date: 2019-12-28
 
   - title: Evaluation of coinjoins without equal value inputs or outputs
     url: /en/newsletters/2020/01/08/#coinjoins-without-equal-value-inputs-or-outputs
-    date: 2020-01-08
 
   - title: "Wormhole: a protocol for sending payments as part of a chaumian coinjoin"
     url: /en/newsletters/2020/01/22/#new-coinjoin-mixing-technique-proposed
-    date: 2020-01-22
 
   - title: "Allowing hardware wallets to safely sign automated coinjoin transactions"
     url: /en/newsletters/2020/05/13/#request-for-an-additional-taproot-signature-commitment
-    date: 2020-05-13
 
   - title: "Comparison of coinjoin privacy to coinswap privacy"
     url: /en/newsletters/2020/06/03/#design-for-a-coinswap-implementation
-    date: 2020-06-03
 
   - title: "WabiSabi: a protocol for coordinated coinjoins with arbitrary output values"
     url: /en/newsletters/2020/06/17/#wabisabi-coordinated-coinjoins-with-arbitrary-output-values
-    date: 2020-06-17
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/compact-block-filters.md
+++ b/_topics/en/compact-block-filters.md
@@ -57,35 +57,27 @@ primary_sources:
 optech_mentions:
   - title: Discussion of what data should be included in BIP158 filters
     url: /en/newsletters/2018/06/08#bip157-bip157-bip158-bip158-lightweight-client-filters
-    date: 2018-06-08
 
   - title: Functions for generating BIP158 filters added to Bitcoin Core
     url: /en/newsletters/2018/08/28/#bitcoin-core-12254
-    date: 2018-08-28
 
   - title: Basic BIP158 support merged into Bitcoin Core
     url: /en/newsletters/2019/04/23/#basic-bip158-support-merged-in-bitcoin-core
-    date: 2019-04-23
 
   - title: BIP157 bandwidth higher than BIP37 bloom filters
     url: /en/newsletters/2019/07/31/#bip157-would-use-more-bandwidth-than-bip37
-    date: 2019-07-31
 
   - title: Bitcoin Core 0.19 released with RPC support for BIP158 block filters
     url: /en/newsletters/2019/11/27/#bip158-block-filters-rpc-only
-    date: 2019-11-27
 
   - title: Maximum number of block filters per request increased from 100 to 1,000
     url: /en/newsletters/2019/11/13/#bips-857
-    date: 2019-11-13
 
   - title: "Bitcoin Core #18877 adds `getcfcheckpt` and `cfcheckpt` messages"
     url: /en/newsletters/2020/05/20/#bitcoin-core-18877
-    date: 2020-05-20
 
   - title: "Bitcoin Core #19010 & #19044 add additional messages from BIP157"
     url: /en/newsletters/2020/06/03/#bitcoin-core-19010
-    date: 2020-06-03
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/consensus-cleanup-soft-fork.md
+++ b/_topics/en/consensus-cleanup-soft-fork.md
@@ -28,27 +28,21 @@ primary_sources:
 optech_mentions:
   - title: Cleanup soft fork proposal
     url: /en/newsletters/2019/03/05#cleanup-soft-fork-proposal
-    date: 2019-03-05
 
   - title: Consensus cleanup background
     url: /en/newsletters/2019/03/05#appendix-consensus-cleanup-background
-    date: 2019-03-05
 
   - title: "Consensus cleanup discussion: codeseparator & sighash types"
     url: /en/newsletters/2019/03/12/#cleanup-soft-fork-proposal-discussion
-    date: 2019-03-12
 
   - title: "CoreDev.tech discussion: cleanup soft fork"
     url: /en/newsletters/2019/06/12/#cleanup-discussion
-    date: 2019-06-12
 
   - title: "2019 year-in-review: consensus cleanup soft fork proposal"
     url: /en/newsletters/2019/12/28/#cleanup
-    date: 2019-12-28
 
   - title: Discussion of minimum safe transaction sizes
     url: /en/newsletters/2020/05/27/#minimum-transaction-size-discussion
-    date: 2020-05-27
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/countersign.md
+++ b/_topics/en/countersign.md
@@ -37,11 +37,9 @@ primary_sources:
 optech_mentions:
   - title: "2018 year-in-review: untrackable authentication"
     url: /en/newsletters/2018/12/28/#countersign
-    date: 2018-12-28
 
   - title: "CoreDev.tech meetings: v2 P2P transport and countersign"
     url: /en/newsletters/2019/06/12/#v2-p2p
-    date: 2019-06-12
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/covenants.md
+++ b/_topics/en/covenants.md
@@ -34,43 +34,33 @@ primary_sources:
 optech_mentions:
   - title: "Scaling Bitcoin Tokyo 2018, Script Roundtable: OP_CHECKSIGFROMSTACK"
     url: /en/newsletters/2018/10/09/#discussion-the-evolution-of-bitcoin-script
-    date: 2018-10-09
 
   - title: "New proposed opcode: OP_CHECKOUTPUTSHASHVERIFY"
     url: /en/newsletters/2019/05/29/#proposed-new-opcode-for-transaction-output-commitments
-    date: 2019-05-29
 
   - title: "CoreDev.tech discussion: potential script changes"
     url: /en/newsletters/2019/06/12/#potential-script-changes
-    date: 2019-06-12
 
   - title: Bitcoin vaults without covenants
     url: /en/newsletters/2019/08/14#bitcoin-vaults-without-covenants
-    date: 2019-08-14
 
   - title: OP_CHECKOUTPUTSHASHVERIFY renamed OP_CHECKTEMPLATEVERIFY and updated
     url: /en/newsletters/2019/12/04/#op-checktemplateverify-ctv
-    date: 2019-12-04
 
   - title: Suggested changes to OP_CHECKTEMPLATEVERIFY proposal
     url: /en/newsletters/2019/12/18/#proposed-changes-to-bip-ctv
-    date: 2019-12-18
 
   - title: "2019 year-in-review: OP_CHECKTEMPLATEVERIFY"
     url: /en/newsletters/2019/12/28/#ctv
-    date: 2019-12-28
 
   - title: OP_CHECKTEMPLATEVERIFY workshop report
     url: /en/newsletters/2020/02/12/#op-checktemplateverify-ctv-workshop
-    date: 2020-02-12
 
   - title: Vault prototype using pre-signed transactions
     url: /en/newsletters/2020/04/22/#vaults-prototype
-    date: 2020-04-22
 
   - title: Demo implementation of a multisig vaults covenant prototype
     url: /en/newsletters/2020/04/29/#multiparty-vault-architecture
-    date: 2020-04-29
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/cpfp-carve-out.md
+++ b/_topics/en/cpfp-carve-out.md
@@ -42,31 +42,24 @@ primary_sources:
 optech_mentions:
   - title: CPFP carve out proposal
     url: /en/newsletters/2018/12/04/#cpfp-carve-out
-    date: 2018-12-04
 
   - title: Proposal to override some BIP125 conditions, alternative to carve out
     url: /en/newsletters/2019/06/12/#proposal-to-override-some-bip125-rbf-conditions
-    date: 2019-06-12
 
   - title: "Bitcoin Core #15681 merged with CPFP carve out"
     url: /en/newsletters/2019/07/24/#bitcoin-core-15681
-    date: 2019-07-24
 
   - title: "Bitcoin Core #16421 merged allowing carve outs to be RBF replaced"
     url: /en/newsletters/2019/09/11/#bitcoin-core-16421
-    date: 2019-09-11
 
   - title: "LN simplified commitments using CPFP carve-out"
     url: /en/newsletters/2019/10/30/#ln-simplified-commitments
-    date: 2019-10-30
 
   - title: "Continued discussion of LN anchor outputs using CPFP carve-out"
     url: /en/newsletters/2019/11/06/#continued-discussion-of-ln-anchor-outputs
-    date: 2019-11-06
 
   - title: Bitcoin Core 0.19 released with CPFP carve-out
     url: /en/newsletters/2019/11/27/#cpfp-carve-out
-    date: 2019-11-27
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/cpfp.md
+++ b/_topics/en/cpfp.md
@@ -50,23 +50,18 @@ primary_sources:
 optech_mentions:
   - title: Simplified fee bumping for LN
     url: /en/newsletters/2018/11/27/#simplified-fee-bumping-for-ln
-    date: 2018-11-27
 
   - title: CPFP carve-out proposed
     url: /en/newsletters/2018/12/04/#cpfp-carve-out
-    date: 2018-12-04
 
   - title: "LND #3140 adds support for RBF and CPFP fee bumping sweep transactions"
     url: /en/newsletters/2019/06/19/#lnd-3140
-    date: 2019-06-19
 
   - title: "Refactor preparing for ancestor relay"
     url: /en/newsletters/2019/09/25/#bitcoin-core-16400
-    date: 2019-09-25
 
   - title: Copay adds support for CPFP fee bumping incoming transactions
     url: /en/newsletters/2020/05/20/#copay-enables-cpfp-for-incoming-transactions
-    date: 2020-05-20
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/cve-2018-17144.md
+++ b/_topics/en/cve-2018-17144.md
@@ -66,27 +66,21 @@ primary_sources:
 optech_mentions:
   - title: Upgrade to Bitcoin Core 0.16.3 to fix DoS vulnerability
     url: /en/newsletters/2018/09/18/#upgrade-to-bitcoin-core-0-16-3-to-fix-denial-of-service-vulnerability
-    date: 2018-09-18
 
   - title: Upgrade to Bitcoin Core 0.16.3 to fix CVE-2018-17144
     url: /en/newsletters/2018/09/25/#upgrade-to-bitcoin-core-0-16-3-to-fix-cve-2018-17144
-    date: 2018-09-25
 
   - title: Information about CVE-2018-17144
     url: /en/newsletters/2018/09/25/#cve-2018-17144
-    date: 2018-09-25
 
   - title: CVE-2018-17144 exploited on testnet
     url: /en/newsletters/2018/10/02/#cve-2018-17144-duplicate-inputs-bug-exploited-on-testnet
-    date: 2018-10-02
 
   - title: "2018 year-in-review: CVE-2018-17144"
     url: /en/newsletters/2018/12/28/#september
-    date: 2018-12-28
 
   - title: "Talk summary: Near misses: what could have gone wrong"
     url: /en/newsletters/2019/10/16/#near-misses-what-could-have-gone-wrong
-    date: 2019-10-16
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/dandelion.md
+++ b/_topics/en/dandelion.md
@@ -31,27 +31,21 @@ primary_sources:
 optech_mentions:
   - title: What's the BIP156 hold-up in Bitcoin Core?
     url: /en/newsletters/2019/01/29/#what-s-the-hold-up-implementing-bip156-dandelion-in-bitcoin-core
-    date: 2019-01-29
 
   - title: PRs that need more review or development
     url: /en/newsletters/2019/02/19/#bitcoin-core-freeze-week
-    date: 2019-02-19
 
   - title: Erlay compatible with BIP156
     url: /en/newsletters/2019/06/05/#erlay-proposed
-    date: 2019-06-05
 
   - title: Discussion of Dandelion route selection
     url: /en/newsletters/2018/07/03/#dandelion-transaction-relay
-    date: 2018-07-03
 
   - title: Dandelion DoS-resistant stem routing being researched
     url: /en/newsletters/2018/08/21/#dandelion-protocol-dos-resistant-stem-routing
-    date: 2018-08-21
 
   - title: "2018 year-in-review notable developments: BIP156 Dandelion"
     url: /en/newsletters/2018/12/28/#dandelion
-    date: 2018-12-28
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/eclipse-attacks.md
+++ b/_topics/en/eclipse-attacks.md
@@ -60,35 +60,27 @@ primary_sources:
 optech_mentions:
   - title: Differentiating peers based on ASN instead of address prefix
     url: /en/newsletters/2019/06/26/#differentiating-peers-based-on-asn-instead-of-address-prefix
-    date: 2019-06-26
 
   - title: Discussion of eclipse attacks on LN nodes
     url: /en/newsletters/2019/12/18/#discussion-of-eclipse-attacks-on-ln-nodes
-    date: 2019-12-18
 
   - title: "2019 year-in-review: erlay and other P2P improvements"
     url: /en/newsletters/2019/12/28/#erlay-and-other-p2p-improvements
-    date: 2019-12-28
 
   - title: "Bitcoin Core #16702 chooses peers based on ASN instead of IP address"
     url: /en/newsletters/2020/02/05/#bitcoin-core-16702
-    date: 2020-02-05
 
   - title: "Review club discussion of Bitcoin Core #17428 anchor connections"
     url: /en/newsletters/2020/03/11/#bitcoin-core-pr-review-club
-    date: 2020-03-11
 
   - title: "Presentation about attacking Bitcoin Core, including using eclipse attacks"
     url: /en/newsletters/2020/05/06/#attacking-bitcoin-core
-    date: 2020-05-06
 
   - title: "Time dilation attack: using eclipse attacks to steal money from LN nodes"
     url: /en/newsletters/2020/06/10/#time-dilation-attacks-against-ln
-    date: 2020-06-10
 
   - title: "Bitcoin Core 0.20 released with asmap feature to improve eclipse resistance"
     url: /en/newsletters/2020/06/10/#bitcoin-core-0-20-0
-    date: 2020-06-10
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/eltoo.md
+++ b/_topics/en/eltoo.md
@@ -42,35 +42,27 @@ primary_sources:
 optech_mentions:
   - title: "2018 year-in-review: Eltoo"
     url: /en/newsletters/2018/12/28#april
-    date: 2018-12-28
 
   - title: Optimization for Eltoo-based payment channels
     url: /en/newsletters/2019/01/08/#continued-sighash-discussion
-    date: 2019-01-08
 
   - title: SIGHASH_ANYPREVOUT proposal compatible with Eltoo
     url: /en/newsletters/2019/05/21/#proposed-anyprevout-sighash-modes
-    date: 2019-05-21
 
   - title: Eltoo demo implementation
     url: /en/newsletters/2019/09/11/#eltoo-sample-implementation-and-discussion
-    date: 2019-09-11
 
   - title: "Modification to `SIGHASH_ANYPREVOUTANYSCRIPT` to improve eltoo flexibility"
     url: /en/newsletters/2020/01/29/#layered-commitments-with-eltoo
-    date: 2020-01-29
 
   - title: Implementing statechains without eltoo
     url: /en/newsletters/2020/04/01/#implementing-statechains-without-schnorr-or-eltoo
-    date: 2020-04-01
 
   - title: "Impact of SIGHASH_NOINPUT and eltoo on LN backups"
     url: /en/newsletters/2020/06/03/#ln-backups
-    date: 2020-06-03
 
   - title: Upgrading LN commitment formats, including for eltoo
     url: /en/newsletters/2020/07/29/#upgrading-channel-commitment-formats
-    date: 2020-07-29
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/erlay.md
+++ b/_topics/en/erlay.md
@@ -43,19 +43,15 @@ primary_sources:
 optech_mentions:
   - title: Erlay proposed
     url: /en/newsletters/2019/06/05/#erlay-proposed
-    date: 2019-06-05
 
   - title: Draft BIP for enabling Erlay compatibility
     url: /en/newsletters/2019/10/02/#draft-bip-for-enabling-erlay-compatibility
-    date: 2019-10-02
 
   - title: Erlay-compatible transaction reconciliation protocol published as BIP330
     url: /en/newsletters/2019/11/13/#bips-851
-    date: 2019-11-13
 
   - title: "2019 year-in-review: erlay"
     url: /en/newsletters/2019/12/28/#erlay-and-other-p2p-improvements
-    date: 2019-12-28
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/generic-signmessage.md
+++ b/_topics/en/generic-signmessage.md
@@ -44,15 +44,12 @@ primary_sources:
 optech_mentions:
   - title: BIP322 proposed
     url: /en/newsletters/2018/09/18/#bip322-generic-signed-message-format
-    date: 2018-09-18
 
   - title: "2018 year-in-review: initial discussion that became BIP322"
     url: /en/newsletters/2018/12/28/#march
-    date: 2018-12-28
 
   - title: Bitcoin Core PR opened for BIP322 signmessage support
     url: /en/newsletters/2019/07/31/#pr-opened-for-bip322-generic-signed-message-format
-    date: 2019-07-31
 
   - title: Searching for a bech32 signmessage format
     url: /en/bech32-sending-support/#bip322
@@ -60,15 +57,12 @@ optech_mentions:
 
   - title: Additional request for feedback on BIP322 generic signmessage
     url: /en/newsletters/2020/03/11/#bip322-generic-signmessage-progress-or-perish
-    date: 2020-03-11
 
   - title: Proposed update to BIP322 generic signmessage
     url: /en/newsletters/2020/04/01/#proposed-update-to-bip322-generic-signmessage
-    date: 2020-04-01
 
   - title: "Simplified BIP322, only allowing signatures from one script per proof"
     url: /en/newsletters/2020/05/06/#bips-903
-    date: 2020-05-06
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/hold-invoices.md
+++ b/_topics/en/hold-invoices.md
@@ -37,23 +37,18 @@ primary_sources:
 optech_mentions:
   - title: "LND #2022 merged adding support for hold invoices"
     url: /en/newsletters/2019/03/19/#lnd-2022
-    date: 2019-03-19
 
   - title: "C-Lightning #2540 adds hook allowing plugins to implement hold invoices"
     url: /en/newsletters/2019/04/16/#c-lightning-2540
-    date: 2019-04-16
 
   - title: "LND #3390 simplifies hold invoice logic by separate HTLC tracking"
     url: /en/newsletters/2019/09/11/#lnd-3390
-    date: 2019-09-11
 
   - title: "Reverse up-front payments could improve hold invoice cost spreading"
     url: /en/newsletters/2020/02/26/#reverse-up-front-payments
-    date: 2020-02-26
 
   - title: Zap 0.7.0 Beta adds support for hold invoices
     url: /en/newsletters/2020/07/22/#zap-0-7-0-beta-released
-    date: 2020-07-22
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/hwi.md
+++ b/_topics/en/hwi.md
@@ -30,31 +30,24 @@ primary_sources:
 optech_mentions:
   - title: Bitcoin Core preliminary hardware wallet support
     url: /en/newsletters/2019/02/19/#bitcoin-core-preliminary-hardware-wallet-support
-    date: 2019-02-19
 
   - title: Bitcoin Core 0.18 with basic hardware signer support
     url: /en/newsletters/2019/05/07/#basic-hardware-signer-support-through-independent-tool
-    date: 2019-05-07
 
   - title: "CoreDev.tech discussions: HWI integration into Bitcoin Core"
     url: /en/newsletters/2019/06/12/#hwi
-    date: 2019-06-12
 
   - title: "2019 year-in-review: HWI"
     url: /en/newsletters/2019/12/28/#core-hwi
-    date: 2019-12-18
 
   - title: BTCPay Vault using HWI for signing
     url: /en/newsletters/2020/02/19/#btcpay-vault-using-hwi-for-signing
-    date: 2020-02-19
 
   - title: Fix for segwit fee overpayment attack affects HWI compatibility
     url: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
-    date: 2020-06-10
 
   - title: Initial release of Lily Wallet supports HWI
     url: /en/newsletters/2020/07/22/#lily-wallet-initial-release
-    date: 2020-07-22
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/jit-routing.md
+++ b/_topics/en/jit-routing.md
@@ -27,11 +27,9 @@ primary_sources:
 optech_mentions:
   - title: Free rebalancing for JIT routing
     url: /en/newsletters/2019/07/10#brainstorming-just-in-time-routing-and-free-channel-rebalancing
-    date: 2019-07-10
 
   - title: Additional JIT routing discussion
     url: /en/newsletters/2019/07/24/#additional-just-in-time-jit-ln-routing-discussion
-    date: 2019-07-24
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/large-channels.md
+++ b/_topics/en/large-channels.md
@@ -70,39 +70,30 @@ primary_sources:
 optech_mentions:
   - title: "LN 1.1 specification meeting: wumbo channels and payments proposal"
     url: /en/newsletters/2018/11/20/#wumbo
-    date: 2018-11-20
 
   - title: "BOLTs #596 updates BOLT2 to allow channel opens over ~0.17 BTC"
     url: /en/newsletters/2020/02/26/#bolts-596
-    date: 2020-02-26
 
   - title:  "Eclair #1323 advertise support for channel opens over ~0.17 BTC"
     url: /en/newsletters/2020/03/11/#eclair-1323
-    date: 2020-03-11
 
   - title: "C-Lightning #3612 adds support for `option_support_large_channel`"
     url: /en/newsletters/2020/04/08/#c-lightning-3612
-    date: 2020-04-08
 
   - title: "LND #4075 allows creating invoices over 0.043 BTC"
     url: /en/newsletters/2020/04/15/#lnd-4075
-    date: 2020-04-15
 
   - title: "C-Lightning 0.8.2 released with support for large channels"
     url: /en/newsletters/2020/05/06/#c-lightning-0-8-2
-    date: 2020-05-06
 
   - title: LND 0.10.0-beta released with the ability to create invoices over 0.043 BTC
     url: /en/newsletters/2020/05/06/#lnd-0-10-0-beta
-    date: 2020-05-06
 
   - title: "C-Lightning fixes incompatibility when opening large channels with Eclair"
     url: /en/newsletters/2020/05/13/#c-lightning-0-8-2-1
-    date: 2020-05-13
 
   - title: "LND #4429 enables support for large channels by default"
     url: /en/newsletters/2020/07/22/#lnd-4429
-    date: 2020-07-22
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/mast.md
+++ b/_topics/en/mast.md
@@ -61,23 +61,18 @@ primary_sources:
 optech_mentions:
   - title: "Taproot: an optimization for MAST"
     url: /en/newsletters/2018/12/28/#taproot
-    date: 2018-12-28
 
   - title: "Should `OP_CODESEPARATOR` be disabled in MAST scripts?"
     url: /en/newsletters/2019/01/08/#continued-sighash-discussion
-    date: 2019-01-08
 
   - title: It should be possible to upgrade miniscript for things like MAST
     url: /en/newsletters/2019/02/05/#miniscript
-    date: 2019-02-05
 
   - title: Overview of Taproot and it's MAST-based encumbrances
     url: /en/newsletters/2019/05/14/#overview-of-the-taproot--tapscript-proposed-bips
-    date: 2019-05-14
 
   - title: Discussion about taproot versus alternative MAST-enabling proposals
     url: /en/newsletters/2020/02/19/#discussion-about-taproot-versus-alternatives
-    date: 2020-02-19
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/miniscript.md
+++ b/_topics/en/miniscript.md
@@ -37,23 +37,18 @@ primary_sources:
 optech_mentions:
   - title: Miniscript presentation
     url: /en/newsletters/2019/02/05/#miniscript
-    date: 2019-02-05
 
   - title: Final stack empty, insights from miniscript development
     url: /en/newsletters/2019/05/29/#final-stack-empty
-    date: 2019-05-29
 
   - title: Miniscript request for comments
     url: /en/newsletters/2019/08/28/#miniscript-request-for-comments
-    date: 2019-08-28
 
   - title: "2019 year-in-review: miniscript"
     url: /en/newsletters/2019/12/28/#miniscript
-    date: 2019-12-28
 
   - title: Question about a specification for miniscript
     url: /en/newsletters/2020/03/25/#where-can-i-find-the-miniscript-policy-language-specification
-    date: 2020-03-25
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/minisketch.md
+++ b/_topics/en/minisketch.md
@@ -35,15 +35,12 @@ primary_sources:
 optech_mentions:
   - title: "2018 year-in-review: research into reducing transaction relay data"
     url: /en/newsletters/2018/12/28/#libminisketch
-    date: 2018-12-28
 
   - title: Minisketch library released with implications for Bitcoin and LN
     url: /en/newsletters/2018/12/18/#minisketch-library-released
-    date: 2018-12-18
 
   - title: Researching bandwidth-efficient set reconciliation protocol
     url: /en/newsletters/2018/08/21/#bandwidth-efficient-set-reconciliation-protocol-for-transactions
-    date: 2018-08-21
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/multipath-payments.md
+++ b/_topics/en/multipath-payments.md
@@ -60,103 +60,78 @@ primary_sources:
 optech_mentions:
   - title: "LN protocol 1.1 goals: multipath payments"
     url: /en/newsletters/2018/11/20/#multi-path-payments
-    date: 2018-11-20
 
   - title: "LND #3390 separates tracking of HTLCs from invoices as necessary for AMP"
     url: /en/newsletters/2019/09/11/#lnd-3390
-    date: 2019-09-15
 
   - title: "LND #3499 extends several RPCs to support tracking multipath payments"
     url: /en/newsletters/2019/11/27/#lnd-3499
-    date: 2019-11-27
 
   - title: "Eclair #1153 adds experimental support for multipath payments"
     url: /en/newsletters/2019/11/20/#eclair-1153
-    date: 2019-11-20
 
   - title: "LND #3442 preparatory PR adding features necessary for multipath payments"
     url: /en/newsletters/2019/11/13/#lnd-3442
-    date: 2019-11-13
 
   - title: "C-Lightning #3259 adds payment secrets to prevent multipath probing"
     url: /en/newsletters/2019/12/04/#c-lightning-3259
-    date: 2019-12-04
 
   - title: 'LND #3788 adds support for "payment addresses" (payment secrets)'
     url: /en/newsletters/2019/12/11/#lnd-3788
-    date: 2019-12-11
 
   - title: Multiple LN implementations add multipath payment support
     url: /en/newsletters/2019/12/18/#ln-implementations-add-multipath-payment-support
-    date: 2019-12-18
 
   - title: Basic multipath payment support added to LN specification
     url: /en/newsletters/2019/12/18/#bolts-643
-    date: 2019-12-18
 
   - title: "2019 year-in-review: multipath payments"
     url: /en/newsletters/2019/12/28/#multipath
-    date: 2019-12-28
 
   - title: "Eclair #1283 allows multipath payments to traverse unannounced channels"
     url: /en/newsletters/2020/01/22/#eclair-1283
-    date: 2020-01-22
 
   - title: "LND 0.9.0-beta adds support for receiving multipath payments"
     url: /en/newsletters/2020/01/29/#upgrade-to-lnd-0-9-0-beta
-    date: 2020-01-29
 
   - title: "Eclair 0.3.3 adds support for multipath payments"
     url: /en/newsletters/2020/02/05/#upgrade-to-eclair-0-3-3
-    date: 2020-02-05
 
   - title: "LND #3957 adds code useful for Atomic Multipath Payments (AMP) support"
     url: /en/newsletters/2020/02/12/#lnd-3957
-    date: 2020-02-12
 
   - title: "Boomerang: improving latency and throughput with multipath payments"
     url: /en/newsletters/2020/02/26/#boomerang-redundancy-improves-latency-and-throughput-in-payment-channel-networks
-    date: 2020-02-26
 
   - title: "LND #3970 adds support for multipath payments to its payment lifecycle"
     url: /en/newsletters/2020/04/08/#lnd-3970
-    date: 2020-04-08
 
   - title: "LND #3967 adds support for sending multipath payments"
     url: /en/newsletters/2020/04/15/#lnd-3967
-    date: 2020-04-15
 
   - title: "Rust-Lightning #441 adds support for basic multipath payments"
     url: /en/newsletters/2020/04/22/#rust-lightning-441
-    date: 2020-04-22
 
   - title: "LND 0.10 presentation: multipath payments"
     url: /en/newsletters/2020/05/06/#lnd-v0-10
-    date: 2020-05-06
 
   - title: "LND 0.10.0-beta released with support for multipath payments"
     url: /en/newsletters/2020/05/06/#lnd-0-10-0-beta
-    date: 2020-05-06
 
   - title: Lightning Loop adds support for multipath payments
     url: /en/newsletters/2020/05/20/#lightning-loop-using-multipath-payments
-    date: 2020-05-20
 
   - title: "Eclair #1427 and #1439 add support to Eclair for sending multipath payments"
     url: /en/newsletters/2020/07/08/#eclair-1427
-    date: 2020-07-08
 
   - title: Eclair 0.4.1 adds support for sending multipath payments
     url: /en/newsletters/2020/07/08/#eclair-0-4-1
-    date: 2020-07-08
 
   - title: Zap 0.7.0 Beta adds support for multipath payments
     url: /en/newsletters/2020/07/22/#zap-0-7-0-beta-released
-    date: 2020-07-22
 
   - title: "C-Lightning #3809 adds support for sending of multipath payments"
     url: /en/newsletters/2020/07/22/#c-lightning-3809
-    date: 2020-07-22
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/musig.md
+++ b/_topics/en/musig.md
@@ -49,39 +49,30 @@ optech_mentions:
 
   - title: BLS signatures based on the MuSig construction
     url: /en/newsletters/2018/08/07/#library-announced-for-bls-signatures
-    date: 2018-08-07
 
   - title: "2018 year-in-review: publication of MuSig protocol"
     url: /en/newsletters/2018/12/28/#january
-    date: 2018-12-28
 
   - title: Libsecp256k1-zkp supports MuSig key and signature aggregation
     url: /en/newsletters/2019/02/26/#schnorr-ready-fork-of-libsecp256k1-available
-    date: 2019-02-26
 
   - title: Extensions to PSBTs to help make them compatible with advanced protocols
     url: /en/newsletters/2019/03/12/#extension-fields-to-partially-signed-bitcoin-transactions-psbts
-    date: 2019-03-12
 
   - title: "Breaking Bitcoin presentation: secure protocols on bip-taproot"
     url: /en/newsletters/2019/06/19/#secure-protocols-on-bip-taproot
-    date: 2019-06-19
 
   - title: LN gossip update proposal to use MuSig
     url: /en/newsletters/2019/07/17/#gossip-update-proposal
-    date: 2019-07-17
 
   - title: MuSig and attacks based on Wagner's algorithm
     url: /en/newsletters/2019/11/27/#schnorr-taproot-updates
-    date: 2019-11-27
 
   - title: Composable MuSig---concerns about safely using signer sub-groups
     url: /en/newsletters/2019/12/04/#composable-musig
-    date: 2019-12-30
 
   - title: Presentations and discussions about musig-style multiparty signatures
     url: /en/newsletters/2020/07/01/#schnorr-signatures-and-multisignatures
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/op_checksigfromstack.md
+++ b/_topics/en/op_checksigfromstack.md
@@ -158,15 +158,12 @@ primary_sources:
 optech_mentions:
   - title: Discussion of potential script changes, including `OP_CSFS`
     url: /en/newsletters/2019/06/12/#potential-script-changes
-    date: 2019-06-12
 
   - title: "Criticism of `OP_COSHV` and `SIGHASH_ANYPREVOUT`; `OP_CSFS` as alternative"
     url: /en/newsletters/2019/05/29/#not-generic-enough
-    date: 2019-05-29
 
   - title: "Discussion: the evolution of Bitcoin Script, `OP_CSFS` discussion"
     url: /en/newsletters/2018/10/09/#op-checksigfromstack
-    date: 2018-10-09
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/op_checktemplateverify.md
+++ b/_topics/en/op_checktemplateverify.md
@@ -61,40 +61,31 @@ primary_sources:
 optech_mentions:
   - title: Proposed new opcode for transaction output commitments
     url: /en/newsletters/2019/05/29/#proposed-new-opcode-for-transaction-output-commitments
-    date: 2019-05-29
 
   - title: "Detailed summary: proposed transaction output commitments"
     url: /en/newsletters/2019/05/29/#proposed-transaction-output-commitments
-    date: 2019-05-29
     feature: true
 
   - title: COSHV proposal replaced
     url: /en/newsletters/2019/06/05/#coshv-proposal-replaced
-    date: 2019-06-05
 
   - title: Potential script changes, including new COSHV opcode
     url: /en/newsletters/2019/06/12/#potential-script-changes
-    date: 2019-06-12
 
   - title: "OP_CHECKTEMPLATEVERIFY (CTV) replaces COSHV proposal; concerns restated"
     url: /en/newsletters/2019/12/04/#op-checktemplateverify-ctv
-    date: 2019-12-04
 
   - title: "2019 year-in-review: OP_CHECKTEMPLATEVERIFY"
     url: /en/newsletters/2019/12/28/#ctv
-    date: 2019-12-28
 
   - title: "BIPs #875 assigns BIP119 to the OP_CHECKTEMPLATEVERIFY proposal"
     url: /en/newsletters/2020/01/29/#bips-875
-    date: 2020-01-29
 
   - title: OP_CHECKTEMPLATEVERIFY workshop summary
     url: /en/newsletters/2020/02/12/#op-checktemplateverify-ctv-workshop
-    date: 2020-02-12
 
   - title: Vault prototype with sample implementation using OP_CHECKTEMPLATEVERIFY
     url: /en/newsletters/2020/04/22/#vaults-prototype
-    date: 2020-02-19
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/op_codeseparator.md
+++ b/_topics/en/op_codeseparator.md
@@ -118,27 +118,21 @@ primary_sources:
 optech_mentions:
   - title: "Bitcoin Core 0.16.1 to cease relaying transactions using `OP_CODESEPARATOR`"
     url: /en/newsletters/2018/06/08/#check-for-use-of-the-codeseparator-opcode
-    date: 2018-06-08
 
   - title: "Should `OP_CODESEPARATOR` be included in future Script language upgrades?"
     url: /en/newsletters/2019/01/08/#continued-sighash-discussion
-    date: 2019-01-08
 
   - title: "Proposed consensus cleanup soft fork: prevent use of `OP_CODESEPARATOR`"
     url: /en/newsletters/2019/03/05/#prevent-use-of-op-codeseparator-and-findanddelete-in-legacy-transactions
-    date: 2019-03-05
 
   - title: "Consensus cleanup background: legacy transaction verification"
     url: /en/newsletters/2019/03/05/#legacy-transaction-verification
-    date: 2019-03-05
 
   - title: "Discussion about cleanup soft fork: concerns about `OP_CODESEPARATOR`"
     url: /en/newsletters/2019/03/12/#cleanup-soft-fork-proposal-discussion
-    date: 2019-03-12
 
   - title: "Discussion of `OP_CODESEPARATOR` design for proposed tapscript soft fork"
     url: /en/newsletters/2019/12/04/#continued-schnorr-taproot-discussion
-    date: 2019-12-04
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/output-linking.md
+++ b/_topics/en/output-linking.md
@@ -61,31 +61,24 @@ primary_sources:
 optech_mentions:
   - title: "Bitcoin Core #12257: new `-avoidpartialspends` configuration option"
     url: /en/newsletters/2018/07/31/#bitcoin-core-12257
-    date: 2018-07-31
 
   - title: "Weak signature nonces discovered in reused addresses"
     url: /en/newsletters/2019/01/15/#weak-signature-nonces-discovered
-    date: 2019-01-15
 
   - title: "Esplora block explorer updated with privacy warning against address reuse"
     url: /en/newsletters/2019/03/19/#esplora-updated
-    date: 2019-03-19
 
   - title: "Bitcoin Core #13756 adds `avoid_reuse` wallet flag"
     url: /en/newsletters/2019/06/26/#bitcoin-core-13756
-    date: 2019-06-26
 
   - title: "Bitcoin Core 0.19 new feature: `avoid_reuse` wallet flag"
     url: /en/newsletters/2019/11/27/#optional-privacy-preserving-address-management
-    date: 2019-11-27
 
   - title: "Bitcoin Core #17621 fixes potential privacy leak in the `avoid_reuse` flag"
     url: /en/newsletters/2020/01/15/#bitcoin-core-17621
-    date: 2020-01-15
 
   - title: "Bitcoin Core #17843 fixes balance discrepancy related to `avoid_reuse` flag"
     url: /en/newsletters/2020/01/22/#bitcoin-core-17843
-    date: 2020-01-22
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/output-script-descriptors.md
+++ b/_topics/en/output-script-descriptors.md
@@ -37,31 +37,24 @@ primary_sources:
 optech_mentions:
   - title: First use of descriptors in Bitcoin Core
     url: /en/newsletters/2018/07/24/#first-use-of-output-script-descriptors
-    date: 2018-07-24
 
   - title: Key origin support
     url: /en/newsletters/2018/10/30/#bitcoin-core-14150
-    date: 2018-10-30
 
   - title: Descriptor checksum support added
     url: /en/newsletters/2019/02/19/#bitcoin-core-15368
-    date: 2019-02-19
 
   - title: Descriptors extended with sortedmulti
     url: /en/newsletters/2019/10/16/#bitcoin-core-17056
-    date: 2019-10-16
 
   - title: "Encoded descriptors (e.g., with base64)"
     url: /en/newsletters/2020/01/08/#encoded-descriptors
-    date: 2020-01-08
 
   - title: "Bitcoin Core #18032 add `descriptor` field to multisig address RPCs"
     url: /en/newsletters/2020/02/12/#bitcoin-core-18032
-    date: 2020-02-12
 
   - title: "Bitcoin Core #16528 adds support for native output descriptor wallets"
     url: /en/newsletters/2020/05/06/#bitcoin-core-16528
-    date: 2020-05-06
 
   - title: "Field Report: Using descriptors at River Financial"
     url: /en/river-descriptors-psbt/

--- a/_topics/en/package-relay.md
+++ b/_topics/en/package-relay.md
@@ -52,19 +52,15 @@ primary_sources:
 optech_mentions:
   - title: CPFP carve out suggested but package relay needed for completeness
     url: /en/newsletters/2018/12/04/#cpfp-carve-out
-    date: 2018-12-04
 
   - title: "Bitcoin Core #16400 refactors code in anticipation of package relay"
     url: /en/newsletters/2019/09/25/#bitcoin-core-16400
-    date: 2019-09-25
 
   - title: New LN attack; full solution requires package relay
     url: /en/newsletters/2020/04/29/#fn:package-relay
-    date: 2020-04-29
 
   - title: New BIP339 wtxid transaction announcements simplifies package relay
     url: /en/newsletters/2020/07/01/#bips-933
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/payjoin.md
+++ b/_topics/en/payjoin.md
@@ -34,35 +34,27 @@ primary_sources:
 optech_mentions:
   - title: Pay-to-EndPoint (P2EP) proposed
     url: /en/newsletters/2018/08/14/#pay-to-end-point-p2ep-idea-proposed
-    date: 2018-08-14
 
   - title: Bustapay discussion (simplified alternative to P2EP)
     url: /en/newsletters/2018/09/18/#bustapay-discussion
-    date: 2018-09-18
 
   - title: "2018 year-in-review: Pay-to-EndPoint (P2EP)"
     url: /en/newsletters/2018/12/28/#p2ep
-    date: 2018-12-28
 
   - title: Mailing list discussion about BIP79 Bustapay
     url: /en/newsletters/2019/01/29/#post-about-bip79-p2ep-payjoin
-    date: 2019-01-29
 
   - title: BTCPay adds support for sending and receiving payjoined payments
     url: /en/newsletters/2020/04/22/#btcpay-adds-support-for-sending-and-receiving-payjoined-payments
-    date: 2020-04-22
 
   - title: Comparison of payjoin privacy to coinswap privacy
     url: /en/newsletters/2020/06/03/#design-for-a-coinswap-implementation
-    date: 2020-06-03
 
   - title: Discussion about payjoin and its history
     url: /en/newsletters/2020/06/03/#payjoin-p2ep
-    date: 2020-06-03
 
   - title: New BIP78 specification of payjoin
     url: /en/newsletters/2020/07/01/#bips-923
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/psbt.md
+++ b/_topics/en/psbt.md
@@ -43,95 +43,72 @@ primary_sources:
 optech_mentions:
   - title: PSBT discussion
     url: /en/newsletters/2018/07/03/#bip174-discussion
-    date: 2018-07-03
 
   - title: Features included in Bitcoin Core 0.17
     url: /en/newsletters/2018/07/10/#bip174
-    date: 2018-07-10
 
   - title: New Bitcoin Core RPCs for initial PSBT support
     url: /en/newsletters/2018/07/24/#bip174-partially-signed-bitcoin-transaction-psbt-support-merged
-    date: 2018-07-24
 
   - title: Three new Bitcoin Core RPCs for managing PSBTs
     url: /en/newsletters/2019/02/19/#bitcoin-core-13932
-    date: 2019-02-19
 
   - title: Discussion of PSBT extension fields
     url: /en/newsletters/2019/03/12/#extension-fields-to-partially-signed-bitcoin-transactions-psbts
-    date: 2019-03-12
 
   - title: PSBT enhancements included in Bitcoin Core 0.18
     url: /en/newsletters/2019/05/07/#more-psbt-tools-and-refinements
-    date: 2019-05-07
 
   - title: Update to the utxoupdatepsbt RPC in Bitcoin Core
     url: /en/newsletters/2019/07/10/#bitcoin-core-15427
-    date: 2019-07-10
 
   - title: Modifying BIP174 for extensibility
     url: /en/newsletters/2019/08/07/#bip174-extensibility
-    date: 2019-08-07
 
   - title: Range of identifiers allocated to proprietary PSBT extensions
     url: /en/newsletters/2019/11/13/#bips-849
-    date: 2019-11-13
 
   - title: "Bitcoin Core #16373 allows the bumpfee RPC used for RBF to return a PSBT"
     url: /en/newsletters/2020/01/15/#bitcoin-core-16373
-    date: 2020-01-15
 
   - title: "Bitcoin Core #17492 allows the wallet GUI to place a PSBT in the clipboard"
     url: /en/newsletters/2020/01/29/#bitcoin-core-17492
-    date: 2020-01-29
 
   - title: CKBunker using PSBTs for an HSM
     url: /en/newsletters/2020/02/19/#ckbunker-using-psbts-for-an-hsm
-    date: 2020-02-19
 
   - title: "Bitcoin Core #17264 includes HD derivation path in PSBTs by default"
     url: /en/newsletters/2020/03/04/#bitcoin-core-17264
-    date: 2020-03-04
 
   - title: "LND #4079 adds support for funding channels with PSBTs"
     url: /en/newsletters/2020/04/08/#lnd-4079
-    date: 2020-04-08
 
   - title: "Bitcoin Core #17509 allows saving and loading PSBTs from files"
     url: /en/newsletters/2020/04/29/#bitcoin-core-17509
-    date: 2020-04-29
 
   - title: "LND 0.10 presentation: funding channels using PSBTs"
     url: /en/newsletters/2020/05/06/#lnd-v0-10
-    date: 2020-05-06
 
   - title: LND 0.10.0-beta released with support for funding channels using PSBTs
     url: /en/newsletters/2020/05/06/#lnd-0-10-0-beta
-    date: 2020-05-06
 
   - title: "C-Lightning #3738 adds initial support for creating PSBTs"
     url: /en/newsletters/2020/05/27/#c-lightning-3738
-    date: 2020-05-27
 
   - title: "Bitcoin Core #18027 adds GUI support for signing & broadcasting PSBTs"
     url: /en/newsletters/2020/06/24/#bitcoin-core-18027
-    date: 2020-06-24
 
   - title: "Bitcoin Core #19215 adds additional data to PSBTs for segwit inputs"
     url: /en/newsletters/2020/07/08/#bitcoin-core-19215
-    date: 2020-07-08
 
   - title: "C-Lightning #3775 adds RPCs for creating and using PSBTs"
     url: /en/newsletters/2020/07/08/#c-lightning-3775
-    date: 2020-07-08
 
   - title: "Electrum 4.0.1 replaces their partial transactions format with PSBTs"
     url: /en/newsletters/2020/07/22/#electrum-adds-lightning-network-and-psbt-support
-    date: 2020-07-22
 
   - title: Initial release of Lily Wallet supports PSBTs
     url: /en/newsletters/2020/07/22/#lily-wallet-initial-release
-    date: 2020-07-22
 
   - title: "Field Report: Using PSBT at River Financial"
     url: /en/river-descriptors-psbt/
@@ -139,7 +116,6 @@ optech_mentions:
 
   - title: "LND #4455 makes it safe to batch open channels using PSBTs"
     url: /en/newsletters/2020/07/29/#lnd-4455
-    date: 2020-07-29
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -60,23 +60,18 @@ optech_mentions:
 
   - title: "2018 year-in-review: transaction statistics"
     url: /en/newsletters/2018/12/28/#opt-in-rbf
-    date: 2018-12-28
 
   - title: Proposal to override some BIP125 RBF conditions
     url: /en/newsletters/2019/06/12/#proposal-to-override-some-bip125-rbf-conditions
-    date: 2019-06-12
 
   - title: LND adds support for RBF fee bumping
     url: /en/newsletters/2019/06/19/#lnd-3140
-    date: 2019-06-19
 
   - title: Bitcoin Core removes `mempoolreplacement` configuration option
     url: /en/newsletters/2019/06/26/#bitcoin-core-16171
-    date: 2019-06-26
 
   - title: "Bitcoin Core #16373 allows the bumpfee RPC used for RBF to return a PSBT"
     url: /en/newsletters/2020/01/15/#bitcoin-core-16373
-    date: 2020-01-15
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/reproducible-builds.md
+++ b/_topics/en/reproducible-builds.md
@@ -37,35 +37,27 @@ primary_sources:
 optech_mentions:
   - title: "Notable Bitcoin Core PRs: reproducible builds using GNU Guix"
     url: /en/newsletters/2019/02/19/#bitcoin-core-freeze-week
-    date: 2019-02-19
 
   - title: "Breaking Bitcoin summaries: Bitcoin build system security"
     url: /en/newsletters/2019/06/19/#bitcoin-build-system-security
-    date: 2019-06-19
 
   - title: Merged PR for reproducible build of Bitcoin Core using GNU Guix
     url: /en/newsletters/2019/07/17/#bitcoin-core-15277
-    date: 2019-07-17
 
   - title: New reproducibly-build architecture and Snap packages for Bitcoin Core
     url: /en/newsletters/2019/05/07/#new-architecture-and-new-ubuntu-snap-package
-    date: 2019-05-07
 
   - title: "2019 year-in-review: reproducible builds"
     url: /en/newsletters/2019/12/28/#reproducibility
-    date: 2019-12-28
 
   - title: "Eclair #1295 allows the eclair-core module to be reproducibly built"
     url: /en/newsletters/2020/02/05/#eclair-1295
-    date: 2020-02-05
 
   - title: "Eclair #1307 updates packaging to also reproducibly build Eclair GUI"
     url: /en/newsletters/2020/03/04/#eclair-1307
-    date: 2020-03-04
 
   - title: "Bitcoin Core #17595 adds Guix support for Windows builds"
     url: /en/newsletters/2020/04/22/#bitcoin-core-17595
-    date: 2020-04-22
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -41,27 +41,21 @@ optech_mentions:
 
   - title: Proposed schnorr BIP
     url: /en/newsletters/2018/07/10/#featured-news-schnorr-signature-proposed-bip
-    date: 2018-07-10
 
   - title: Continued bip-schnorr discussion
     url: /en/newsletters/2018/07/17/#continuing-discussion-about-schnorr-signatures
-    date: 2018-07-17
 
   - title: Proposed change to schnorr pubkeys
     url: /en/newsletters/2019/08/14/#proposed-change-to-schnorr-pubkeys
-    date: 2019-08-14
 
   - title: Update on changes to schnorr, taproot, and tapscript
     url: /en/newsletters/2019/10/16/#taproot-update
-    date: 2019-10-16
 
   - title: "Talk summary: the quest for practical threshold Schnorr signatures"
     url: /en/newsletters/2019/10/16/#the-quest-for-practical-threshold-schnorr-signatures
-    date: 2019-10-16
 
   - title: Announcement of structured taproot review (including schnorr)
     url: /en/newsletters/2019/10/23/#taproot-review
-    date: 2019-10-23
 
   - title: Bitcoin Optech schnorr/taproot workshop
     url: /en/schorr-taproot-workshop/
@@ -70,47 +64,36 @@ optech_mentions:
 
   - title: Blog post about x-only pubkeys for use in schnorr signature schemes
     url: /en/newsletters/2019/11/13/#x-only-pubkeys
-    date: 2019-11-13
 
   - title: Safety of precomputed public keys used with schnorr signatures
     url: /en/newsletters/2020/02/05/#safety-concerns-related-to-precomputed-public-keys-used-with-schnorr-signatures
-    date: 2020-02-05
 
   - title: "BIP340 alternative x-only pubkey tiebreaker and tagged hash"
     url: /en/newsletters/2020/02/05/#alternative-x-only-pubkey-tiebreaker
-    date: 2020-02-05
 
   - title: Discussion about taproot versus other schnorr-enabling proposals
     url: /en/newsletters/2020/02/19/#discussion-about-taproot-versus-alternatives
-    date: 2020-02-19
 
   - title: Proposed update to schnorr key selection and signature generation
     url: /en/newsletters/2020/03/04/#updates-to-bip340-schnorr-keys-and-signatures
-    date: 2020-03-04
 
   - title: BIP340 schnorr signature recommendations updated for improved security
     url: /en/newsletters/2020/03/04/#bips-886
-    date: 2020-03-04
 
   - title: Implementing statechains without schnorr signatures
     url: /en/newsletters/2020/04/01/#implementing-statechains-without-schnorr-or-eltoo
-    date: 2020-04-01
 
   - title: Mitigating differential power analysis in schnorr signatures
     url: /en/newsletters/2020/04/01/#mitigating-differential-power-analysis-in-schnorr-signatures
-    date: 2020-04-01
 
   - title: "BIP340 schnorr updated with alternative tiebreaker & nonce recommendation"
     url: /en/newsletters/2020/05/06/#bips-893
-    date: 2020-05-06
 
   - title: RFC6979 nonce generation versus BIP340's recommended procedure
     url: /en/newsletters/2020/05/27/#why-isn-t-rfc6979-used-for-schnorr-signature-nonce-generation
-    date: 2020-05-27
 
   - title: Presentations and discussions about schnorr signatures
     url: /en/newsletters/2020/07/01/#schnorr-signatures-and-multisignatures
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/sidechains.md
+++ b/_topics/en/sidechains.md
@@ -46,7 +46,6 @@ optech_mentions:
 
   - title: "Notable changes: BIP301"
     url: /en/newsletters/2019/07/31/#bips-643
-    date: 2019-07-31
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/sighash_noinput.md
+++ b/_topics/en/sighash_noinput.md
@@ -34,63 +34,48 @@ primary_sources:
 optech_mentions:
   - title: Renaming of `SIGHASH_NOINPUT` to `SIGHASH_NOINPUT_UNSAFE`
     url: /en/newsletters/2018/07/17/#naming-of-sighash-noinput
-    date: 2018-07-17
 
   - title: "Discussion of the evolution of script: `SIGHASH_NOINPUT_UNSAFE`"
     url: /en/newsletters/2018/10/09/#discussion-the-evolution-of-bitcoin-script
-    date: 2018-10-09
 
   - title: Proposal included additional data in sighashes
     url: /en/newsletters/2018/11/27/#sighash-updates
-    date: 2018-11-27
 
   - title: "`SIGHASH_NOINPUT_UNSAFE` edge cases"
     url: /en/newsletters/2019/01/08/#continued-sighash-discussion
-    date: 2019-01-08
 
   - title: Tagging outputs to increase safety of `SIGHASH_NOINPUT_UNSAFE`
     url: /en/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
-    date: 2019-02-19
 
   - title: Discussion about increasing `SIGHASH_NOINPUT_UNSAFE` safety
     url: /en/newsletters/2019/03/19/#more-discussion-about-sighash-noinput-unsafe
-    date: 2019-03-19
 
   - title: New proposed `SIGHASH_ANYPREVOUT` mode
     url: /en/newsletters/2019/05/21/#proposed-anyprevout-sighash-modes
-    date: 2019-05-21
 
   - title: Criticism of `SIGHASH_ANYPREVOUT` and a generic alternative
     url: /en/newsletters/2019/05/29/#not-generic-enough
-    date: 2019-05-29
 
   - title: Continued discussion of noinput/anyprevout
     url: /en/newsletters/2019/10/09/#continued-discussion-about-noinput-anyprevout
-    date: 2019-10-09
 
   - title: "2018 year-in-review: `SIGHASH_NOINPUT`"
     url: /en/newsletters/2018/12/28#sighash_noinput
-    date: 2018-12-28
 
   - title: "2019 year-in-review: `SIGHASH_ANYPREVOUT`"
     url: /en/newsletters/2019/12/28/#anyprevout
-    date: 2019-12-28
 
   - title: "Modification to `SIGHASH_ANYPREVOUTANYSCRIPT` to improve eltoo flexibility"
     url: /en/newsletters/2020/01/29/#layered-commitments-with-eltoo
-    date: 2020-01-29
 
   - title: "Impact of SIGHASH_NOINPUT and eltoo on LN backups"
     url: /en/newsletters/2020/06/03/#ln-backups
-    date: 2020-06-03
 
   - title: "Coinpool: using SIGHASH_NOINPUT to help create payment pools"
     url: /en/newsletters/2020/06/17/#coinpool-generalized-privacy-for-identifiable-onchain-protocols
-    date: 2020-06-17
 
   - title: "Request to replace BIP118 with the `SIGHASH_ANYPREVOUT` proposal"
     url: /en/newsletters/2020/07/15/#bip118-update
-    date: 2020-07-15
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/signet.md
+++ b/_topics/en/signet.md
@@ -37,39 +37,30 @@ primary_sources:
 optech_mentions:
   - title: Feedback requested on signet
     url: /en/newsletters/2019/03/12/#feedback-requested-on-signet
-    date: 2019-03-12
 
   - title: "CoreDev.tech discussion: signet"
     url: /en/newsletters/2019/06/12#signet
-    date: 2019-06-12
 
   - title: Progress on signet
     url: /en/newsletters/2019/07/24/#progress-on-signet
-    date: 2019-07-24
 
   - title: C-Lightning adds support for signet
     url: /en/newsletters/2019/07/24/#c-lightning-2816
-    date: 2019-07-24
 
   - title: C-Lightning 0.7.2.1 released with support for signet
     url: /en/newsletters/2019/08/21/#upgrade-to-c-lightning-0-7-2-1
-    date: 2019-08-21
 
   - title: Eltoo demo implementation using custom signet
     url: /en/newsletters/2019/09/11/#eltoo-sample-implementation-and-discussion
-    date: 2019-09-11
 
   - title: Signet protocol published as BIP325
     url: /en/newsletters/2019/11/13/#bips-803
-    date: 2019-11-13
 
   - title: "2019 year-in-review: signet"
     url: /en/newsletters/2019/12/28/#signet
-    date: 2019-12-28
 
   - title: "BIP325 updated: all signets to use same genesis block but different magic"
     url: /en/newsletters/2020/05/06/#bips-900
-    date: 2020-05-06
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/splicing.md
+++ b/_topics/en/splicing.md
@@ -56,15 +56,12 @@ primary_sources:
 optech_mentions:
   - title: Proposals for LN splicing
     url: /en/newsletters/2018/10/16/#proposal-for-lightning-network-payment-channel-splicing
-    date: 2018-10-16
 
   - title: LN 1.1 protocol goals
     url: /en/newsletters/2018/11/20/#splicing
-    date: 2018-11-20
 
   - title: "2018 year-in-review: splicing"
     url: /en/newsletters/2018/12/28/#splicing
-    date: 2018-12-28
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/spontaneous-payments.md
+++ b/_topics/en/spontaneous-payments.md
@@ -48,47 +48,36 @@ extended_summary: |
 optech_mentions:
   - title: LND PR for spontaneous LN payments
     url: /en/newsletters/2019/01/22/#pr-opened-for-spontaneous-ln-payments
-    date: 2019-01-22
 
   - title: Using ECDH for uncoordinated LN payments
     url: /en/newsletters/2019/06/19/#using-ecdh-for-uncoordinated-ln-payments
-    date: 2019-06-19
 
   - title: Eclair 0.3.3 adds experimental support for trampoline payments
     url: /en/newsletters/2020/02/05/#upgrade-to-eclair-0-3-3
-    date: 2020-02-05
 
   - title: "C-Lightning #3611 adds a keysend plugin to support spontaneous payments"
     url: /en/newsletters/2020/04/22/#c-lightning-3611
-    date: 2020-04-22
 
   - title: "C-Lightning 0.8.2 released with a plugin for sending spontaneous payments"
     url: /en/newsletters/2020/05/06/#c-lightning-0-8-2
-    date: 2020-05-06
 
   - title: Juggernaut uses spontaneous payments for messaging and instant payments"
     url: /en/newsletters/2020/05/20/#lightning-based-messenger-application-juggernaut-launches
-    date: 2020-05-20
 
   - title: Breez wallet adds support for spontaneous payments
     url: /en/newsletters/2020/05/20/#breez-wallet-enables-spontaneous-payments
-    date: 2020-05-20
 
   - title: "LND #4167 allows spontaneous payments made using keysend to be held"
     url: /en/newsletters/2020/07/08/#lnd-4167
-    date: 2020-07-08
 
   - title: Zap 0.7.0 Beta adds support for spontaneous payments
     url: /en/newsletters/2020/07/22/#zap-0-7-0-beta-released
-    date: 2020-07-22
 
   - title: "C-Lightning #3792 adds support for sending keysend spontaneous payments"
     url: /en/newsletters/2020/07/22/#c-lightning-3792
-    date: 2020-07-22
 
   - title: "Eclair #1485 adds support for keysend spontaneous payments"
     url: /en/newsletters/2020/07/29/#eclair-1485
-    date: 2020-07-29
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -36,7 +36,6 @@ primary_sources:
 optech_mentions:
   - title: Reducing taproot commitment size
     url: /en/newsletters/2019/05/29/#move-the-oddness-byte
-    date: 2019-05-29
 
   - title: "Executive briefing: the next soft fork"
     url: /en/2019-exec-briefing/#the-next-softfork
@@ -45,32 +44,25 @@ optech_mentions:
 
   - title: Overview of Taproot and Tapscript
     url: /en/newsletters/2019/05/14/#soft-fork-discussion
-    date: 2019-05-14
 
   - title: Extended summary of bip-taproot and bip-tapscript
     url: /en/newsletters/2019/05/14/#overview-of-the-taproot--tapscript-proposed-bips
-    date: 2019-05-14
     feature: true
 
   - title: Taproot (major developments of 2018, January)
     url: /en/newsletters/2018/12/28/#taproot
-    date: 2018-12-28
 
   - title: What a taproot soft fork might look like
     url: /en/newsletters/2018/12/18/#description-about-what-might-be-included-in-a-schnorr-taproot-soft-fork
-    date: 2018-12-18
 
   - title: "Suggested removal of P2SH address wrapper from taproot proposal"
     url: /en/newsletters/2019/09/25/#comment-if-you-expect-to-need-p2sh-wrapped-taproot-addresses
-    date: 2019-09-25
 
   - title: Update on changes to schnorr, taproot, and tapscript
     url: /en/newsletters/2019/10/16/#taproot-update
-    date: 2019-10-16
 
   - title: Announcement of structured taproot review
     url: /en/newsletters/2019/10/23/#taproot-review
-    date: 2019-10-23
 
   - title: Bitcoin Optech schnorr/taproot workshop
     url: /en/schorr-taproot-workshop/
@@ -79,79 +71,60 @@ optech_mentions:
 
   - title: Impact of bech32 length-change mutablity on v1 segwit script length
     url: /en/newsletters/2019/11/13/#taproot-review-discussion-and-related-information
-    date: 2019-11-13
 
   - title: Blog post about x-only schnorr pubkeys
     url: /en/newsletters/2019/11/13/#x-only-pubkeys
-    date: 2019-11-13
 
   - title: "2019 year-in-review: taproot"
     url: /en/newsletters/2019/12/28/#taproot
-    date: 2019-12-28
 
   - title: Final organized review, presentation slides, and LN integration ideas
     url: /en/newsletters/2020/01/08/#final-week-of-organized-taproot-review
-    date: 2020-01-08
 
   - title: btcdeb adds `tap` command for experimenting with taproot and tapscript
     url: /en/newsletters/2020/02/05/#taproot-and-tapscript-experimentation-tool
-    date: 2020-02-05
 
   - title: Discussion about taproot versus alternatives
     url: /en/newsletters/2020/02/19/#discussion-about-taproot-versus-alternatives
-    date: 2020-02-19
 
   - title: Taproot security from quantum computing threats
     url: /en/newsletters/2020/02/26/#could-taproot-create-larger-security-risks-or-hinder-future-protocol-adjustments-re-quantum-threats
-    date: 2020-02-26
 
   - title: "Security analysis: taproot in the generic group model"
     url: /en/newsletters/2020/03/04/#taproot-in-the-generic-group-model
-    date: 2020-03-04
 
   - title: Request for additional signature commitment to previous scriptPubKeys
     url: /en/newsletters/2020/05/13/#request-for-an-additional-taproot-signature-commitment
-    date: 2020-05-13
 
   - title: "Request for comments on amending BIP341 taproot transaction digest"
     url: /en/newsletters/2020/05/20/#evaluate-proposed-changes-to-bip341-taproot-transaction-digest
-    date: 2020-05-28
 
   - title: Example sizes of multisig taproot transactions
     url: /en/newsletters/2020/05/27/#what-are-the-sizes-of-single-sig-and-2-of-3-multisig-taproot-inputs
-    date: 2020-05-27
 
   - title: Taproot eliminates vulnerability related to segwit fee overpayment attack
     url: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
-    date: 2020-06-10
 
   - title: BIP341 transaction digest amended with extra commitment to scriptPubKeys
     url: /en/newsletters/2020/06/10/#bips-920
-    date: 2020-06-10
 
   - title: "Coinpool: using taproot to help create payment pools"
     url: /en/newsletters/2020/06/17/#coinpool-generalized-privacy-for-identifiable-onchain-protocols
-    date: 2020-06-17
 
   - title: New chatroom for discussing taproot activation
     url: /en/newsletters/2020/07/22/#new-irc-room
-    date: 2020-07-22
 
   - title: Upgrading LN commitment formats, including for taproot
     url: /en/newsletters/2020/07/29/#upgrading-channel-commitment-formats
-    date: 2020-07-29
 
   - title: Question about leaf versions in taproot
     url: /en/newsletters/2020/07/29/#what-are-leaf-versions-in-taproot
-    date: 2020-07-29
 
   - title: Question about the different features in taproot for upgrading
     url: /en/newsletters/2020/07/29/#what-are-the-different-upgradability-features-in-the-bip-taproot-bip341-proposal
-    date: 2020-07-29
 
   - title: Discussion about backporting wtxid relay for taproot activation
     url: /en/newsletters/2020/07/29/#bitcoin-core-18044
-    date: 2020-07-29
 
 ## Optional
 see_also:

--- a/_topics/en/tapscript.md
+++ b/_topics/en/tapscript.md
@@ -45,24 +45,19 @@ optech_mentions:
 
   - title: Extended summary of bip-taproot and bip-tapscript
     url: /en/newsletters/2019/05/14/#overview-of-the-taproot--tapscript-proposed-bips
-    date: 2019-05-14
     feature: true
 
   - title: Overview of Taproot and Tapscript
     url: /en/newsletters/2019/05/14/#soft-fork-discussion
-    date: 2019-05-14
 
   - title: Tapscript resource limits
     url: /en/newsletters/2019/09/25/#tapscript-resource-limits
-    date: 2019-09-25
 
   - title: Update on changes to schnorr, taproot, and tapscript
     url: /en/newsletters/2019/10/16/#taproot-update
-    date: 2019-10-16
 
   - title: Announcement of structured taproot review (including tapscript)
     url: /en/newsletters/2019/10/23/#taproot-review
-    date: 2019-10-23
 
   - title: Bitcoin Optech schnorr/taproot workshop
     url: /en/schorr-taproot-workshop/
@@ -71,19 +66,15 @@ optech_mentions:
 
   - title: Discussion about position commitments using signature-checking opcodes
     url: /en/newsletters/2019/12/04/#continued-schnorr-taproot-discussion
-    date: 2019-12-04
 
   - title: "2019 year-in-review: taproot and tapscript"
     url: /en/newsletters/2019/12/28/#taproot
-    date: 2019-12-28
 
   - title: btcdeb adds `tap` command for experimenting with taproot and tapscript
     url: /en/newsletters/2020/02/05/#taproot-and-tapscript-experimentation-tool
-    date: 2020-02-05
 
   - title: "Bitcoin Core #16902 fixes an inefficiency in OP_IF related opcodes"
     url: /en/newsletters/2020/03/18/#bitcoin-core-16902
-    date: 2020-03-18
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/trampoline-payments.md
+++ b/_topics/en/trampoline-payments.md
@@ -43,19 +43,15 @@ primary_sources:
 optech_mentions:
   - title: Trampoline payments for LN
     url: /en/newsletters/2019/04/02/#trampoline-payments-for-ln
-    date: 2019-04-02
 
   - title: BOLT PR and discussion about trampoline payments
     url: /en/newsletters/2019/08/07/#trampoline-payments
-    date: 2019-08-07
 
   - title: "Eclair #1209 adds experimental support for trampoline onion format"
     url: /en/newsletters/2019/11/20/#eclair-1209
-    date: 2019-11-20
 
   - title: "2019 year-in-review: trampoline payments"
     url: /en/newsletters/2019/12/28/#trampoline
-    date: 2019-12-28
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/transaction-bloom-filtering.md
+++ b/_topics/en/transaction-bloom-filtering.md
@@ -77,19 +77,15 @@ primary_sources:
 optech_mentions:
   - title: Bitcoin Core PR#16152 disables bloom filter support by default
     url: /en/newsletters/2019/07/24/#bitcoin-core-16152
-    date: 2019-07-24
 
   - title: Mailing list discussion about disabling bloom filters in Bitcoin Core
     url: /en/newsletters/2019/07/31/#bloom-filter-discussion
-    date: 2019-07-31
 
   - title: Bitcoin Core 0.19 released with bloom filters disabled
     url: /en/newsletters/2019/11/27/#deprecated-or-removed-features
-    date: 2019-11-27
 
   - title: "Bitcoin Core PR#16248 adds bloom filter whitelist option"
     url: /en/newsletters/2019/08/21/#bitcoin-core-16248
-    date: 2019-08-21
 
   - title: "BRD field report: using native segwit addresses with bloom filters"
     url: /en/bech32-sending-support/#brd-field-report
@@ -97,7 +93,6 @@ optech_mentions:
 
   - title: "Bitcoin Core #19260 disconnects peers who inappropriately send filterclear"
     url: /en/newsletters/2020/06/24/#bitcoin-core-19260
-    date: 2020-06-24
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/transaction-pinning.md
+++ b/_topics/en/transaction-pinning.md
@@ -65,15 +65,12 @@ extended_summary: |
 optech_mentions:
   - title: What is transaction pinning?
     url: /en/newsletters/2018/11/27/#what-is-transaction-pinning
-    date: 2018-11-27
 
   - title: Eltoo may not be entirely reliable because of transaction pinning
     url: /en/newsletters/2018/12/28/#april
-    date: 2018-12-28
 
   - title: Proposal to override some BIP125 RBF conditions to avoid pinning
     url: /en/newsletters/2019/06/12/#proposal-to-override-some-bip125-rbf-conditions
-    date: 2019-06-12
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/unannounced-channels.md
+++ b/_topics/en/unannounced-channels.md
@@ -43,39 +43,30 @@ extended_summary: |
 optech_mentions:
   - title: "LND #1944 tweaks `sendtoroute` RPC to allow routing via private channels"
     url: /en/newsletters/2018/11/13/#lnd-1944
-    date: 2018-11-13
 
   - title: "C-Lightning #2230 adds a `private` flag to the `listpeers` RPC"
     url: /en/newsletters/2019/01/15/#c-lightning-2230
-    date: 2019-01-15
 
   - title: "C-Lightning #2234 adds route hints for private channels to `invoice` RPC"
     url: /en/newsletters/2019/01/22/#c-lightning-2234
-    date: 2019-01-22
 
   - title: "Talk about LN topology and lack of public info about unannounced channels"
     url: /en/newsletters/2019/09/18/#lightning-network-topology
-    date: 2019-09-18
 
   - title: "C-Lightning #3351 enhances `invoice` RPC for private channels"
     url: /en/newsletters/2020/01/08/#c-lightning-3351
-    date: 2020-01-08
 
   - title: "Eclair #1283 allows multipath payments to traverse unannounced channels"
     url: /en/newsletters/2020/01/22/#eclair-1283
-    date: 2020-01-22
 
   - title: "Breaking the link between UTXOs and unannounced channels"
     url: /en/newsletters/2020/01/29/#breaking-the-link-between-utxos-and-unannounced-channels
-    date: 2020-01-29
 
   - title: "C-Lightning #3600 adds blinded paths to improve unannounced channel privacy"
     url: /en/newsletters/2020/04/08/#c-lightning-3600
-    date: 2020-04-08
 
   - title: "C-Lighting #3623 improves unannounced channel privacy when routing payments"
     url: /en/newsletters/2020/04/22/#c-lightning-3623
-    date: 2020-04-22
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/utreexo.md
+++ b/_topics/en/utreexo.md
@@ -34,15 +34,12 @@ primary_sources:
 optech_mentions:
   - title: "CoreDev.Tech summaries: Utreexo"
     url: /en/newsletters/2018/10/16/#using-utxo-accumulators-to-reduce-data-storage-requirements-utreexo
-    date: 2018-10-16
 
   - title: Exploring accumulators
     url: /en/newsletters/2019/02/05/#accumulators-for-blockchains
-    date: 2019-02-05
 
   - title: Utreexo Q&A session at CoreDev.Tech
     url: /en/newsletters/2019/06/12/#utreexo
-    date: 2019-06-12
 
 ## Optional.  Same format as "primary_sources" above
 # see_also:

--- a/_topics/en/v2-p2p-transport.md
+++ b/_topics/en/v2-p2p-transport.md
@@ -35,23 +35,18 @@ primary_sources:
 optech_mentions:
   - title: Continuing work on P2P protocol encryption
     url: /en/newsletters/2018/08/21/#p2p-protocol-encryption
-    date: 2018-08-21
 
   - title: PR opened for initial BIP151 support
     url: /en/newsletters/2018/08/28/#pr-opened-for-initial-bip151-support
-    date: 2018-08-28
 
   - title: Criticism and defense of BIP151 choices
     url: /en/newsletters/2018/09/11/#bip151-discussion
-    date: 2018-09-11
 
   - title: Announcement of v2 P2P transport proposal
     url: /en/newsletters/2019/03/26/#version-2-p2p-transport-proposal
-    date: 2019-03-26
 
   - title: "CoreDev.tech discussion of v2 P2P transport proposal"
     url: /en/newsletters/2019/06/12/#v2-p2p
-    date: 2019-06-12
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/vaults.md
+++ b/_topics/en/vaults.md
@@ -58,31 +58,24 @@ primary_sources:
 optech_mentions:
   - title: "Bitcoin vaults without covenants & weaknesses in previous vault proposals"
     url: /en/newsletters/2019/08/14/#bitcoin-vaults-without-covenants
-    date: 2019-08-14
 
   - title: "2019 year-in-review: vaults without covenants"
     url: /en/newsletters/2019/12/28/#vaults
-    date: 2019-12-28
 
   - title: "OP_CHECKTEMPLATEVERIFY (CTV) workshop discussion: using CTV with vaults"
     url: /en/newsletters/2020/02/12/#op-checktemplateverify-ctv-workshop
-    date: 2020-02-12
 
   - title: Vault prototype written in Python
     url: /en/newsletters/2020/04/22/#vaults-prototype
-    date: 2020-04-22
 
   - title: "Revault: an implementation of multiparty vaults"
     url: /en/newsletters/2020/04/29/#multiparty-vault-architecture
-    date: 2020-04-29
 
   - title: Presentation of the Revault multiparty vault architecture
     url: /en/newsletters/2020/06/03/#the-revault-multiparty-vault-architecture
-    date: 2020-06-03
 
   - title: Service proposed for storing presigned vault transactions
     url: /en/newsletters/2020/07/01/#proposed-service-for-storing-relaying-and-broadcasting-presigned-transactions
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/_topics/en/watchtowers.md
+++ b/_topics/en/watchtowers.md
@@ -34,67 +34,51 @@ extended_summary: |
 optech_mentions:
   - title: "LND PR #1543 adding watchtower version 0 encoding and encryption"
     url: /en/newsletters/2018/08/07/#lnd-1543
-    date: 2018-08-07
 
   - title: "LND PRs #1535 and #1512 adding server-side communication for watchtowers"
     url: /en/newsletters/2018/10/30/#lnd-1535-1512
-    date: 2018-10-30
 
   - title: "LND PR #2124 adding support for detecting and using onchain spends"
     url: /en/newsletters/2018/11/20/#lnd-2124
-    date: 2018-11-20
 
   - title: "LND PR #2448 adding a standalone watchtower"
     url: /en/newsletters/2019/01/22/#lnd-2448
-    date: 2019-01-22
 
   - title: "LND PR #2439 adding a default policy for the watchtower"
     url: /en/newsletters/2019/01/22/#lnd-2439
-    date: 2019-01-22
 
   - title: "LND PR #2618 implementing private watchtower support"
     url: /en/newsletters/2019/03/19/#lnd-2618
-    date: 2019-03-19
 
   - title: "LND PR #3133 adding support for altruist watchtowers"
     url: /en/newsletters/2019/06/19/#lnd-3133
-    date: 2019-06-19
 
   - title: LND 0.7.0-beta release with initial watchtower support
     url: /en/newsletters/2019/07/03/#lnd-0-7-0-beta-released
-    date: 2019-07-03
 
   - title: Watchtower storage costs
     url: /en/newsletters/2019/09/25/#watchtower-storage-costs
-    date: 2019-09-25
 
   - title: Watchtower BOLT specification proposed
     url: /en/newsletters/2019/12/04/#proposed-watchtower-bolt
-    date: 2019-12-04
 
   - title: Discussion about watchtowers for eltoo payment channels
     url: /en/newsletters/2019/12/11/#watchtowers-for-eltoo-payment-channels
-    date: 2019-12-11
 
   - title: "2019 year-in-review: watchtowers"
     url: /en/newsletters/2019/12/28/#watchtowers
-    date: 2019-12-28
 
   - title: Updated watchtower BOLT specification proposal
     url: /en/newsletters/2020/03/18/#proposed-watchtower-bolt-has-been-updated
-    date: 2020-03-18
 
   - title: "C-Lightning #3659 adds support for watchtowers"
     url: /en/newsletters/2020/05/13/#c-lightning-3659
-    date: 2020-05-13
 
   - title: Service proposed for storing presigned watchtower transactions
     url: /en/newsletters/2020/07/01/#proposed-service-for-storing-relaying-and-broadcasting-presigned-transactions
-    date: 2020-07-01
 
   - title: Presentation about watchtower protocol development
     url: /en/newsletters/2020/07/01/#watchtowers-and-bolt13
-    date: 2020-07-01
 
 ## Optional.  Same format as "primary_sources" above
 see_also:

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -281,3 +281,7 @@ ul.li {
   font-style: italic;
   cursor: pointer;
 }
+
+.bold {
+  font-weight: 700;
+}

--- a/en/topic-dates.md
+++ b/en/topic-dates.md
@@ -30,7 +30,8 @@ before the main content -->
     {%- for topic in site.topics -%}
     {%- assign mymentions = '' -%}
       {%- for mention in topic.optech_mentions -%}
-        {%- assign mydate = mention.date | date: "%Y-%m-%d" -%}
+        {%- include functions/get-mention-date.md -%}
+        {%- assign mydate = date | date: "%Y-%m-%d" -%}
         {%- if mydate contains month -%}
           {% capture mymentions %}{{mymentions}}{{mention.title | markdownify | remove: "<p>" | remove: "</p>" | strip }}&nbsp;<a href="{{mention.url}}">🔗</a>ENDMENTION{% endcapture %}
           {% assign number_of_events = number_of_events | plus: 1 %}


### PR DESCRIPTION
Less typing for Harding, less checking for reviewers, and fewer typos.

This caught 5 inconsistencies between the date field and the newsletter date of publication:

```
diff -r _site.old/en/topics/hwi/index.html _site/en/topics/hwi/index.html
94c94
<   <li>2019-12-18 <a href="/en/newsletters/2019/12/28/#core-hwi">2019 year-in-review: HWI</a></li>
---
>   <li>2019-12-28 <a href="/en/newsletters/2019/12/28/#core-hwi">2019 year-in-review: HWI</a></li>
diff -r _site.old/en/topics/multipath-payments/index.html _site/en/topics/multipath-payments/index.html
140c140
<   <li>2019-09-15 <a href="/en/newsletters/2019/09/11/#lnd-3390">LND #3390 separates tracking of HTLCs from invoices as necessary for AMP</a></li>
---
>   <li>2019-09-11 <a href="/en/newsletters/2019/09/11/#lnd-3390">LND #3390 separates tracking of HTLCs from invoices as necessary for AMP</a></li>
diff -r _site.old/en/topics/musig/index.html _site/en/topics/musig/index.html
100c100
<   <li>2019-12-30 <a href="/en/newsletters/2019/12/04/#composable-musig">Composable MuSig—concerns about safely using signer sub-groups</a></li>
---
>   <li>2019-12-04 <a href="/en/newsletters/2019/12/04/#composable-musig">Composable MuSig—concerns about safely using signer sub-groups</a></li>
diff -r _site.old/en/topics/op_checktemplateverify/index.html _site/en/topics/op_checktemplateverify/index.html
113c113
<   <li>2020-02-19 <a href="/en/newsletters/2020/04/22/#vaults-prototype">Vault prototype with sample implementation using OP_CHECKTEMPLATEVERIFY</a></li>
---
>   <li>2020-04-22 <a href="/en/newsletters/2020/04/22/#vaults-prototype">Vault prototype with sample implementation using OP_CHECKTEMPLATEVERIFY</a></li>
diff -r _site.old/en/topics/taproot/index.html _site/en/topics/taproot/index.html
101c101
<   <li>2020-05-28 <a href="/en/newsletters/2020/05/20/#evaluate-proposed-changes-to-bip341-taproot-transaction-digest">Request for comments on amending BIP341 taproot transaction digest</a></li>
---
>   <li>2020-05-20 <a href="/en/newsletters/2020/05/20/#evaluate-proposed-changes-to-bip341-taproot-transaction-digest">Request for comments on amending BIP341 taproot transaction digest</a></li>
```

The date field can be removed from all newsletter references after this PR (or in the same PR if desired)

We can also swap the order of the conditional if we want the option of overriding the newsletter publication date.