### PR TITLE
Newsletters: update legacy references to C-Lightning PRs

### DIFF
--- a/_posts/en/newsletters/2018-08-14-newsletter.md
+++ b/_posts/en/newsletters/2018-08-14-newsletter.md
@@ -211,19 +211,19 @@ users and developers highly appreciate that work.*
   automatically converted to the use of satoshis per kiloweight (1,000
   vbytes) as defined in the [protocol][BOLT2].
 
-- C-Lightning: a paying node will no longer send an HTLC commitment
+- [C-Lightning #1811][]: a paying node will no longer send an HTLC commitment
   (payment) to another node unless it's heard from that node within the
   past 30 seconds.  If necessary, it'll ping the recipient node before
   sending the commitment.  This helps the paying node abort a payment
   earlier in the process if that payment was destined to fail anyway
   because of a network interruption.
 
-- C-Lightning: various moderate improvements to the code for
+  Also included are various other moderate improvements to the code for
   reconnecting to disconnected peers, including exponential backoff and
   reconnection time fuzzing.
 
 {% include references.md %}
-{% include linkers/issues.md issues="13922,13907,13925,1644,13666" %}
+{% include linkers/issues.md issues="13922,13907,13925,1644,13666,1811" %}
 
 [news3 lower relay]: {{news3}}#news
 [BOLT2]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md

--- a/_posts/en/newsletters/2018-08-28-newsletter.md
+++ b/_posts/en/newsletters/2018-08-28-newsletter.md
@@ -154,18 +154,18 @@ wait until version 0.18 in about six months from now.*
   spending any of the same inputs with a higher fee as described by
   [BIP125][].
 
-- C-Lightning tagged its first release candidate for version 0.16.1.
+- [C-Lightning #1874][] tagged its first release candidate for version 0.6.1.
 
-- C-Lightning reduced the number of places where it refers to 1,000
+- [C-Lightning #1870][] reduced the number of places where it refers to 1,000
   weight units as "sipa" and began calling them by the more widely
   accepted term "kiloweights" (kw).
 
-- C-Lightning made multiple improvements to how it handles fees,
+  The PR also made multiple improvements to how it handles fees,
   both for on-chain transactions to open and close channels where
   C-Lightning outsources fee estimation to Bitcoin Core, and also for
   fees in payment channels.
 
-- C-Lightning implemented additional parts of [BOLT2][], particularly
+- [C-Lightning #1854][] implemented additional parts of [BOLT2][], particularly
   related to the `option_data_loss_protect` field, to improve handling
   of cases where your node appears to have lost essential data---a
   commitment value---or the remote node is sending invalid commitment
@@ -173,7 +173,7 @@ wait until version 0.18 in about six months from now.*
 
 ---
 {% include references.md %}
-{% include linkers/issues.md issues="14032,12254,12676" %}
+{% include linkers/issues.md issues="14032,12254,12676,1874,1870,1854" %}
 
 [dandelion protocol]: https://arxiv.org/abs/1701.04439
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/

--- a/_posts/en/newsletters/2018-09-04-newsletter.md
+++ b/_posts/en/newsletters/2018-09-04-newsletter.md
@@ -130,14 +130,14 @@ wait until version 0.18 in about six months from now.*
   allowing you to easily discover the minimum feerates being used by
   your peers.
 
-- C-Lightning now allows you to ask lightningd to calculate a feerate
+- [C-Lightning #1887][] now allows you to ask lightningd to calculate a feerate
   target for your on-chain transactions by passing the either "urgent",
   "normal", or "slow" to the `feerate` parameter.  Alternatively, you
   may use this parameter to manually specify a particular feerate you
   want to use.
 
 {% include references.md %}
-{% include linkers/issues.md issues="12952,13987" %}
+{% include linkers/issues.md issues="12952,13987,1887" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
 [dashboard post]: /en/dashboard-announcement/

--- a/_posts/en/newsletters/2018-09-11-newsletter.md
+++ b/_posts/en/newsletters/2018-09-11-newsletter.md
@@ -97,18 +97,18 @@ wait until version 0.18 in about six months from now.*
   Core 0.17 and are expected to be used for other interactions with the
   wallet in the future.
 
-- LND made almost 30 merges in the past week, many of which made
+- **LND** made almost 30 merges in the past week, many of which made
   small enhancements or bugfixes to its autopilot facility---its ability
   to allow users to choose to automatically open new channels with
   automatically-selected peers.  Several merges also updated which
   versions of libraries LND depends upon.
 
-- C-Lightning added several hundred lines of documentation to its
+- [C-Lightning #1899][] added several hundred lines of documentation to its
   repository this week, most of it inline code documentation or updates
   to files in its [/doc directory][c-lightning docs].
 
 {% include references.md %}
-{% include linkers/issues.md issues="12775,12490,14096" %}
+{% include linkers/issues.md issues="12775,12490,14096,1899" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
 [workshop]: /workshops

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -180,12 +180,12 @@ wait until version 0.18 in about six months from now.*
   automation to work, users must already have Tor installed and running
   as a service.
 
-- C-Lightning: for testing, an RPC proxy is now used to simplify mocking
+- [C-Lightning #1860][]: for testing, an RPC proxy is now used to simplify mocking
   responses to various RPC calls, making it easier to test lightningd's
   handling of things such as fee estimates and crashes of bitcoind.
 
 {% include references.md %}
-{% include linkers/issues.md issues="14054,1843,1516,7965,14168,10973,14180" %}
+{% include linkers/issues.md issues="14054,1843,1516,7965,14168,10973,14180,1860" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
 [workshop]: /workshops

--- a/_posts/en/newsletters/2018-09-25-newsletter.md
+++ b/_posts/en/newsletters/2018-09-25-newsletter.md
@@ -154,17 +154,17 @@ wait until version 0.18 in about six months from now.*
   peers into believing a different peer had a routing failure, thus
   possibly redirecting traffic to the malicious node.
 
-- C-Lightning now provides a `gossipwith` tool that allows you to
+- [C-Lightning #1945][] now provides a `gossipwith` tool that allows you to
   receive gossip from a node independently of lightningd or even to send
   the remote node a message.  This tool is used for additional testing
   of lightningd's gossip component.
 
-- C-Lightning now complies with updates to [BOLT7][bolt7] by
+- [C-Lightning #1954][] now complies with updates to [BOLT7][bolt7] by
   splitting the previous `flags` field for the `listchannels` RPC into
   two new fields: `message_flags` and `channel_flags`.  Also code
   comments and references to [BOLT2][] and [BOLT11][] have been updated.
 
-- C-Lightning has significantly expanded the in-code documentation of
+- [C-Lightning #1905][] has significantly expanded the in-code documentation of
   its secrets module.  The documentation is remarkably good (and, at
   times, quite humorous).  See [hsmd.c][].  The code comments even
   document other code comments:
@@ -180,12 +180,12 @@ wait until version 0.18 in about six months from now.*
      derive_funding_key(&channel_seed, &funding_pubkey, &funding_privkey);
     ```
 
-- C-Lightning can now make multiple requests in parallel to bitcoind,
+- [C-Lightning #1947][] can now make multiple requests in parallel to bitcoind,
   speeding up operations on slow systems or on nodes performing long-running
   operations.
 
 {% include references.md %}
-{% include linkers/issues.md issues="13152,1738,1707" %}
+{% include linkers/issues.md issues="13152,1738,1707,1945,1954,1905,1947" %}
 
 {% assign bse = "https://bitcoin.stackexchange.com/a/" %}
 [bse 79484]: {{bse}}79484

--- a/_posts/en/newsletters/2018-11-27-newsletter.md
+++ b/_posts/en/newsletters/2018-11-27-newsletter.md
@@ -161,7 +161,7 @@ commits].*
   all uppercase (but not mixed case) per the [BIP173][] bech32
   specification.
 
-- C-Lightning [<!--c-lightning-->#2081][c-lightning #2081] and [#2092][c-lightning #2092]
+- [C-Lightning #2081][] and [#2092][c-lightning #2092]
   fix a problem with running multiple RPC commands in parallel.  As a
   user-visible change, `lightningd` now adds a double newline (`\n\n`)
   instead of just a single newline to the final output from an RPC.  As

--- a/_posts/en/newsletters/2019-04-23-newsletter.md
+++ b/_posts/en/newsletters/2019-04-23-newsletter.md
@@ -128,7 +128,7 @@ backported to its pending release.*
   Optech's [RBF usability study][] and so allows fee bumps made by
   Bitcoin Core users to succeed more often.
 
-- C-Lightning PRs [<!--c-lightning-->#2541][c-lightning #2541], [#2545][c-lightning
+- [C-Lightning #2541][], [#2545][c-lightning
   #2545], and [#2546][c-lightning #2546] implement multiple changes to
   the gossip subsystem used for tracking which channels are available
   and calculating routes across them.  This work was motivated by the


### PR DESCRIPTION
Closes #576 

When we first started covering C-Lightning merged PRs, their method of "merging" by rebasing PRs on top of their master branch didn't directly provide me the information necessary to attribute the correct PR on GitHub.  Later, I developed a script that took a commit ID and found the PR, so we've been printing C-Lightning PR numbers for the past two years (almost).

This PR revises the old C-Lightning listings to use their PR numbers.  In a couple cases, this required consolidating multiple entries from different commits into a single PR entry.  I also fixed a couple other cases to work with our auto-linking plugin, since they were found my my grep command `vi $( git grep -l '^- C-L' )`.

I had to find the commits referenced in our descriptions using a combination of (1) our description (2) the newsletter date compared to commit date, so it's possible some could be misattributed to the wrong PR.  That said, I'm pretty confident in my matching.

I also fixed one unrelated typo which confused the heck out of me when trying to find the correct PR based on context clues (`C-Lightning 0.16.1` → `C-Lightning 0.6.1`).