### PR TITLE
Topics: add stub descriptions for all currently qualifying proposed topics

### DIFF
--- a/_contrib/new-topic
+++ b/_contrib/new-topic
@@ -56,6 +56,11 @@ optech_mentions:
 #   - title:
 #     link:
 
+## Optional.  Force the display (true) or non-display (false) of stub
+## topic notice.  Default is to display if the page.content is below a
+## threshold word count
+#stub: false
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_includes/snippets/stub-topic.md
+++ b/_includes/snippets/stub-topic.md
@@ -1,0 +1,5 @@
+<div style="background-color: lightgrey; text-align: center;" markdown="1">
+*This topic description is a stub.  We would welcome a [pull
+request](https://github.com/{{site.github_username}}/{{site.repository_name}}/edit/master/{{page.path}})
+providing more background information about the topic.*
+</div>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -74,6 +74,16 @@ layout: post
 
   <!-- Variable for use in links -->
   {% capture gh_base %}https://github.com/{{site.github_username}}/{{site.repository_name}}{% endcapture %}
+
+  <!-- whether or not to display a stub notice -->
+  {% assign word_count = page.content | number_of_words %}
+  {% if page.stub != false %}
+    <!-- if any words, not a stub.  We may increase word count later -->
+    {% if word_count < 1 or page.stub == true %}
+      {% capture notices %}{{notices}}{% include snippets/stub-topic.md %}{% endcapture %}
+    {% endif %}
+  {% endif %}
+
 {% endcapture %}
 
 <!-- Actual page content -->
@@ -84,6 +94,8 @@ layout: post
   {{page.excerpt}}
 
   {{page.content}}
+
+  {{notices | default: newline}}
 
   {%- if page.primary_sources and page.primary_sources != '' -%}
     ## Primary code and documentation

--- a/_topics/en/asicboost.md
+++ b/_topics/en/asicboost.md
@@ -1,0 +1,70 @@
+---
+title: ASICBoost
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+  - Overt ASICBoost
+  - Covert ASICBoost
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Mining
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: AsicBoost---A Speedup for Bitcoin Mining
+      link: https://arxiv.org/abs/1604.00575
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: Overt ASICBoost support for S9 miners
+    url: /en/newsletters/2018/10/30/#overt-asicboost-support-for-s9-miners
+
+  - title: "Bitcoin Core #15471 removes warning falsely triggered by use of overt ASICBoost"
+    url: /en/newsletters/2019/03/05/#bitcoin-core-15471
+
+  - title: "Question about block templates versus actual blocks: ASICBoost explains one difference"
+    url: /en/newsletters/2021/04/28/#why-does-the-mined-block-differ-so-much-from-the-block-template
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **ASICBoost** is a technique for specially constructing a Bitcoin
+  block header in order to reduce by about 15% the number of operations
+  necessary to find a certain amount of proof of work.
+
+---
+ASICBoost can be implemented in two forms:
+
+- **Overt ASICBoost** requires manipulating the nVersion field of a
+  block header.  This is clearly visible on the block chain.  Miners
+  wishing to use overt ASICBoost are recommended to use the version bits
+  reserved for general purpose use by [BIP320][].
+
+- **Covert ASICBoost** requires manipulating part of the merkle root
+  field of a block header.  This can be done undetectably, although
+  naive implementations often leave clues.
+
+    Covert ASICBoost is not compatible with blocks that contain
+    secondary commitments to their transactions, as is the case with any
+    block that contains a segwit transaction.  This produced
+    [controversy][segwit asicboost] when it was discovered that a mining
+    hardware manufacturer who strongly objected to segwit had secretly
+    designed features into their ASICs to use covert ASICBoost.
+
+[segwit asicboost]: /en/topics/soft-fork-activation/#2016-7-bip9-bip148-and-bip91-the-bip141143-segwit-activation
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/atomic-multipath.md
+++ b/_topics/en/atomic-multipath.md
@@ -1,0 +1,77 @@
+---
+title: Atomic multipath payments (AMPs)
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+shortname: amp
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+  - AMP
+  # Although common, I prefer not to put "OG AMP" in the alias list -harding
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Lightning Network
+  - Privacy Enhancements
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: Atomic Multipath Payments
+      link: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-February/000993.html
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "LN protocol 1.1 goals: multipath payments"
+    url: /en/newsletters/2018/11/20/#multi-path-payments
+
+  - title: "LND #3957 adds code useful for Atomic Multipath Payments (AMP) support"
+    url: /en/newsletters/2020/02/12/#lnd-3957
+
+  - title: "LND #5108 adds support for spontaneous multipath payments using AMP"
+    url: /en/newsletters/2021/04/14/#lnd-5108
+
+  - title: "LND #5159 adds support for making spontaneous AMPs"
+    url: /en/newsletters/2021/05/05/#lnd-5159
+
+  - title: "LND #5253 adds support for Atomic Multipath Payment (AMP) invoices"
+    url: /en/newsletters/2021/05/19/#lnd-5253
+
+  - title: "LND #5336 adds the ability for users to reuse AMP invoices non-interactively"
+    url: /en/newsletters/2021/06/09/#lnd-5336
+
+  - title: "LND 0.13.0-beta allows receiving and sending payments using AMP"
+    url: /en/newsletters/2021/06/23/#lnd-0-13-0-beta
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: Simplified Multipath Payments (SMP)
+    link: topic multipath payments
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Atomic Multipath Payments (AMPs)**, sometimes called **Original AMP**
+  or **OG AMP**, allow a spender to pay multiple hashes all derived from
+  the same preimage---a preimage the receiver can only reconstruct if
+  they receive a sufficient number of shares.
+---
+Unlike Simplified Multipath Payments ([SMP][topic multipath payments]), this only
+allows the receiver to accept a payment if they receive all of the
+individual parts.  Each share using a different hash adds privacy by
+preventing the separate payments from being automatically correlated
+with each other by a third party.  The proposal's downside is that the
+spender selects all the preimages, so knowledge of the preimage doesn't
+provide cryptographic proof that they actually paid the receiver.
+
+Both AMP and SMP allow splitting higher value HTLCs into multiple lower
+value HTLCs that are more likely to
+individually succeed, so a spender with sufficient liquidity can use
+almost all of their funds at once no matter how many channels those
+funds are split across.
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/exfiltration-resistant-signing.md
+++ b/_topics/en/exfiltration-resistant-signing.md
@@ -1,0 +1,51 @@
+---
+title: Exfiltration resistant signing
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Security Enhancements
+  - Wallet Collaboration Tools
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: Overview of anti-covert-channel signing techniques
+      link: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-March/017667.html
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: Proposal to standardize an exfiltration resistant nonce protocol
+    url: /en/newsletters/2020/03/04/#proposal-to-standardize-an-exfiltration-resistant-nonce-protocol
+
+  - title: Overview of anti-covert-channel signing techniques
+    url: /en/newsletters/2020/03/11/#exfiltration-resistant-nonce-protocols
+
+  - title: Description of anti-exfiltration technique being used in BitBox02 and Jade hardware wallets
+    url: /en/newsletters/2021/02/17/#anti-exfiltration
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Exfiltration resistant signing** is the process of creating
+  signatures for Bitcoin transactions using a protocol that can be
+  audited to ensure the signature doesn't contain any biased or
+  otherwise manipulated elements that could be used to compromise the
+  signer's private keys.
+---
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/hd-key-generation.md
+++ b/_topics/en/hd-key-generation.md
@@ -1,0 +1,91 @@
+---
+title: HD key generation
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+shortname: bip32
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+ - BIP32
+ - HD wallets
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Scripts and Addresses
+  - Wallet Collaboration Tools
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: BIP32
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "Bitcoin Core #14150 adds key origin support to descriptors for tracking BIP32 xpubs"
+    url: /en/newsletters/2018/10/30/#bitcoin-core-14150
+
+  - title: "Suggestion to include BIP32 derivation paths in BIP174 PSBTs"
+    url: /en/newsletters/2019/05/14/#addition-of-derivation-paths-to-bip174-psbts
+
+  - title: "BIPs #784 updates BIP174 PSBTs to include a BIP32 xpub"
+    url: /en/newsletters/2019/07/17/#bips-784
+
+  - title: "Question about BIP32 extended pubkeys (xpubs) versus ypubs and zpubs"
+    url: /en/newsletters/2019/07/31/#why-does-the-importmulti-rpc-not-support-zpub-and-ypub
+
+  - title: "Question: what is the max allowed depth for BIP32 derivation paths?"
+    url: /en/newsletters/2019/12/18/#what-is-the-max-allowed-depth-for-bip32-derivation-paths
+
+  - title: "Question: why was the BIP32 fingerprint used for BIP174 PSBT?"
+    url: /en/newsletters/2020/01/29/#why-was-the-bip32-fingerprint-used-for-bip174-psbt
+
+  - title: "Proposal for using one BIP32 keychain to seed multiple child keychains"
+    url: /en/newsletters/2020/04/15/#proposal-for-using-one-bip32-keychain-to-seed-multiple-child-keychains
+
+  - title: "BIPs #910 Assigns BIP85 to the Deterministic Entropy From BIP32 Keychains proposal"
+    url: /en/newsletters/2020/06/17/#bips-910
+
+  - title: Proposed BIP for BIP32 path templates
+    url: /en/newsletters/2020/07/08/#proposed-bip-for-bip32-path-templates
+
+  - title: Proposal for secure exchange of BIP32 xpubs during multisig wallet set up
+    url: /en/newsletters/2021/02/17/#securely-setting-up-multisig-wallets
+
+  - title: Closing lost LN channels with only a BIP32 seed
+    url: /en/newsletters/2021/05/05/#closing-lost-channels-with-only-a-bip32-seed
+
+  - title: "BIPs #1089 assigns BIP87 to proposal for standardized BIP32 paths for multisig wallets"
+    url: /en/newsletters/2021/05/26/#bips-1089
+
+  - title: "BIPs #1097 assigns BIP129 to proposal for exchange of xpubs during multisig wallet set up"
+    url: /en/newsletters/2021/05/26/#bips-1097
+
+  - title: "Bitcoin Core #22095 adds test to ensure BIP32 derived keys are correctly padded"
+    url: /en/newsletters/2021/06/09/#bitcoin-core-22095
+
+  - title: Proposed BIP32 key derivation path for single-sig P2TR
+    url: /en/newsletters/2021/06/30/#key-derivation-path-for-single-sig-p2tr
+
+  - title: No changes to BIP32 derivation needed to implement taproot receiving support
+    url: /en/newsletters/2021/07/14/#preparing-for-taproot-4-from-p2wpkh-to-single-sig-p2tr
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **HD key generation** as specified in **BIP32** allows securely
+  creating an unlimited number of keypairs from a seed as small as 128
+  bits.  A wallet may also create extended pubkeys (xpubs) that allow
+  external software to create new pubkeys for the wallet without
+  learning the corresponding private keys.
+
+---
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/multipath-payments.md
+++ b/_topics/en/multipath-payments.md
@@ -51,12 +51,6 @@ optech_mentions:
   - title: "LND #3442 preparatory PR adding features necessary for multipath payments"
     url: /en/newsletters/2019/11/13/#lnd-3442
 
-  - title: "C-Lightning #3259 adds payment secrets to prevent multipath probing"
-    url: /en/newsletters/2019/12/04/#c-lightning-3259
-
-  - title: 'LND #3788 adds support for "payment addresses" (payment secrets)'
-    url: /en/newsletters/2019/12/11/#lnd-3788
-
   - title: Multiple LN implementations add multipath payment support
     url: /en/newsletters/2019/12/18/#ln-implementations-add-multipath-payment-support
 
@@ -117,9 +111,6 @@ optech_mentions:
   - title: New paper analyzes benefit of multipath payments on routing success
     url: /en/newsletters/2021/03/31/#paper-on-probabilistic-path-selection
 
-  - title: "Rust-Lightning #893 requires payment secrets to prevent multipath probing"
-    url: /en/newsletters/2021/05/05/#rust-lightning-893
-
   - title: Electrum 4.1.0 adds support for multipath payments
     url: /en/newsletters/2021/05/19/#electrum-4-1-0-enhances-lightning-features
 
@@ -127,6 +118,9 @@ optech_mentions:
 see_also:
   - title: Atomic Multipath Payments (AMPs)
     link: topic amp
+
+  - title: Payment secrets
+    link: topic payment secrets
 ---
 Although proposed after atomic multipath payments ([AMP][topic amp]),
 simplified multipath payments required fewer changes to the LN protocol

--- a/_topics/en/multipath-payments.md
+++ b/_topics/en/multipath-payments.md
@@ -1,14 +1,19 @@
 ---
 title: Multipath payments
 
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+#shortname:
+
 ## Optional.  An entry will be added to the topics index for each alias
 #
 ## LND source code calls these multi-path payments, Eclair source code
 ## calls them multi-part payments, no C-Lightning sources yet but Rusty and
 ## Zmn call them multipath payments
 aliases:
-  - AMP
   - Multipart payments
+  - Simplified multipath payments
+  - Base AMP
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
@@ -17,16 +22,15 @@ categories:
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
-  **Multipath payments** are LN payments split into two or more parts
-  and sent using a different path for each part.
+  **Simplified Multipath Payments (SMPs)**, also called **Base AMP**,
+  are LN payments that are split into two or more parts all sharing the
+  same hash and preimage, and which are sent using a different path for
+  each part.
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
-    - title: Atomic Multipath Payments
-      link: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-February/000993.html
-
-    - title: Base AMP
+    - title: Simplified Multipath Payments
       link: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-November/001577.html
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
@@ -35,7 +39,7 @@ optech_mentions:
   - title: "LN protocol 1.1 goals: multipath payments"
     url: /en/newsletters/2018/11/20/#multi-path-payments
 
-  - title: "LND #3390 separates tracking of HTLCs from invoices as necessary for AMP"
+  - title: "LND #3390 separates tracking of HTLCs from invoices as necessary for SMP"
     url: /en/newsletters/2019/09/11/#lnd-3390
 
   - title: "LND #3499 extends several RPCs to support tracking multipath payments"
@@ -71,9 +75,6 @@ optech_mentions:
   - title: "Eclair 0.3.3 adds support for multipath payments"
     url: /en/newsletters/2020/02/05/#upgrade-to-eclair-0-3-3
 
-  - title: "LND #3957 adds code useful for Atomic Multipath Payments (AMP) support"
-    url: /en/newsletters/2020/02/12/#lnd-3957
-
   - title: "Boomerang: improving latency and throughput with multipath payments"
     url: /en/newsletters/2020/02/26/#boomerang-redundancy-improves-latency-and-throughput-in-payment-channel-networks
 
@@ -83,7 +84,7 @@ optech_mentions:
   - title: "LND #3967 adds support for sending multipath payments"
     url: /en/newsletters/2020/04/15/#lnd-3967
 
-  - title: "Rust-Lightning #441 adds support for basic multipath payments"
+  - title: "Rust-Lightning #441 adds support for simplified multipath payments"
     url: /en/newsletters/2020/04/22/#rust-lightning-441
 
   - title: "LND 0.10 presentation: multipath payments"
@@ -116,54 +117,31 @@ optech_mentions:
   - title: New paper analyzes benefit of multipath payments on routing success
     url: /en/newsletters/2021/03/31/#paper-on-probabilistic-path-selection
 
-  - title: "LND #5108 adds support for spontaneous multipath payments using AMP"
-    url: /en/newsletters/2021/04/14/#lnd-5108
-
   - title: "Rust-Lightning #893 requires payment secrets to prevent multipath probing"
     url: /en/newsletters/2021/05/05/#rust-lightning-893
-
-  - title: "LND #5159 adds support for making spontaneous AMPs"
-    url: /en/newsletters/2021/05/05/#lnd-5159
 
   - title: Electrum 4.1.0 adds support for multipath payments
     url: /en/newsletters/2021/05/19/#electrum-4-1-0-enhances-lightning-features
 
-  - title: "LND #5253 adds support for Atomic Multipath Payment (AMP) invoices"
-    url: /en/newsletters/2021/05/19/#lnd-5253
-
-  - title: "LND #5336 adds the ability for users to reuse AMP invoices non-interactively"
-    url: /en/newsletters/2021/06/09/#lnd-5336
-
-  - title: "LND 0.13.0-beta allows receiving and sending payments using AMP"
-    url: /en/newsletters/2021/06/23/#lnd-0-13-0-beta
-
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Atomic Multipath Payments (AMPs)
+    link: topic amp
 ---
-Smaller payments are more likely to succeed in general, and allowing a
-payment to be split allows the spender to use almost all of their funds at
-once no matter how many channels those funds are split across.  There
-are two basic multipath proposals:
+Although proposed after atomic multipath payments ([AMP][topic amp]),
+simplified multipath payments required fewer changes to the LN protocol
+to implement and preserved the ability for spenders to receive a
+cryptographic proof of payment, so they were the first to be deployed on
+the production network.
 
-- *Atomic Multipath Payments (AMP)*, sometimes called *Original AMP*
-  or *OG AMP*, which allows a spender to pay multiple hashes all
-  derived from the same preimage---a preimage the receiver can only
-  reconstruct if they receive a sufficient number of shares.  This
-  only allows the receiver to accept a payment if they receive all of the
-  individual parts.  Each share using a different hash adds privacy by
-  preventing the separate payments from being automatically correlated
-  with each other by a third party.  The proposal's downside is that
-  the spender selects all the preimages, so knowledge of the preimage
-  doesn't provide cryptographic proof that they actually paid the
-  receiver.
+The main downside of simplified multipath payments when using
+[HTLCs][topic htlc] is that third-parties who see multiple payments all
+using the same hash can infer that they're part of a larger true payment.
 
-- *Base-AMP* which simply sends multiple payments all using to the
-  same hash and assumes the receiver will wait until the full amount
-  is received before claiming the payment (releasing the hash preimage
-  and allowing generation of a provable receipt).  It's also possible
-  for third-parties who see multiple payments using the same hash to
-  assume they're part of the same true payment.
+Both AMP and SMP allow splitting higher value HTLCs into multiple lower
+value HTLCs that are more likely to
+individually succeed, so a spender with sufficient liquidity can use
+almost all of their funds at once no matter how many channels those
+funds are split across.
 
 {% include references.md %}

--- a/_topics/en/payment-secrets.md
+++ b/_topics/en/payment-secrets.md
@@ -1,0 +1,71 @@
+---
+title: Payment secrets
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Lightning Network
+  - Privacy Enhancements
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: BOLT4
+    - title: BOLT11
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "C-Lightning #3259 adds payment secrets to prevent multipath probing"
+    url: /en/newsletters/2019/12/04/#c-lightning-3259
+
+  - title: 'LND #3788 adds support for "payment addresses" (payment secrets)'
+    url: /en/newsletters/2019/12/11/#lnd-3788
+
+  - title: "BOLTs #643 adds payment secrets to LN specification"
+    url: /en/newsletters/2019/12/18/#bolts-643
+
+  - title: "CVE-2020-26896 could have been prevented by payment secrets"
+    url: /en/newsletters/2020/10/28/#cve-2020-26896-improper-preimage-revelation
+
+  - title: "LND #4752 prevents the node from releasing a local payment preimage without a payment secret"
+    url: /en/newsletters/2020/12/02/#lnd-4752
+
+  - title: "Rust-Lightning #893 requires payment secrets to prevent multipath probing"
+    url: /en/newsletters/2021/05/05/#rust-lightning-893
+
+  - title: "Eclair #1810 makes it mandatory for peers to signal and comply with the payment_secret feature"
+    url: /en/newsletters/2021/05/26/#eclair-1810
+
+  - title: "LND #5336 allows non-interactive reuse of AMP invoices by changing the payment secret"
+    url: /en/newsletters/2021/06/09/#lnd-5336
+
+  - title: "C-Lightning #4646 makes payment secrets required"
+    url: /en/newsletters/2021/07/21/#c-lightning-4646
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: Simplified multipath payments
+    link: topic multipath payments
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Payment secrets** are extra data added to BOLT11 invoices that
+  spenders include in their BOLT4 onion-encrypted payments.  This
+  allows the receiver to only accept a payment from the intended
+  spender, preventing a probing attack against the receiver when
+  simplified multipath payments are being used.
+
+---
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/rendez-vous-routing.md
+++ b/_topics/en/rendez-vous-routing.md
@@ -1,0 +1,55 @@
+---
+title: Rendez-vous routing
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+shortname: rv routing
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+  - Hidden destinations
+  - Blinded paths
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Lightning Network
+  - Privacy Enhancements
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: Route blinding
+      link: https://github.com/lightningnetwork/lightning-rfc/blob/route-blinding/proposals/route-blinding.md
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "Lightning Network protocol 1.1 goals: hidden destinations"
+    url: /en/newsletters/2018/11/20/#hidden-destinations
+
+  - title: "Decoy nodes and lightweight rendez-vous routing (blinded paths)"
+    url: /en/newsletters/2020/02/19/#decoy-nodes-and-lightweight-rendez-vous-routing
+
+  - title: "C-Lightning #3600 adds experimental support for onion messages using blinded paths"
+    url: /en/newsletters/2020/04/08/#c-lightning-3600
+
+  - title: "C-Lightning #3623 adds a minimal implementation for spending payments using blinded paths"
+    url: /en/newsletters/2020/04/22/#c-lightning-3623
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: Unannounced channels
+    link: topic unannounced channels
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Rendez-vous routing**, **hidden destinations**, and **blinded paths** are
+  names for techniques that allow an LN node to send a payment to an
+  unannounced node without learning where that node is in the
+  network topology or what channels it shares with other nodes.
+
+---
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/segregated-witness.md
+++ b/_topics/en/segregated-witness.md
@@ -1,0 +1,74 @@
+---
+title: Segregated witness
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+shortname: segwit
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Soft Forks
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: BIP141 segregated witness
+      link: BIP141
+
+    - title: BIP143 verification of signatures in spends of segwit v0 witness programs
+      link: BIP143
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: Temporary reduction in segwit block production
+    url: /en/newsletters/2018/11/06/#temporary-reduction-in-segwit-block-production
+
+  - title: "Bitcoin Core #14454 adds support to the importmulti RPC for segwit addresses and scripts"
+    url: /en/newsletters/2018/11/06/#bitcoin-core-14454
+
+  - title: "Bitcoin Core #14811 updates the getblocktemplate RPC to require that the segwit flag be passed"
+    url: /en/newsletters/2019/01/08/#bitcoin-core-14811
+
+  - title: "Question: Are there still miners or mining pools which refuse to implement SegWit?"
+    url: /en/newsletters/2019/04/30/#are-there-still-miners-or-mining-pools-which-refuse-to-implement-segwit
+
+  - title: "Bitcoin Core #14039 causes Bitcoin Core to reject legacy transactions encoded as segwit"
+    url: /en/newsletters/2019/04/30/#bitcoin-core-14039
+
+  - title: "Bitcoin Core #15846 relays and mines transactions paying any segwit address version"
+    url: /en/newsletters/2019/04/30/#bitcoin-core-15846
+
+  - title: Fee overpayment attack on multi-input segwit transactions
+    url: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
+
+  - title: "BIPs #933 adds BIP339 for transaction relay announcement using segwit wtxids"
+    url: /en/newsletters/2020/07/01/#bips-933
+
+  - title: "Bitcoin Core #18044 adds support for announcing and requesting transactions by their segwit wtxid"
+    url: /en/newsletters/2020/07/29/#bitcoin-core-18044
+
+  - title: "BIPs #947 updates the BIP325 specification of signet to allow segwit-style virtual transactions"
+    url: /en/newsletters/2020/08/05/#bips-947
+
+  - title: "Bitcoin Core #21009 removes logic needed to upgrade a pre-segwit node to segwit"
+    url: /en/newsletters/2021/05/05/#bitcoin-core-21009
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: Taproot
+    link: topic taproot
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Segregated witness** (segwit) was a soft fork that activated in 2017.
+
+---
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/side-channels.md
+++ b/_topics/en/side-channels.md
@@ -1,0 +1,57 @@
+---
+title: Side channels
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Security Problems
+  - Security Enhancements
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+#primary_sources:
+#    - title: Test
+#    - title: Example
+#      link: https://example.com
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "Presentation: Extracting Seeds from Hardware Wallets"
+    url: /en/newsletters/2019/06/19/#extracting-seeds-from-hardware-wallets
+
+  - title: "Presentation: Remote Side-Channel Attacks on Anonymous Transactions"
+    url: /en/newsletters/2020/02/26/#remote-side-channel-attacks-on-anonymous-transactions
+
+  - title: "New SafeGCD algorithm can speed up signing while remaining side-channel resistant"
+    url: /en/newsletters/2021/02/17/#faster-signature-operations
+
+  - title: "Libsecp256k1 #831 implements SafeGCD algorithm which speeds up side-channel resistant signing"
+    url: /en/newsletters/2021/03/24/#libsecp256k1-831
+
+  - title: "Libsecp256k1 #906 reduces iterations when using a constant-time signing algorithm"
+    url: /en/newsletters/2021/04/28/#libsecp256k1-906
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Side channels** are weaknesses in security protocols that arise from
+  flaws in the hardware and software used to implement the protocol,
+  rather than from flaws in the protocol's algorithms.
+
+---
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/signer-delegation.md
+++ b/_topics/en/signer-delegation.md
@@ -1,0 +1,52 @@
+---
+title: Signer delegation
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+aliases:
+  - Delegation
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Contract Protocols
+  - Scripts and Addresses
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: Graftroot
+      link: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-February/015700.html
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: Continued discussion over graftroot delegation safety
+    url: /en/newsletters/2018/07/03/#continued-discussion-over-graftroot-safety
+
+  - title: Implementing statechain delegation without schnorr or eltoo
+    url: /en/newsletters/2020/04/01/#implementing-statechains-without-schnorr-or-eltoo
+
+  - title: Signing delegation under existing consensus rules
+    url: /en/newsletters/2021/03/24/#signing-delegation-under-existing-consensus-rules
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: Statechains
+    link: topic statechains
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Signer delegation** is the ability for authorized spender Alice to
+  allow third-party Bob to spend her UTXO without
+  Alice giving away her private key, creating an onchain transaction, or
+  knowing Bob's public key in advance.
+
+---
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/static-channel-backups.md
+++ b/_topics/en/static-channel-backups.md
@@ -1,0 +1,71 @@
+---
+title: Static channel backups
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Lightning Network
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: BOLT2
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: "C-Lightning #1854 partly implements option_data_loss_protect"
+    url: /en/newsletters/2018/08/28/#c-lightning-1854
+
+  - title: "LND #2370 now updates a channel.backup file each time a new channel is opened or closed"
+    url: /en/newsletters/2019/01/29/#lnd-2370
+
+  - title: Closing lost channels with only a BIP32 seed and option_data_loss_protect
+    url: /en/newsletters/2021/05/05/#closing-lost-channels-with-only-a-bip32-seed
+
+## Optional.  Same format as "primary_sources" above
+# see_also:
+#   - title:
+#     link:
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Static channel backups** are backup files that only need to be
+  updated when an LN node opens or closes a new channel.  In case of data
+  loss, they allow the node to attempt to get the latest channel state from their
+  remote peer.
+
+
+---
+The mechanism allows a node that has potentially lost some of its
+state to encourage its peer to initiate a channel close. Since the peer
+should still have the most recent state, it can close the channel using that
+state and allow both nodes to receive their most recent balances.
+
+This method does carry two risks:
+
+- **Advertising weakness:** the peer can guess that something is wrong
+and attempt to steal funds from the stale node by closing the channel
+using an old state. But the risk is mitigated in large part by the LN
+penalty mechanism: if the stale node does have a revocation of that old
+state in its backups, it can create a breach remedy transaction (justice
+transaction) that will seize *all* of the lying peer’s funds from that
+channel. Because of this risk, peers using the `option_data_loss_protect`
+mechanism have an incentive to close the channel honestly with the
+latest state when they hear from a stale node.
+
+- **Mutual loss:** if both peers lose state, or if the remote peer
+  becomes permanently unavailable, static channel backups can't help
+  recover the current channel state.
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}

