### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, project gets detected as:

JavaScript 24.8%
Gnuplot 24.5%
HTML 20.3%
Shell 7.6%
Makefile 6.7%
SCSS 5.6%
Other 10.5%

After this change, project gets detected as:

Markdown 97.9%
JavaScript 0.5%
Gnuplot 0.5%
HTML 0.4%
Shell 0.2%
Makefile 0.1%
Other 0.4%

---

before this change | after this change
--- | ---
<img width="217" alt="Screen Shot 2021-09-23 at 19 08 21" src="https://user-images.githubusercontent.com/52637275/134554596-834ad494-94da-4dd3-94f6-9eac14ac7b9a.png"> | <img width="214" alt="Screen Shot 2021-09-23 at 19 09 05" src="https://user-images.githubusercontent.com/52637275/134554630-6949523d-afb1-4560-af2f-df3428affe4d.png">

---

This comes from this idea in https://github.com/bitcoinops/scaling-book/pull/28#issuecomment-925577864.
As you can see, with this change **you'd be losing detail on the weight of SCSS**.
I suppose you should ponder if losing that detail the change is still worth to you. https://github.com/bitcoinops/scaling-book/pull/28, on the other hand, was a lossless change, that was an easier decision. :)
