### PR TITLE
Topics: replace duplicate entry in PTLCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ test-before-build:
 	## Check that newly added or modifyed PNGs are optimized
 	_contrib/travis-check-png-optimized.sh
 
+	## Check for duplicate links in any particular topic file
+	! git grep url:  _topics/ | sed 's/ \+/ /g' | sort | uniq -d | grep .
+
 test-after-build:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .

--- a/_topics/en/ptlc.md
+++ b/_topics/en/ptlc.md
@@ -83,8 +83,8 @@ optech_mentions:
   - title: Using witness asymmetric payment channels for move from HTLCs to PTLCs
     url: /en/newsletters/2020/09/02/#witness-asymmetric-payment-channels
 
-  - title: "Using witness asymmetric payment channels as part of a PTLC implementation"
-    url: /en/newsletters/2020/09/02/#witness-asymmetric-payment-channels
+  - title: Updated witness asymmetric channels proposal for move from HTLCs to PTLCs
+    url: /en/newsletters/2020/10/14/#updated-witness-asymmetric-payment-channel-proposal
 
 ## Optional.  Same format as "primary_sources" above
 see_also:


### PR DESCRIPTION
It seems I accidentally added the same link to the PTLCs topic twice (it was that exciting!).  This replaces the redundancy with a different link and adds a test to hopefully stop me from doing it again.