### PR TITLE
References: deprecated some old quick links

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -28,24 +28,31 @@
 [bolts repo]: https://github.com/lightningnetwork/lightning-rfc/
 [c-lightning]: https://github.com/ElementsProject/lightning
 [c-lightning repo]: https://github.com/ElementsProject/lightning
-[cve-2012-2459]: https://bitcointalk.org/?topic=102395
-[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842
-[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144
-[descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 [eclair repo]: https://github.com/ACINQ/eclair
-[eltoo]: https://blockstream.com/eltoo.pdf
-[erlay]: https://arxiv.org/pdf/1905.10518.pdf
-[hwi]: https://github.com/bitcoin-core/HWI
+[hwi repo]: https://github.com/bitcoin-core/HWI
 [libminisketch]: https://github.com/sipa/minisketch
 [libsecp256k1]: https://github.com/bitcoin-core/secp256k1
 [libsecp256k1 repo]: https://github.com/bitcoin-core/secp256k1
 [lnd repo]: https://github.com/lightningnetwork/lnd/
+[rust-lightning repo]: https://github.com/rust-bitcoin/rust-lightning
+
+{% comment %}<!-- deprecated links; don't use these any more -->{% endcomment %}
+{% assign pagedate_epoch = page.date | date: '%s' %}
+{% assign deprecated_links_v0_epoch = '2020-09-24' | date: '%s' %}
+{% if pagedate_epoch < deprecated_links_v0_epoch %}
+[cve-2012-2459]: https://bitcointalk.org/?topic=102395
+[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842
+[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144
+[eltoo]: https://blockstream.com/eltoo.pdf
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf
+[hwi]: https://github.com/bitcoin-core/HWI
 [miniscript]: /en/topics/miniscript/
 [musig]: https://eprint.iacr.org/2018/068
 {% assign _link_descriptors = 'https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md' %}
+[descriptor]: {{_link_descriptors}}
 [output script descriptor]: {{_link_descriptors}}
 [output script descriptors]: {{_link_descriptors}}
-[rust-lightning repo]: https://github.com/rust-bitcoin/rust-lightning
+{% endif %}
 
 {% comment %}<!-- BIPs in order lowest to highest
 Note: as of 2019-02-24/Jekyll 3.8.3, this is currently inefficient as

--- a/_topics/en/cve-2018-17144.md
+++ b/_topics/en/cve-2018-17144.md
@@ -56,6 +56,7 @@ extended_summary: |
 ## "[title](link)"
 primary_sources:
     - title: CVE-2018-17144
+      link: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144
     - title: CVE-2018-17144 Full Disclosure
       link: https://bitcoincore.org/en/2018/09/20/notice/
     - title: "Bitcoin Core PR #14247: Fix crash bug with duplicate inputs within a transaction"

--- a/_topics/en/eltoo.md
+++ b/_topics/en/eltoo.md
@@ -36,6 +36,7 @@ extended_summary: |
 ## "[title](link)"
 primary_sources:
     - title: Eltoo
+      link: https://blockstream.com/eltoo.pdf
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry

--- a/_topics/en/erlay.md
+++ b/_topics/en/erlay.md
@@ -37,6 +37,7 @@ extended_summary: |
 ## "[title](link)"
 primary_sources:
     - title: Erlay
+      link: https://arxiv.org/pdf/1905.10518.pdf
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry

--- a/_topics/en/musig.md
+++ b/_topics/en/musig.md
@@ -34,7 +34,7 @@ extended_summary: |
 ## "[title](link)"
 primary_sources:
     - title: MuSig paper
-      link: musig
+      link: https://eprint.iacr.org/2018/068
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry

--- a/_topics/en/output-script-descriptors.md
+++ b/_topics/en/output-script-descriptors.md
@@ -31,6 +31,7 @@ extended_summary: |
 ## "[title](link)"
 primary_sources:
     - title: Output script descriptors
+      link: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -18,7 +18,7 @@ excerpt: >
 extended_summary: |
   Schnorr is secure under the same cryptographic assumptions as
   [ECDSA][] and it is easier and faster to create secure multiparty
-  signatures using schnorr with protocols such as [MuSig][].  A new
+  signatures using schnorr with protocols such as [MuSig][topic musig].  A new
   signature type also provides an opportunity to change the signature
   serialization format from [BER/DER][] to something that's more compact
   and simpler to implement.

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -20,7 +20,7 @@ extended_summary: |
   the committed scripts or by simply providing a signature that verifies
   against the public key (allowing the script to be kept private).
   Taproot is intended for use with schnorr signatures that simplify
-  multiparty construction (e.g. using [MuSig][]) and with MAST to
+  multiparty construction (e.g. using [MuSig][topic musig]) and with MAST to
   allow committing to more than one script, any one of which may be
   used at spend time.
 


### PR DESCRIPTION
In last week's newsletter, @bitschmidty [caught](https://github.com/bitcoinops/bitcoinops.github.io/pull/459#discussion_r492166331) me accidentally linking directly to Wuille's miniscript page rather than the Optech topic page I wanted.  This happened because, prior to the addition of the topics page, I had defined some quick reference links for highly-referenced subjects; obviously, many of those subjects later became topics.

This PR deprecates those old links.  On pages with dates in the past, the old link definitions will be used.  On pages with newer dates (or no dates at all, like the topic pages), the old link definitions aren't evaluated and so the hyperlink won't be generated, causing the post-build test to fail---hopefully ensuring I insert the appropriate topic link (or whatever).

Except for two places where we revise a link on a topics page to point at another topics page (rather than a primary source), this PR should not result in any changes to the compiled site.