### PR TITLE
Topics: improve topic descriptions added in Newsletter 149

### DIFF
--- a/_topics/en/psbt.md
+++ b/_topics/en/psbt.md
@@ -138,7 +138,7 @@ optech_mentions:
   - title: "BIPs #1059 publishes the draft specification for v2 PSBTs as BIP370"
     url: /en/newsletters/2021/03/24/#bips-1059
 
-  - title: "LND #5291 improves the way LND ensures PSBTs use segwit inputs"
+  - title: "LND #5291 improves the way it ensures PSBTs use segwit inputs"
     url: /en/newsletters/2021/05/19/#lnd-5291
 
   - title: BlueWallet v6.1.0 adds support for using PSBTs with watch-only wallets

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -71,7 +71,7 @@ optech_mentions:
   - title: CVE-2021-31876 discrepancy between BIP125 and Bitcoin Core implementation
     url: /en/newsletters/2021/05/12/#cve-2021-31876-discrepancy-between-bip125-and-bitcoin-core-implementation
 
-  - title: Continued discussion about CVE-2021-31876
+  - title: "Continued discussion about CVE-2021-31876's impact on protocols using RBF"
     url: /en/newsletters/2021/05/19/#cve-2021-31876-bip125-implementation-discrepancy-follow-up
 
 ## Optional.  Same format as "primary_sources" above


### PR DESCRIPTION
This addresses two comments from @jnewbery regarding the topic links in Newsletter 149.  I do leave unaddressed a couple comments from John about the newsletter content itself, but I think of newsletter content as being mostly static once published, while the topic pages are dynamic.