### PR TITLE
Linker: update links for GitHub API change

### DIFF
--- a/_includes/linkers/issues.md
+++ b/_includes/linkers/issues.md
@@ -22,18 +22,18 @@ requests, and other templated URLs.
 -->
 {% assign _issues = include.issues | split: "," %}
 {% endcapture %}{% for _issue in _issues %}
-[bitcoin core #{{_issue}}]: https://github.com/bitcoin/bitcoin/issues/{{_issue}}
-[bitcoin core gui #{{_issue}}]: https://github.com/bitcoin-core/gui/issues/{{_issue}}
-[lnd #{{_issue}}]: https://github.com/lightningnetwork/lnd/issues/{{_issue}}
-[c-lightning #{{_issue}}]: https://github.com/ElementsProject/lightning/issues/{{_issue}}
-[libsecp256k1 #{{_issue}}]: https://github.com/bitcoin-core/secp256k1/issues/{{_issue}}
-[eclair #{{_issue}}]: https://github.com/ACINQ/eclair/issues/{{_issue}}
-[bips #{{_issue}}]: https://github.com/bitcoin/bips/issues/{{_issue}}
-[bolts #{{_issue}}]: https://github.com/lightning/bolts/issues/{{_issue}}
-[rust bitcoin #{{_issue}}]: https://github.com/rust-bitcoin/rust-bitcoin/issues/{{_issue}}
-[rust-lightning #{{_issue}}]: https://github.com/rust-bitcoin/rust-lightning/issues/{{_issue}}
+[bitcoin core #{{_issue}}]: https://github.com/bitcoin/bitcoin/pull/{{_issue}}
+[bitcoin core gui #{{_issue}}]: https://github.com/bitcoin-core/gui/pull/{{_issue}}
+[lnd #{{_issue}}]: https://github.com/lightningnetwork/lnd/pull/{{_issue}}
+[c-lightning #{{_issue}}]: https://github.com/ElementsProject/lightning/pull/{{_issue}}
+[libsecp256k1 #{{_issue}}]: https://github.com/bitcoin-core/secp256k1/pull/{{_issue}}
+[eclair #{{_issue}}]: https://github.com/ACINQ/eclair/pull/{{_issue}}
+[bips #{{_issue}}]: https://github.com/bitcoin/bips/pull/{{_issue}}
+[bolts #{{_issue}}]: https://github.com/lightning/bolts/pull/{{_issue}}
+[rust bitcoin #{{_issue}}]: https://github.com/rust-bitcoin/rust-bitcoin/pull/{{_issue}}
+[rust-lightning #{{_issue}}]: https://github.com/rust-bitcoin/rust-lightning/pull/{{_issue}}
 [review club #{{_issue}}]: https://bitcoincore.reviews/{{_issue}}
-[hwi #{{_issue}}]: https://github.com/bitcoin-core/HWI/issues/{{_issue}}
-[btcpay server #{{_issue}}]: https://github.com/btcpayserver/btcpayserver/issues/{{_issue}}
-[bdk #{{_issue}}]: https://github.com/bitcoindevkit/bdk/issues/{{_issue}}
+[hwi #{{_issue}}]: https://github.com/bitcoin-core/HWI/pull/{{_issue}}
+[btcpay server #{{_issue}}]: https://github.com/btcpayserver/btcpayserver/pull/{{_issue}}
+[bdk #{{_issue}}]: https://github.com/bitcoindevkit/bdk/pull/{{_issue}}
 {% endfor %}


### PR DESCRIPTION
Closes #698 

`github.com/org/project/issue/number` used to redirect to either an issue or a PR appropriately.  Now it returns a 404 if the number doesn't correspond to an issue.

`github.com/org/project/pull/number` still has the same redirect behavior, so we update to use that instead.  Tested on both PRs (most of our links) and also an issue, see `/en/newsletters/2020/01/29/#bolts-705` on the preview.