### PR TITLE
Rebuild indices for all languages on preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ clean:
 preview:
 	## Don't do a full rebuild (to save time), but always rebuild index pages.
 	rm -f _site/index.html \
-	      _site/en/blog/index.html \
-	      _site/en/newsletters/index.html \
-	      _site/en/publications/index.html \
-	      _site/en/topics/categories/index.html \
-	      _site/en/topics/dates/index.html \
-	      _site/en/topics/index.html
+	      _site/*/blog/index.html \
+	      _site/*/newsletters/index.html \
+	      _site/*/publications/index.html \
+	      _site/*/topics/categories/index.html \
+	      _site/*/topics/dates/index.html \
+	      _site/*/topics/index.html
 	bundle exec jekyll serve $(JEKYLL_FLAGS)
 
 build:


### PR DESCRIPTION
This updates the Makefile to rebuild indices of all languages so that translated articles and links to other languages show up in previews.

Note that I have never worked with Makefiles before, so I'm just taking a stab in the dark here—although it did seem to achieve the desired effect.