### PR TITLE
Transaction Pinning: emphasize that the sum of fees needs to be replaced

### DIFF
--- a/_topics/en/transaction-pinning.md
+++ b/_topics/en/transaction-pinning.md
@@ -71,10 +71,10 @@ Some of the limits that can be abused to enable transaction pinning
 include:
 
 - **[BIP125][] RBF rule #3** requires a replacement transaction
-  pay a higher absolute fee (not just feerate) than the transaction
-  being replaced and any of its children.  This can allow an attacker
-  to attach a large and low-feerate transaction to the transaction
-  they want to pin, forcing any fee bump to pay for the
+  pay a higher absolute fee (not just feerate) than the sum of fees paid
+  by the transaction being replaced and all of its children.  This can
+  allow an attacker to attach a large and low-feerate transaction to
+  the transaction they want to pin, forcing any fee bump to pay for the
   replacement of the large child transaction.  E.g., with the 2019
   Bitcoin Core defaults, an attacker can require an honest participant
   pay a minimum of 0.001 BTC to fee bump a transaction (or even


### PR DESCRIPTION
The [existing wording](https://bitcoinops.org/en/topics/transaction-pinning/) could easily be misunderstood as the minimum absolute fee needed to equal just the highest paying transaction ("any"), instead of the sum of all fees of the replaced transaction and its children, as it is described in [BIP125](https://github.com/bitcoin/bips/blame/master/bip-0125.mediawiki#L56). I think this proposal makes it less ambiguous.