### PR TITLE
Spelling: s/discrete/discreet/ for DLCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ test-before-build:
 	## Check for duplicate links in any particular topic file
 	! git grep url:  _topics/ | sed 's/ \+/ /g' | sort | uniq -d | grep .
 
+	## Check for mistakes typical spell checkers can't catch
+	! git --no-pager grep -i '[d]iscrete log contract'
+
 test-after-build:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 all: test-before-build build test-after-build
 production: all production-test
 
+## If we call git in our tests without using the --no-pager option
+## or redirecting stdout to another command, fail unconditionally.
+## This addresses an issue where `make` can't be run within an IDE because
+## it tries to paginate the output, see:
+## https://github.com/bitcoinops/bitcoinops.github.io/pull/494#discussion_r546376335
+export GIT_PAGER='_contrib/kill0'
+
 clean:
 	bundle exec jekyll clean
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -109,6 +109,7 @@ spelled the same.
 | Use | Don't use | Notes |
 |-|-|-|
 | adaptor signatures | adapter signatures | |
+| discreet log contracts | discrete<!-- --> log contracts | Remembering to spell this correctly more often than one time in ten is known as the discrete log problem |
 | k-of-n multisig and n-of-n multisignature | m-of-n multisig or any_other_letter-of-any_other_letter multisig | When spoken, 'm-of-n' can easily be confused with 'n-of-n' |
 | light client | lite client | |
 | merklized | merkelized or merkleized | |

--- a/_contrib/kill0
+++ b/_contrib/kill0
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "ERROR: within tests, use: git --no-pager"
+kill 0

--- a/_posts/en/newsletters/2019-05-14-newsletter.md
+++ b/_posts/en/newsletters/2019-05-14-newsletter.md
@@ -481,7 +481,7 @@ have been wanting for years.  The first of these features, Schnorr
 signatures, will make available increased privacy and reduced fees for
 the growing number of Bitcoin users taking advantage of multisig
 security (including LN users), and research into advanced uses of
-Schnorr such as [scriptless scripts][] and [discrete log contracts][]
+Schnorr such as [scriptless scripts][] and [discreet log contracts][]
 may enable many significant improvements in efficiency, privacy, and
 financial contracting without further necessary consensus changes.
 
@@ -587,6 +587,6 @@ the fault of the newsletter author.
 [hsms]: https://en.wikipedia.org/wiki/Hardware_security_module
 [musig]: https://blockstream.com/2018/01/23/en-musig-key-aggregation-schnorr-signatures/
 [scriptless scripts]: http://diyhpl.us/wiki/transcripts/layer2-summit/2018/scriptless-scripts/
-[discrete log contracts]: https://adiabat.github.io/dlc.pdf
+[discreet log contracts]: https://adiabat.github.io/dlc.pdf
 [example implementation]: https://github.com/sipa/bitcoin/commits/taproot
 [bech32 series]: /en/bech32-sending-support/


### PR DESCRIPTION
This fixes a couple puny problems.  h/t @Xekyo 