### PR TITLE
Fix typo BIP116 -> BIP118

### DIFF
--- a/_posts/en/newsletters/2020-04-01-newsletter.md
+++ b/_posts/en/newsletters/2020-04-01-newsletter.md
@@ -44,7 +44,7 @@ notable changes to popular Bitcoin infrastructure projects.
     such as [schnorr signatures][topic schnorr signatures]
     and [SIGHASH_ANYPREVOUT][topic sighash_noinput]:
 
-    1. Replace the eltoo mechanism (which requires either [BIP116][]
+    1. Replace the eltoo mechanism (which requires either [BIP118][]
        `SIGHASH_NOINPUT` or [bip-anyprevout][] `SIGHASH_ANYPREVOUT`)
        with a decrementing locktime similar to that proposed for
        [duplex micropayment channels][].  E.g., when Alice receives

--- a/_posts/ja/newsletters/2020-04-01-newsletter-ja.md
+++ b/_posts/ja/newsletters/2020-04-01-newsletter-ja.md
@@ -19,7 +19,7 @@ lang: ja
 
     今週、Tom TrevethanがBitcoin-Devメーリングリストに、[schnorr signatures][topic schnorr signatures]や[SIGHASH_ANYPREVOUT][topic sighash_noinput]のような現状提案されているソフトフォークの変更を待つのではなく、現在のBitcoinプロトコルで使用できるようにするためのstatechainsの設計の2つの修正について投稿しました。
 
-    1. eltooメカニズム(これは、[BIP116][]`SIGHASH_NOINPUT`または[bip-anyprevout][]`SIGHASH_ANYPREVOUT`を必要とする)を、[duplex micropayment channels][]に提案されたものと同様の、徐々に減少するロックタイムで置き換える。例えば、AliceがstatechainsのUTXOの制御を受け取ると、タイムロックは30日間、彼女が一方的にそのUTXOをチェーン上で使うことができないようにする。アリスがUTXOをボブに転送するとき、タイムロックは彼を29日間だけ制限します。これは、ボブによる支出がアリスによる支出よりも優先されます。このアプローチの欠点は、信頼できる第三者の許可なしに資金を使うことができるようになるまで、代表者が長い間待つ必要があるかもしれないということです。
+    1. eltooメカニズム(これは、[BIP118][]`SIGHASH_NOINPUT`または[bip-anyprevout][]`SIGHASH_ANYPREVOUT`を必要とする)を、[duplex micropayment channels][]に提案されたものと同様の、徐々に減少するロックタイムで置き換える。例えば、AliceがstatechainsのUTXOの制御を受け取ると、タイムロックは30日間、彼女が一方的にそのUTXOをチェーン上で使うことができないようにする。アリスがUTXOをボブに転送するとき、タイムロックは彼を29日間だけ制限します。これは、ボブによる支出がアリスによる支出よりも優先されます。このアプローチの欠点は、信頼できる第三者の許可なしに資金を使うことができるようになるまで、代表者が長い間待つ必要があるかもしれないということです。
 
     2. 信頼されたサードパーティと現在のデリゲートとの間の2-of-2 schnorr multisig([adapter signature][scriptless scripts]を使用)を、[secure multiparty computation][mpc]を使用したシングルシグニ ングに置き換える。このアプローチの主な欠点は、複雑さが増してセキュリティレビューが難しくなることです。
 


### PR DESCRIPTION
Newsletter 91 incorrectly referred to sighash_noinput as BIP116 instead of BIP118.