### PR TITLE
news125: PR 20305 fixup

### DIFF
--- a/_posts/en/newsletters/2020-11-25-newsletter.md
+++ b/_posts/en/newsletters/2020-11-25-newsletter.md
@@ -99,7 +99,7 @@ version 0.21.*
 
 - [Bitcoin Core #20305][] starts shifting RPC feerate units to satoshis
   per vbyte (sat/vB) rather than BTC per 1,000 vbytes (BTC/kvB) by introducing a
-  `fee_rate` parameter to the `sendtoaddress`,
+  `fee_rate` parameter/option denominated in sat/vB to the `sendtoaddress`,
   `sendmany`, `fundrawtransaction`, and `walletcreatefundedpsbt` RPCs as well as
   to the experimental [new][news116 send] `send` RPC. In addition, the `bumpfee` RPC `fee_rate`
   option is changed from BTC/kB to sat/vB. Users are warned that the latter is a


### PR DESCRIPTION
During the multiple edits of this writeup, I didn't notice that the unit of the new `fee_rate` was removed, without which it no longer makes sense in the writeup why `fee_rate` was added.

I also didn't notice that "option" was removed in favor of parameter only, which is somewhat incorrect, as `fee_rate` is an option, not a param, in several of the changed RPCs.

- re-add "denominated in sat/vB"

- re-add "option"