### PR TITLE
Topics template: sort BIPs in expected order

### DIFF
--- a/_includes/functions/sort-rename.md
+++ b/_includes/functions/sort-rename.md
@@ -1,0 +1,13 @@
+{% capture /dev/null %}
+<!-- rename things for sorting purposes -->
+{% assign _result = include.name %}
+{% if include.name contains "BIP" %}
+  {% assign _strlen = include.name | split: ' ' | first | size %}
+  {% case _strlen %}
+    {% when 4 %}{% assign _result = include.name | replace: "BIP", "BIP000" %}
+    {% when 5 %}{% assign _result = include.name | replace: "BIP", "BIP00" %}
+    {% when 6 %}{% assign _result = include.name | replace: "BIP", "BIP0" %}
+    {% else %}{% include ERROR675_BIP_STRING_DOESNT_MATCH_EXPECTED_PATTERN %}
+  {% endcase %}
+{% endif %}
+{% endcapture %}{{_result}}

--- a/en/topics.md
+++ b/en/topics.md
@@ -12,9 +12,9 @@ links, e.g. <a href=URL>Name</a>, so that it's easy to sort by name
 rather than URL. -->{% endcomment %}
 {% capture raw_topics_list %}
 {%- for topic in site.topics -%}
-  <!--{{topic.title}}-->[{{topic.title}}]({{topic.url}})ENDTOPIC
+  <!--{% include functions/sort-rename.md name=topic.title %}-->[{{topic.title}}]({{topic.url}})ENDTOPIC
   {%- for alias in topic.aliases -%}
-    <!--{{alias}}-->*[{{alias}}]({{topic.url}})*ENDTOPIC
+    <!--{% include functions/sort-rename.md name=alias %}-->*[{{alias}}]({{topic.url}})*ENDTOPIC
   {%- endfor -%}
 {%- endfor -%}
 {% endcapture %}


### PR DESCRIPTION
Because our style guide says not to insert prefix zeros into BIP names (a style I strongly prefer), the topic names and aliases for BIPs were sorting in an unexpected order, e.g. BIP125 appearing before BIP70.  This PR should fix that; screenshot below of live site compared to this commit.

![2021-03-19-10_32_56_232912547](https://user-images.githubusercontent.com/61096/111839619-27922980-889f-11eb-9ee4-466aa3fe22a6.png)
