### PR TITLE
Correct symbol for kibibyte

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -53,7 +53,7 @@ following abbreviations we assume readers will already know.
 - DoS (Denial-of-service)
 - ECDSA (Elliptic Curve Digital Signature Algorithm)
 - kB, MB, GB, TB, etc... (SI-prefixed byte sizes)
-- kiB, MiB, GiB, TiB, etc... (SI-prefixed binary byte sizes)
+- KiB, MiB, GiB, TiB, etc... (Prefixes denoting byte sizes in powers of 1024)
 - LN (Lightning Network)
 - LND (Lightning Network Daemon - the Lightning Labs LN implementation)
 - mempool (memory pool)


### PR DESCRIPTION
The symbol for kibi is "Ki" with a capital k. Since the International
System of Units restricts the use of SI prefixes strictly to powers of
10, the description of that line is updated to not mention SI in the
context.