### PR TITLE
Calc-size: default to 2-in-2-out

### DIFF
--- a/en/tools/calc-size.md
+++ b/en/tools/calc-size.md
@@ -55,7 +55,7 @@ size:
    </select>
 
   <br>
-  Number of inputs: <input type="number" id="inputs" min="1" value="1" onchange="updateTotal()"/><br>
+  Number of inputs: <input type="number" id="inputs" min="1" value="2" onchange="updateTotal()"/><br>
   Number of outputs: <input type="number" id="outputs" min="1" value="2" onchange="updateTotal()"/>
 
   <br><br><hr>


### PR DESCRIPTION
The overall cost to create and spend a P2TR output is essentially the same as P2WPKH but the division of the costs between inputs and outputs is quite different, with P2TR being closer to symmetric than P2WPKH.  This means our default of a 1-input-2-output transaction gives a misleading impression that P2TR is much more expensive than P2WPKH.

This PR changes the default transaction template to use 2 inputs and 2 outputs, which eliminates the confusion.

(Thanks to someone reading a Reddit thread about this for reporting it to me.)