--- a/_topics/en/timelocks.md
+++ b/_topics/en/timelocks.md
@@ -1,0 +1,81 @@
+---
+title: Timelocks
+
+## Optional.  Shorter name to use for reference style links e.g., "foo"
+## will allow using the link [topic foo][].  Not case sensitive
+# shortname: foo
+
+## Optional.  An entry will be added to the topics index for each alias
+#aliases:
+#  - Foo
+
+## Required.  At least one category to which this topic belongs.  See
+## schema for options
+categories:
+  - Scripts and Addresses
+  - Contract Protocols
+  - Transaction Relay Policy
+
+## Optional.  Produces a Markdown link with either "[title][]" or
+## "[title](link)"
+primary_sources:
+    - title: BIP65 `OP_CHECKLOCKTIMEVERIFY` for absolute timelocks in scripts
+      link: BIP65
+
+    - title: BIP68 relative timelocks using consensus-enforced sequence numbers
+      link: BIP68
+
+    - title: BIP112 `OP_CHECKSEQUENCEVERIFY` for relative timelocks in scripts
+      link: BIP112
+
+## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
+## true" to bold entry
+optech_mentions:
+  - title: For BIP322 generic signed messages, unclear how to support timelocks
+    url: /en/newsletters/2018/09/18/#bip322-generic-signed-message-format
+
+  - title: Transaction pinning as a major challenge for protocols involving timelocks
+    url: /en/newsletters/2018/12/04/#cpfp-carve-out
+
+  - title: Lightning Loop announce, using submarine swaps with onchain timelocks
+    url: /en/newsletters/2019/03/26/#loop-announced
+
+  - title: Fidelity bonds based on long-term timelocks
+    url: /en/newsletters/2019/07/31/#fidelity-bonds-for-improved-sybil-resistance
+
+  - title: Using decrementing locktimes instead of eltoo for statechains
+    url: /en/newsletters/2020/04/01/#implementing-statechains-without-schnorr-or-eltoo
+
+  - title: New cross-chain coinswap construction that only requires timelocks on one chain
+    url: /en/newsletters/2020/05/20/#two-transaction-cross-chain-atomic-swap-or-same-chain-coinswap
+
+  - title: One-block relative timelocks to prevent pinning issues in coinswaps
+    url: /en/newsletters/2020/09/09/#continued-coinswap-discussion
+
+  - title: Research into conflicts between timelocks and heightlocks
+    url: /en/newsletters/2020/09/23/#research-into-conflicts-between-timelocks-and-heightlocks
+
+  - title: "BOLTs #803 updates BOLT5 with recommendations for handling timelocks near maturity"
+    url: /en/newsletters/2020/12/16/#bolts-803
+
+  - title: Challenges related to timelocks when using CPFP fee bumping in LN
+    url: /en/newsletters/2021/04/21/#using-anchor-outputs-by-default-in-lnd
+
+## Optional.  Same format as "primary_sources" above
+see_also:
+  - title: HTLCs
+    link: topic HTLC
+
+  - title: PTLCs
+    link: topic PTLC
+
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+## Should be less than 500 characters
+excerpt: >
+  **Timelocks** are encumbrances that prevent a transaction or the spend of an
+  output from being confirmed prior to a maturity time or block height.
+
+---
+
+{% include references.md %}
+{% include linkers/issues.md issues="" %}


### PR DESCRIPTION
Adds stub topic pages for all qualifying topics from our spreadsheet tracker and this repository's open issues.  (Qualifying means at least three mentions and doesn't have other issues.)

There are several benefits to having stub descriptions for topics:

- It makes our content more accessible, even if only te people who already know what the topic is about

- We can start linking to the new pages immediately, building backlinks

- If a topic isn't worth hosting a page for, someone can complain before too much effort has been invested in writing about it

- Maybe other people will be interested in expanding stub descriptions into full writeups

h/t to @jnewbery who suggested elements of this approach