### PR TITLE
Style: compound words: keypath & scriptpath

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -89,6 +89,7 @@ following abbreviations we assume readers will already know.
 | coinswap | Coinswap, CoinSwap, coinSwap, or coin-swap | |
 | fee bumping | fee-bumping | |
 | feerate | fee-rate or fee rate | |
+| keypath | key-path or key path | |
 | mainnet | main net | |
 | multisig | multi-sig | |
 | multiparty | multi-party | |
@@ -101,6 +102,7 @@ following abbreviations we assume readers will already know.
 | proof of work | proof-of-work | proof-of-work may be used as an adjective phrase (e.g. "Bitcoin's proof-of-work security is economic in nature"). | |
 | redeemScript | redeem script | |
 | secp256k1 | Secp256k1, SECP256k1 or SECP256K1 | |
+| scriptpath | script-path or script path | |
 | side-channel | sidechannel | when used to describe a side-channel attack |
 | sigop | Sigop, SigOp or sig op | |
 | single-sig | singlesig | |


### PR DESCRIPTION
Opinions welcome.  Previous comments:

@harding

> [7:08:25 pm] <harding> Style guide question for taproot: "key path"/"script path", "key-path"/"script-path", or "keypath"/"scriptpath" (or something else).  BIP341 uses the space versions; I think I'm partial to the single word versions (but no strong preference).  No rush.

@jnewbery 

> [10:28:40 pm] <jnewbery> No strong preference, but my initial reaction is that as those terms become more common, we'll naturally want a single symbol to represent them (ie keypath/scriptpath), much like public key turned into pubkey once it became a common term.

@jonatack 

> I prefer "key path" and "script path"

Current repository state (not counting references in newsletter 154, since those were made despite Jon stating a different preference; also ignoring translations and several cases talking about BIP32 derivation paths):

|        | xpath | x path | x-path |
|--------|-------|--------|--------|
| key    |  1    | 5      | 9      |
| script |  1    | 3      | 12     |

(Note: "x path" may be undercounted by about 8% due to line wrapping occurring at word boundaries.)