### PR TITLE
Layout: Add auto bullet linking to included files

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,11 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+</head>

--- a/_includes/specials/bech32/05-fee-savings.md
+++ b/_includes/specials/bech32/05-fee-savings.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 One reason your users and customers may want you to implement bech32
 sending support is because it'll allow the receivers of those payments
 to save on fees when they re-spend that money.  This week, we'll look at
@@ -60,3 +61,4 @@ relay fee).  This means more people spending native segwit inputs lowers
 the fee not just for those spenders but for everyone who creates
 transactions---including wallets and services that support sending to
 bech32 addresses.
+{% endauto_anchor %}

--- a/_includes/specials/bech32/06-stackexchange.md
+++ b/_includes/specials/bech32/06-stackexchange.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 This week we look at some of the [top-voted bech32 questions and
 answers][top bech32 qa] from the Bitcoin StackExchange.  This includes
 everything since bech32 was first announced about two years ago.
@@ -39,3 +40,4 @@ everything since bech32 was first announced about two years ago.
 [bech32 easy]: {{news38}}#bech32-sending-support
 [top bech32 qa]: https://bitcoin.stackexchange.com/search?tab=votes&q=bech32
 [bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
+{% endauto_anchor %}

--- a/_includes/specials/bech32/07-altbech32.md
+++ b/_includes/specials/bech32/07-altbech32.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 It's said that "imitation is the most sincere form of flattery."  In
 this week's section, we take a quick look at a few other systems that
 are using variations on bech32.  If you're already going to need to
@@ -48,3 +49,4 @@ probably worth your time to implement it for Bitcoin too.
 [blockstream liquid]: https://blockstream.com/liquid/
 [confidential assets]: https://elementsproject.org/features/confidential-transactions
 [blech32 py]: https://github.com/ElementsProject/elements/commit/9cb2fa051fcbe0fe66f15e6b88d224d1935376f4#diff-265badc7e18059096c32a61b0eada470
+{% endauto_anchor %}

--- a/_includes/specials/bech32/11-only-bech32.md
+++ b/_includes/specials/bech32/11-only-bech32.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 [Last week][Newsletter #47], we described one of the costs of not
 upgrading to bech32 sending support---users might think your service is
 out-of-date and so look for alternative services.  This week, we'll look
@@ -61,3 +62,4 @@ their preferred wallet.
 [trust wallet]: https://trustwallet.com/
 [electrum]: https://electrum.org/
 [news45 bech32]: {{news45}}#bech32-sending-support
+{% endauto_anchor %}

--- a/_includes/specials/bech32/12-midway.md
+++ b/_includes/specials/bech32/12-midway.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 This segment marks half-way through our series about bech32, so we decided to
 have some fun this week by describing some bech32-related trivia that's
 interesting but not important enough for its own segment.
@@ -29,3 +30,4 @@ interesting but not important enough for its own segment.
 [cpu time]: https://youtu.be/NqiN9VFE4CU?t=1329
 [wikipedia bch]: https://en.wikipedia.org/wiki/BCH_code
 [first plans]:https://blog.bitmain.com/en/uahf-contingency-plan-uasf-bip148/
+{% endauto_anchor %}

--- a/_includes/specials/bech32/21-brd.md
+++ b/_includes/specials/bech32/21-brd.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 *The following case study contributed by Optech member company [BRD][]
 describes what they learned implementing bech32 and other segwit
 technology for their wallet.*
@@ -81,3 +82,4 @@ fees are still relatively low.
 [identical spk data]: /en/bech32-sending-support/#sending-to-a-legacy-address
 [bech32 future]: /en/bech32-sending-support/#automatic-bech32-support-for-future-soft-forks
 [whensegwit]: https://whensegwit.com/
+{% endauto_anchor %}

--- a/_includes/specials/bech32/23-compat.md
+++ b/_includes/specials/bech32/23-compat.md
@@ -1,4 +1,4 @@
-As of this writing, here are what we think are some of the most
+{% auto_anchor %}As of this writing, here are what we think are some of the most
 significant bech32-related insights we've gleaned from creating and
 reviewing the [Compatibility Matrix][].
 
@@ -40,3 +40,4 @@ reviewing the [Compatibility Matrix][].
   of change output to the type of payment output) but, in most cases,
   this seems like a missed opportunity for wallets to send change to
   their own bech32 addresses for increased fee savings.
+{% endauto_anchor %}

--- a/_includes/specials/taproot/en/01-single-sig.md
+++ b/_includes/specials/taproot/en/01-single-sig.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 Using Optech's [transaction size calculator][], we can compare the sizes
 of different types of single-sig transactions.  As expected,
 transactions using P2WPKH inputs and outputs are much smaller than those
@@ -73,3 +74,4 @@ for single-sigs, both for wallet users and for the network as a whole.
 [news3 sig size]: /en/newsletters/2018/07/10/#unrelayable-transactions
 [news101 fee overpayment attack]: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
 [batch graph]: https://github.com/jonasnick/secp256k1/blob/schnorrsig-batch-verify/doc/speedup-batch.md
+{% endauto_anchor %}

--- a/_includes/specials/taproot/en/02-descriptors.md
+++ b/_includes/specials/taproot/en/02-descriptors.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 [Output script descriptors][topic descriptors] provide a generic way for
 wallets to store the information needed to create addresses, efficiently
 scan for outputs paying those addresses, and later spend from those
@@ -97,3 +98,4 @@ using more advanced taproot features later.
 
 {% include linkers/issues.md issues="22051" %}
 [bip341 safety]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-22
+{% endauto_anchor %}

--- a/_includes/specials/taproot/en/03-p2wpkh-to-p2tr.md
+++ b/_includes/specials/taproot/en/03-p2wpkh-to-p2tr.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 For wallets that already support receiving and spending v0 segwit P2WPKH
 outputs, upgrading to v1 segwit P2TR for single-sig should be easy.
 Here are the main steps:
@@ -117,3 +118,4 @@ pages of the Bitcoin Wiki so other developers can learn from your code.
 [bip341 sigmsg]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#common-signature-message
 [wiki bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
 [wiki taproot uses]: https://en.bitcoin.it/wiki/Taproot_Uses
+{% endauto_anchor %}

--- a/_includes/specials/taproot/en/04-why-wait.md
+++ b/_includes/specials/taproot/en/04-why-wait.md
@@ -12,6 +12,7 @@ Not tested:
 <!-- Conservatively reorg safe block after activation (+144 blocks) -->
 {% assign safe_trb = "709,776" %}
 {% endcapture %}
+{% auto_anchor %}
 
 Earlier entries in this series saw us encouraging developers working on
 wallets and services to begin implementing [taproot][topic taproot]
@@ -76,3 +77,4 @@ None of the above changes the advice given in the [first part][taproot
 
 [news139 st]: /en/newsletters/2021/03/10/#taproot-activation-discussion
 [taproot series 1]: /en/preparing-for-taproot/#bech32m-sending-support
+{% endauto_anchor %}

--- a/_includes/specials/taproot/en/05-taproot-notebooks.md
+++ b/_includes/specials/taproot/en/05-taproot-notebooks.md
@@ -1,3 +1,4 @@
+{% auto_anchor %}
 Almost two years ago, James Chiang and Elichai Turkel produced an [open source
 repository][taproot-workshop] of Jupyter notebooks for a series of
 Optech workshops to train developers on [taproot][topic taproot] technology.
@@ -53,3 +54,4 @@ taken the time to learn from them earlier.
 [workshops]: /en/schorr-taproot-workshop/
 [notebooks #168]: https://github.com/bitcoinops/taproot-workshop/pull/168
 [mouton tweet]: https://twitter.com/ElleMouton/status/1418108253096095745
+{% endauto_anchor %}

--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -7,11 +7,8 @@
 # - [Summary][]: Details
 # - [Summary](URL): Details
 
-Jekyll::Hooks.register :documents, :pre_render do |post|
-  ## Don't process documents if YAML headers say: "auto_id: false" or
-  ## we're formatting for email
-  unless post.data["auto_id"] == false || ENV['JEKYLL_ENV'] == 'email'
-    post.content.gsub!(/^ *- .*/) do |string|
+def auto_anchor(content)
+    content.gsub!(/^ *- .*/) do |string|
       ## Find shortest match for **bold**, *italics*, or [markdown][links]
       title = string.match(/\*\*.*?\*\*|\*.*?\*|\[.*?\][(\[]/).to_s
 
@@ -27,5 +24,31 @@ Jekyll::Hooks.register :documents, :pre_render do |post|
         string.sub!(/-/, id_prefix)
       end
     end
+end
+
+## Run automatically on all documents
+Jekyll::Hooks.register :documents, :pre_render do |post|
+  ## Don't process documents if YAML headers say: "auto_id: false" or
+  ## we're formatting for email
+  unless post.data["auto_id"] == false || ENV['JEKYLL_ENV'] == 'email'
+    auto_anchor(post.content)
   end
 end
+
+## Block filter that provides {% auto_anchor %}{% endauto_anchor %} for
+## use on {% include %} files
+module Jekyll
+  class RenderAutoAnchor < Liquid::Block
+
+    def render(context)
+      text = super
+      text = auto_anchor(text)
+      text = Liquid::Template.parse(text)
+      text.render(@context)
+    end
+
+  end
+end
+
+Liquid::Template.register_tag('auto_anchor', Jekyll::RenderAutoAnchor)
+


### PR DESCRIPTION
Closes #604 

Apparently it's a known limitation of Jekyll that Liquid template processing doesn't work on `{% include %}` files, which is why the automatic bullet linking isn't working.  This PR adds a `{% auto_anchor %}...{% endauto_anchor %}` block filter that we can put in included files in order to run the anchoring code manually (including calling Liquid).

To test this by diffing the site, I found it necessary to temporarily disable the SEO plugin which outputs a non-deterministic entry in the header of every page.  There's already a bug for that upstream.  (I don't know why this just became a problem now; I've diffed plenty of times before without problems.)  Temporarily disabling the SEO plugin required adding the template from Jekyll Minima to our repository, which is the first commit in this PR.  (To be clear, this PR only adds the ability to disable the plugin, it doesn't actually change anything.)

Diff instructions are:

- Checkout this PR
- Edit `_includes/head.html` and delete the `{%- seo -%}` line
- Build the site: `make clean build`
- Backup the output: `cp -a _site _new_site`
- Drop the two real commits: `git reset --hard HEAD^^`
- Make sure the SEO tag is still deleted
- Build the site again: `make clean build`
- Diff the output: `diff -ruN _site _new_site | colordiff | less -R`

Note: I didn't really check the translations.