### PR TITLE
Links: update to use new lightning/bolts repo

### DIFF
--- a/_includes/linkers/issues.md
+++ b/_includes/linkers/issues.md
@@ -29,7 +29,7 @@ requests, and other templated URLs.
 [libsecp256k1 #{{_issue}}]: https://github.com/bitcoin-core/secp256k1/issues/{{_issue}}
 [eclair #{{_issue}}]: https://github.com/ACINQ/eclair/issues/{{_issue}}
 [bips #{{_issue}}]: https://github.com/bitcoin/bips/issues/{{_issue}}
-[bolts #{{_issue}}]: https://github.com/lightningnetwork/lightning-rfc/issues/{{_issue}}
+[bolts #{{_issue}}]: https://github.com/lightning/bolts/issues/{{_issue}}
 [rust bitcoin #{{_issue}}]: https://github.com/rust-bitcoin/rust-bitcoin/issues/{{_issue}}
 [rust-lightning #{{_issue}}]: https://github.com/rust-bitcoin/rust-lightning/issues/{{_issue}}
 [review club #{{_issue}}]: https://bitcoincore.reviews/{{_issue}}

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -27,7 +27,7 @@
 [bitcoin transcripts]: https://twitter.com/btctranscripts
 [bitcoin.pdf]: https://bitcoincore.org/bitcoin.pdf
 [bitcoin.se]: https://bitcoin.stackexchange.com/
-[bolts repo]: https://github.com/lightningnetwork/lightning-rfc/
+[bolts repo]: https://github.com/lightning/bolts
 [btcpay server repo]: https://github.com/btcpayserver/btcpayserver/
 [c-lightning]: https://github.com/ElementsProject/lightning
 [c-lightning repo]: https://github.com/ElementsProject/lightning


### PR DESCRIPTION
Can be tested by:

- In any newsletter from the past two years, click the "Lightning BOLTs" link in the *Notable changes* section
- In the newsletters returned by the following grep, scrolling to the *Notable changes* section and clicking the link for "BOLTs #xxx" `git grep -l -- '- \[BOLTs' | xargs grep '^title: '`

You could also diff the built site from before and after the change; I was too lazy to do that.  (Maybe if I'm ever not lazy, I'll add generating a diff to the CI script.  Don't hold y'alls breath though :smile:)