### PR TITLE
Style: update currency abbreviations, including for feerates

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -127,12 +127,36 @@ spelled the same.
 
 ## Units
 
-- **Currency:** all amounts should be denominated in BTC.  E.g. "the
-  default minimum relay fee is 0.00000001 BTC/vbyte".  When writing out
-  the name of the currency, pluralize by appending an `s`.  E.g. "Alice
-  owns several bitcoins" not ~~"Alice owns several bitcoin"~~.
+- **Currency:** acceptable units and abbreviations are:
 
-- **Weight:** use vbytes rather than weight units, unless using weight
+    | Unit | Abbreviations | Value | &nbsp; |
+    |-|-|-|-|
+    | bitcoins | **BTC** | |
+    | millibitcoins | mBTC | 0.001 BTC | 1e-3 BTC |
+    | microbitcoins | µBTC, uBTC | 0.000001 BTC | 1e-6 BTC |
+    | satoshis | **sat** | 0.00000001 BTC | 1e-8 BTC |
+    | nanobitcoins | nBTC | 0.000000001 BTC | 1e-9 BTC |
+    | millisatoshis | msat | 0.00000000001 BTC | 1e-11 BTC |
+    | picobitcoins | pBTC | 0.000000000001 BTC | 1e-12 BTC |
+
+    The abbreviations bolded above may always be used without
+    introduction; we encourage introduction of other abbreviations, e.g.
+    "you can send 1 millisatoshi (msat) on LN".
+
+    The pluralization and agreement rules for bitcoin/bitcoins,
+    satoshi/satoshis, and derived units are the same as for
+    dollar/dollars (USD).  Similarly, abbreviations are never
+    pluralized.
+
+- **Feerates:** the preferred unit is "sat/vbyte" (satoshis per vbyte).
+  When used only sporadically within a page or section, it is preferred
+  to write out "sat/vbyte" each time, but when used frequently, you may
+  introduce and use the abbreviation "sat/vB".  See note in
+  *weight/vbytes* item about using SI prefixes.
+
+- **Weight/vbytes:** use vbytes rather than weight units, unless using weight
   units would significantly improve conciseness or comprehensibility.
   You may use fractional vbytes, but consider adding a note that
-  production uses of vbytes require they be rounded up.
+  production uses of vbytes require they be rounded up.  When using SI
+  prefixes with vbytes, introduce the unit the first time it is used,
+  e.g. "...BTC per 1,000 vbytes (BTC/kvB)...".


### PR DESCRIPTION
The goal here was to standardize on "sat/vbyte" as our preferred unit for feerates, but this required rewriting the main item for currency units.