### PR TITLE
Topics: increase max title length and use the extra space (also a News151 fixup)

### DIFF
--- a/_data/schemas/topics.yaml
+++ b/_data/schemas/topics.yaml
@@ -85,7 +85,7 @@ properties:
           description: Title to use for the mention
           type: string
           minLength: 1
-          maxLength: 75  ## Arbitrary but important to keep short for topic index
+          maxLength: 100  ## Arbitrary but important to keep short for topic index
         url:
           description: Internal URL for the mention
           type: string

--- a/_posts/en/newsletters/2021-06-02-newsletter.md
+++ b/_posts/en/newsletters/2021-06-02-newsletter.md
@@ -93,7 +93,7 @@ BOLTs][bolts repo].*
 - [Bitcoin Core #18418][] increases the maximum number of UTXOs received
   to the same address that will be spent simultaneously if the
   `avoid_reuse` wallet flag is set.  The more outputs that are spent
-  together, the higher the fee might be relative to a wallet with
+  together, the higher the fee might be for that particular transaction relative to a wallet with
   default flags but, also, the less likely it becomes that third parties
   will be able to identify the user's later transactions.
 

--- a/_topics/en/output-script-descriptors.md
+++ b/_topics/en/output-script-descriptors.md
@@ -86,7 +86,7 @@ optech_mentions:
   - title: Specter-DIY v1.5.0 adds full descriptor support
     url: /en/newsletters/2021/04/21/#specter-diy-v1-5-0
 
-  - title: "Bitcoin Core #20867 increases max multisig keys for descriptors to 20"
+  - title: "Bitcoin Core #20867 increases the maximum multisig keys for descriptors to 20"
     url: /en/newsletters/2021/05/12/#bitcoin-core-20867
 
   - title: "BIPs #1089 assigns BIP87 to a multisig wallet standard using descriptors"

--- a/_topics/en/package-relay.md
+++ b/_topics/en/package-relay.md
@@ -53,7 +53,7 @@ optech_mentions:
   - title: Upcoming relay policy workshop to discuss package relay and other topics
     url: /en/newsletters/2021/04/28/#call-for-topics-in-layer-crossing-workshop
 
-  - title: "Bitcoin Core #20833 allows `testmempoolaccept` to eval related transactions"
+  - title: "Bitcoin Core #20833 allows `testmempoolaccept` to evaluate descendant transaction chains"
     url: /en/newsletters/2021/06/02/#bitcoin-core-20833
 
 ## Optional.  Same format as "primary_sources" above

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -101,7 +101,7 @@ optech_mentions:
   - title: "Comparison of SSS to `OP_CHECKMULTISIG` to schnorr multisignatures"
     url: /en/newsletters/2021/02/24/#is-sharding-a-good-alternative-to-multisig
 
-  - title: "Rust Bitcoin #589 starts implementing support for taproot and schnorr sigs"
+  - title: "Rust Bitcoin #589 starts implementing support for taproot and schnorr signatures"
     url: /en/newsletters/2021/05/12/#rust-bitcoin-589
 
 ## Optional.  Same format as "primary_sources" above

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -170,7 +170,7 @@ optech_mentions:
   - title: "BIPs #1104 adds activation parameters to the BIP341 taproot specification"
     url: /en/newsletters/2021/05/05/#bips-1104
 
-  - title: "Rust Bitcoin #589 starts implementing support for taproot and schnorr sigs"
+  - title: "Rust Bitcoin #589 starts implementing support for taproot and schnorr signatures"
     url: /en/newsletters/2021/05/12/#rust-bitcoin-589
 
 ## Optional


### PR DESCRIPTION
Addresses these comments:

https://github.com/bitcoinops/bitcoinops.github.io/pull/581#discussion_r643768463
https://github.com/bitcoinops/bitcoinops.github.io/pull/581#discussion_r643774700

plus (from my memory) some previous complaints about recent too-short titles.