### PR TITLE
WIP: Add covenant-related information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ test-before-build: $(covprop_validation) $(covapps_validation) $(compatibility_v
 	! git --no-pager grep -i '[d]iscrete log contract'
 
 test-after-build: build
+	## Check for rendering errors in the built site
+	! grep -r ERROR_ _site/
+
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	! find _site/ -name '*.html' | xargs grep '\[^' | grep .

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ compatibility_validation = $(wildcard _data/compatibility/*.yaml)
 compatibility_validation := $(patsubst _data/compatibility/%.yaml,_site/en/compatibility/%/index.html,$(compatibility_validation))
 topic_validation = $(wildcard _topics/en/*.md)
 topic_validation := $(patsubst _topics/en/%.md,_site/en/topics/%/index.html,$(topic_validation))
+covprop_validation = $(wildcard _covprops/en/*.md)
+covprop_validation := $(patsubst _covprops/en/%.md,_site/en/covenants/proposals/%/index.html,$(covprop_validation))
+covapps_validation = $(wildcard _covapps/en/*.md)
+covapps_validation := $(patsubst _covapps/en/%.md,_site/en/covenants/applications/%/index.html,$(covapps_validation))
 
 clean:
 	bundle exec jekyll clean
@@ -38,7 +42,7 @@ build:
 	bundle exec jekyll build $(JEKYLL_FLAGS)
 
 
-test-before-build: $(compatibility_validation) $(topic_validation)
+test-before-build: $(covprop_validation) $(covapps_validation) $(compatibility_validation) $(topic_validation)
 	## Check for Markdown formatting problems
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .
@@ -121,3 +125,9 @@ _site/en/compatibility/%/index.html : _data/compatibility/%.yaml
 
 _site/en/topics/%/index.html : _topics/en/%.md
 	bundle exec _contrib/schema-validator.rb _data/schemas/topics.yaml $<
+
+_site/en/covenants/proposals/%/index.html : _covprops/en/%.md
+	bundle exec _contrib/schema-validator.rb _data/schemas/covprops.yaml $<
+
+_site/en/covenants/applications/%/index.html : _covapps/en/%.md
+	bundle exec _contrib/schema-validator.rb _data/schemas/covapps.yaml $<

--- a/_config.yml
+++ b/_config.yml
@@ -78,10 +78,10 @@ collections:
     output: true
   covprops:
     output: true
-    permalink: /en/covenants/proposals/:title/
+    permalink: /en/lore/covenants/proposals/:title/
   covapps:
     output: true
-    permalink: /en/covenants/apps/:title/
+    permalink: /en/lore/covenants/apps/:title/
 
 languages:
   - code: ja

--- a/_config.yml
+++ b/_config.yml
@@ -62,10 +62,26 @@ defaults:
       layout: topic
       permalink: /en/topics/:title/
       localizable: false
+  - scope:
+      path: "_covprops"
+    values:
+      layout: covprop
+      localizable: false
+  - scope:
+      path: "_covapps"
+    values:
+      layout: covapp
+      localizable: false
 
 collections:
   topics:
     output: true
+  covprops:
+    output: true
+    permalink: /en/covenants/proposals/:title/
+  covapps:
+    output: true
+    permalink: /en/covenants/apps/:title/
 
 languages:
   - code: ja

--- a/_covapps/en/channel-factories.md
+++ b/_covapps/en/channel-factories.md
@@ -1,0 +1,23 @@
+---
+title: Channel Factories
+uid: channel_factories
+topic_page_or_best_reference: /en/topics/channel_factories/
+excerpt: >
+  Channel factories are an efficient way of creating payment channels.
+  Multiple participants trustlessly combine their funds together using a
+  single transaction.  From the combined funds, they create payment
+  channels between each pair of participants, e.g. Alice with Bob, Bob
+  with Carol, and Alice with Carol.  Although these are regular payment
+  channels, the transactions opening the channels never need to appear
+  on chain as long as the participants remain in cooperation with each
+  other, allowing *n* users to open *n(n-1)/2* channels at the cost of
+  opening and mutual transactions that are only roughly *n* times larger
+  than standard open and mutual close transactions, e.g. 10 users can
+  open 45 channels using transactions only 10x larger than normal.  In
+  the case any participant violates the channel protocol, each
+  participant has the independent ability to close their channel onchain
+  in the proper state, ensuring the protocol remains trustless.
+
+
+---
+Test

--- a/_covapps/en/channel-factories.md
+++ b/_covapps/en/channel-factories.md
@@ -20,4 +20,33 @@ excerpt: >
 
 
 ---
-Test
+Channel factories are similar to [joinpools][topic joinpools].  Also
+similar to joinpools, channel factories don't require any changes to
+Bitcoin---using presigned transactions is enough---but several covenant
+proposals could help make factories more efficient, easier to construct,
+or easier to analyze.
+
+Some notable quotes about channel factories related to covenant
+proposals:
+
+- "The ability to extend the protocol to a larger number of participants
+  also means that it can be used for other protocols, such as the
+  channel factories presented by Burchert et al.  Prior to eltoo this
+  used the Duplex Micropayment Channel construction, which resulted in a
+  far larger number of transactions being published in the case of a
+  non-cooperative settlement of the contract."  ---[Eltoo paper][] by
+  Decker, Russell, and Osuntokun (Note: the eltoo protocol is based on
+  the `SIGHASH_ANYPREVOUT` proposal)
+
+- "IIDs support a simple factory protocol in which not all parties need
+  to sign the factory's funding transaction, thus greatly improving the
+  scale of the factory (at the expense of requiring an on-chain
+  transaction to update the set of channels created by the factory).
+  These channel factories can be combined with the 2Stage protocol to
+  create trust-free and watchtower-free channels including very large
+  numbers of casual users."  ---[Inherited Identifiers (IIDs)
+  introduction][iid intro] by John Law
+
+{% include references.md %}
+[eltoo paper]: https://blockstream.com/eltoo.pdf
+[iid intro]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-September/019470.html

--- a/_covapps/en/congestion_control.md
+++ b/_covapps/en/congestion_control.md
@@ -1,0 +1,11 @@
+---
+title: Congestion control
+uid: congestion_control
+topic_page_or_best_reference: https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki#Congestion_Controlled_Transactions
+excerpt: >
+  Congestion control excerpt FIXME
+
+---
+Congestion control body FIXME
+
+{% include references.md %}

--- a/_covapps/en/dlc-efficiency.md
+++ b/_covapps/en/dlc-efficiency.md
@@ -1,0 +1,11 @@
+---
+title: DLC efficiency improvements
+uid: dlc_efficiency
+topic_page_or_best_reference: /en/newsletters/2022/02/02/#improving-dlc-efficiency-by-changing-script
+excerpt: >
+  DLC efficiency excerpt FIXME
+
+---
+DLC efficiency body FIXME
+
+{% include references.md %}

--- a/_covprops/en/cat+csfs.md
+++ b/_covprops/en/cat+csfs.md
@@ -9,10 +9,13 @@ implementations:
   - name: Liquid
     can_lose_significant_money: true
     reference: https://example.com/FIXME
+    since: 2018
 
   - name: Bcash
     can_lose_significant_money: true
-    reference: https://example.com/FIXME
+    reference: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_checkdatasig.md
+    # also https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-reenabled-opcodes.md
+    since: 2018
 
 covenant_based_apps:
   channel_factories:
@@ -82,7 +85,8 @@ excerpt: >
 
 - **Non-covenant applications:** string concatenation and arbitrary
   signature checking can also be used for several applications unrelated
-  to covenants; see their [Optech topic page][] for details.
+  to covenants; see their [Optech topic page][] for details.  FIXME: add
+  QC resistance.
 
 ## Disadvantages
 

--- a/_covprops/en/cat+csfs.md
+++ b/_covprops/en/cat+csfs.md
@@ -1,0 +1,115 @@
+---
+title: "OP_CAT + OP_CHECKSIGFROMSTACK"
+shorttitle: "OP_CAT + OP_CSFS"
+uid: cat_csfs
+#layout: covprop
+topic_page_or_best_reference: /en/topics/op_checksigfromstack/
+
+implementations:
+  - name: Liquid
+    can_lose_significant_money: true
+    reference: https://example.com/FIXME
+
+  - name: Bcash
+    can_lose_significant_money: true
+    reference: https://example.com/FIXME
+
+covenant_based_apps:
+  channel_factories:
+    enabled: true
+
+  congestion_control:
+    enabled: true
+
+  dlc_efficiency:
+    enabled: true
+
+  drivechains:
+    enabled: true
+
+  eltoo:
+    enabled: true
+
+  statechains:
+    enabled: true
+
+  joinpools:
+    enabled: true
+
+  non_interactive_channels:
+    enabled: true
+
+  bishop_vaults:
+    enabled: true
+
+  mes_vaults:
+    enabled: true
+    example_code: https://blog.blockstream.com/en-covenants-in-elements-alpha/
+    #example_txes: NONE
+
+  obeirne_vaults:
+    enabled: true
+
+  zk_rollups:
+    enabled: true
+
+excerpt: >
+  `OP_CAT` concatenates two strings and `OP_CHECKSIGFROMSTACK`
+  (`OP_CSFS`) checks a pubkey and signature combination against an
+  arbitrary messages.  Bitcoin's existing `OP_CHECKSIG` opcodes check
+  pubkeys and signatures against the transaction containing them.  If
+  the same pubkey and signature are valid for both the containing
+  transaction and the arbitrary message, then the arbitrary message must
+  be a copy of the transaction containing it.  This allows the receiver
+  of an output to specify certain strings that must be present in the
+  transaction spending that output (creating a covenant).  `OP_CAT` is
+  used to concatenate those strings with strings only the spender can
+  provide.
+---
+## Advantages
+
+- **Simple:** the direct behavior of both opcodes is very simple to
+  understand:
+
+   - `OP_CAT` takes two strings and concatenates them
+   - `OP_CSFS` takes a pubkey, message, and signatature and returns true
+     if they're a validate combination (i.e. the private key from
+     which the public key was derived also created the signature for
+     that particular message)<br><br>
+
+- **Flexible:** together the opcodes are believed to enable some version
+  of all covenant-based applications.
+
+- **Non-covenant applications:** string concatenation and arbitrary
+  signature checking can also be used for several applications unrelated
+  to covenants; see their [Optech topic page][] for details.
+
+## Disadvantages
+
+- **General:** the flexible nature of CAT+CSFS allows users to opt-in to
+  receiving payments to types of covenants that other users might
+  find objectionable, such as drivechains or perpetual covenants.
+
+- **Expensive:** using CAT+CSFS for coveneants requires putting a copy
+  of the spending transaction on the execution stack.  That can roughly
+  double the size of a spending transaction over the other data needed
+  to make it valid.  Other proposals such as [OP_TX][] could reduce this
+  overhead.
+
+- **Difficult:** using CAT+CSFS to create a covenant requires
+  concatenating data provided by the covenant creator with data provided
+  by the spender, with the covenant creator needing to devise tests in
+  the Script language that ensure the spender-provided data satisfies
+  the creator's intentions.  That's challenging enough, but the creator
+  also needs to ensure that transactions created within the covenant
+  don't accidentally get into a state where further spending become
+  improssible, burning funds.  Although both of these are challenges for
+  any generalized covenant system, managing trusted and untrusted data
+  as strings is more difficult than other ways of addressing
+  information, e.g. it would be simpler to use [OP_TX][] to introspect
+  on parts of the spending transaction directly.
+
+## Alternative approaches
+
+FIXME:OP_TX
+

--- a/_covprops/en/cat+csfs.md
+++ b/_covprops/en/cat+csfs.md
@@ -1,6 +1,6 @@
 ---
 title: "OP_CAT + OP_CHECKSIGFROMSTACK"
-shorttitle: "OP_CAT + OP_CSFS"
+shorttitle: "CAT+CSFS"
 uid: cat_csfs
 #layout: covprop
 topic_page_or_best_reference: /en/topics/op_checksigfromstack/
@@ -19,42 +19,42 @@ implementations:
 
 covenant_based_apps:
   channel_factories:
-    enabled: true
+    enabled: "true"
 
   congestion_control:
-    enabled: true
+    enabled: "true"
 
   dlc_efficiency:
-    enabled: true
+    enabled: "unknown"
 
   drivechains:
-    enabled: true
+    enabled: "true"
 
   eltoo:
-    enabled: true
+    enabled: "true"
 
   statechains:
-    enabled: true
+    enabled: "true"
 
   joinpools:
-    enabled: true
+    enabled: "true"
 
   non_interactive_channels:
-    enabled: true
+    enabled: "true"
 
   bishop_vaults:
-    enabled: true
+    enabled: "true"
 
   mes_vaults:
-    enabled: true
+    enabled: "true"
     example_code: https://blog.blockstream.com/en-covenants-in-elements-alpha/
     #example_txes: NONE
 
   obeirne_vaults:
-    enabled: true
+    enabled: "true"
 
   zk_rollups:
-    enabled: true
+    enabled: "true"
 
 excerpt: >
   `OP_CAT` concatenates two strings and `OP_CHECKSIGFROMSTACK`

--- a/_covprops/en/cat+csfs.md
+++ b/_covprops/en/cat+csfs.md
@@ -9,13 +9,13 @@ implementations:
   - name: Liquid
     can_lose_significant_money: true
     reference: https://example.com/FIXME
-    since: 2018
+    since: "2018"
 
   - name: Bcash
     can_lose_significant_money: true
     reference: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_checkdatasig.md
     # also https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-reenabled-opcodes.md
-    since: 2018
+    since: "2018"
 
 covenant_based_apps:
   channel_factories:
@@ -85,8 +85,8 @@ excerpt: >
 
 - **Non-covenant applications:** string concatenation and arbitrary
   signature checking can also be used for several applications unrelated
-  to covenants; see their [Optech topic page][] for details.  FIXME: add
-  QC resistance.
+  to covenants; see the CAT+CSFS [topic page][topic
+  op_checksigfromstack] for details.  FIXME: add QC resistance.
 
 ## Disadvantages
 
@@ -97,7 +97,7 @@ excerpt: >
 - **Expensive:** using CAT+CSFS for coveneants requires putting a copy
   of the spending transaction on the execution stack.  That can roughly
   double the size of a spending transaction over the other data needed
-  to make it valid.  Other proposals such as [OP_TX][] could reduce this
+  to make it valid.  Other proposals such as OP_TX could reduce this
   overhead.
 
 - **Difficult:** using CAT+CSFS to create a covenant requires
@@ -110,10 +110,11 @@ excerpt: >
   improssible, burning funds.  Although both of these are challenges for
   any generalized covenant system, managing trusted and untrusted data
   as strings is more difficult than other ways of addressing
-  information, e.g. it would be simpler to use [OP_TX][] to introspect
-  on parts of the spending transaction directly.
+  information, e.g. it would be simpler to use OP_TX to introspect on
+  parts of the spending transaction directly.
 
 ## Alternative approaches
 
 FIXME:OP_TX
 
+{% include references.md %}

--- a/_covprops/en/sighash_anyprevout.md
+++ b/_covprops/en/sighash_anyprevout.md
@@ -1,0 +1,24 @@
+---
+title: "SIGHASH_ANYPREVOUT"
+shorttitle: "APO"
+uid: apo
+topic_page_or_best_reference: /en/topics/sighash_anyprevout/
+
+implementations:
+
+covenant_based_apps:
+  channel_factories:
+    enabled: "true"
+
+  congestion_control:
+    enabled: "unknown"
+
+  dlc_efficiency:
+    enabled: "unknown"
+
+excerpt: >
+  APO excerpt FIXME
+---
+APO body FIXME
+
+{% include references.md %}

--- a/_data/schemas/covapps.yaml
+++ b/_data/schemas/covapps.yaml
@@ -1,0 +1,60 @@
+---
+id: https://bitcoinops.org/schema/covenants/proposals
+description: The covenant-based application object
+type: object
+required:
+  - title
+  - uid
+  - topic_page_or_best_reference
+  - excerpt
+additionalProperties: false
+properties:
+  title:
+    description: Title of the application
+    type: string
+
+  uid:
+    description: Unique identifier for this application
+    type: string
+    maxLength: 20  # arbitrary but short
+    pattern: "^[a-z][a-z0-9_]*$"  # starts lowercase, then all lowercase or numbers or underscore
+
+  shorttitle:
+    description: Short alternative name to use for links and quick mentions
+    type: string
+
+  excerpt:
+    description: A short description of the application
+    type: string
+    minLength: 1   ## Anything not empty
+    maxLength: 1000 ## Arbitrary but suggest keeping it short for cases where the excerpt is included in summaries
+
+  topic_page_or_best_reference:
+    description: A link to the best reference for the proposal, preferably an Optech topic page but possibly an external reference
+    type: string
+
+  implementations:
+    description: A list of known implementations of the proposal, either for testnets or other production networks such as sidechains or altcoins
+    type: list
+    items:
+      type: object
+      required:
+        - name
+        - can_lose_significant_money
+        - reference
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the implementation network, such as "CTV signet" or "Liquid"
+          type: string
+
+        can_lose_significant_money:
+          description: Whether it's easily possible to lose significant amounts of money playing with the network.  This is a proxy for "production network"
+          type: boolean
+
+        reference:
+          description: URL to information about the implementation of this proposal on the indicated network
+          type: string
+
+  extra:
+    description: Extra fields (not validated)

--- a/_data/schemas/covprops.yaml
+++ b/_data/schemas/covprops.yaml
@@ -72,7 +72,8 @@ properties:
             - enabled
           enabled:
             description: Whether the proposal in this document enables the applictaion in this item
-            type: boolean
+            type: string
+            pattern: "^(true|false|unknown)$"
 
           example_code:
             description: Link to example code demonstrating the use of this proposal for this application

--- a/_data/schemas/covprops.yaml
+++ b/_data/schemas/covprops.yaml
@@ -56,6 +56,11 @@ properties:
           description: URL to information about the implementation of this proposal on the indicated network
           type: string
 
+        since:
+          description: Approximate date when the implementation became available for use
+          type: string
+          pattern: "^[0-9]{4}[-0-9]*$"  # e.g. 2018 or 2018-04-01
+
   covenant_based_apps:
     description: A list of covenant-based applications
     type: object

--- a/_data/schemas/covprops.yaml
+++ b/_data/schemas/covprops.yaml
@@ -1,0 +1,84 @@
+---
+id: https://bitcoinops.org/schema/covenants/proposals
+description: The covenant proposal object
+type: object
+required:
+  - title
+  - uid
+  - topic_page_or_best_reference
+  - excerpt
+additionalProperties: false
+properties:
+  title:
+    description: Title of the topic
+    type: string
+
+  uid:
+    description: Unique identifier for this application
+    type: string
+    maxLength: 20  # arbitrary but short
+    pattern: "^[a-z][a-z0-9_]*$"  # starts lowercase, then all lowercase or numbers or underscore
+
+  shorttitle:
+    description: Short alternative name to use for links and quick mentions
+    type: string
+
+  excerpt:
+    description: A short description of the proposal
+    type: string
+    minLength: 1   ## Anything not empty
+    maxLength: 1000 ## Arbitrary but suggest keeping it short for cases where the excerpt is included in summaries
+
+  topic_page_or_best_reference:
+    description: A link to the best reference for the proposal, preferably an Optech topic page but possibly an external reference
+    type: string
+
+  implementations:
+    description: A list of known implementations of the proposal, either for testnets or other production networks such as sidechains or altcoins
+    type: list
+    items:
+      type: object
+      required:
+        - name
+        - can_lose_significant_money
+        - reference
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the implementation network, such as "CTV signet" or "Liquid"
+          type: string
+
+        can_lose_significant_money:
+          description: Whether it's easily possible to lose significant amounts of money playing with the network.  This is a proxy for "production network"
+          type: boolean
+
+        reference:
+          description: URL to information about the implementation of this proposal on the indicated network
+          type: string
+
+  covenant_based_apps:
+    description: A list of covenant-based applications
+    type: object
+    patternProperties:
+      "^":  # Match everything
+        additionalProperties: false
+        properties:
+          required:
+            - enabled
+          enabled:
+            description: Whether the proposal in this document enables the applictaion in this item
+            type: boolean
+
+          example_code:
+            description: Link to example code demonstrating the use of this proposal for this application
+            type: string
+
+          example_txes:
+            description: Link to example transactions demonstrating the use of this proposal for this application
+            type: string
+            
+      
+    
+
+  extra:
+    description: Extra fields (not validated)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,10 +22,8 @@
         <div class="trigger">
             <a class="page-link" href="/about/">About</a>
             <a class="page-link" href="/en/publications/">Publications</a>
-            <a class="page-link" href="/en/topics/">Topics</a>
+            <a class="page-link" href="/en/lore/">Lore</a>
             <a class="page-link" href="/workshops/">Workshops</a>
-            <a class="page-link" href="/en/compatibility/">Compatibility</a>
-            <a class="page-link" href="https://dashboard.bitcoinops.org/">Dashboard</a>
         </div>
       </nav>
     {%- endif -%}

--- a/_includes/linkers/prevnext.md
+++ b/_includes/linkers/prevnext.md
@@ -1,0 +1,16 @@
+{% capture /dev/null %}
+  {% assign entries = include.entries | natural_sort: "title" %}
+  {% capture first_link %}[{{entries[0].title}}]({{entries[0].url}}){% endcapture %}
+  {% capture last_link %}[{{entries[-1].title}}]({{entries[-1].url}}){% endcapture %}
+  {% for entry in entries %}
+    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
+    {% if prev_link %}
+      {% assign next_link = entry_link %}
+      {% break %}
+    {% endif %}
+    {% if entry.url == page.url %}
+      {% assign prev_link = prev_entry | default: last_link %}
+    {% endif %}
+    {% assign prev_entry = entry_link %}
+  {% endfor %}
+{% endcapture %}

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -7,9 +7,15 @@
 [scaling payment batching]: /en/payment-batching/
 [series preparing for taproot]: /en/preparing-for-taproot/
 
-{% comment %}<!-- links for topics -->{% endcomment %}
-{% for topic in site.topics %}
-  [topic {{topic.shortname | default: topic.title}}]: {{topic.url}}
+{% comment %}<!-- links for collections -->{% endcomment %}
+{% for entry in site.topics %}
+  [topic {{entry.shortname | default: entry.title}}]: {{entry.url}}
+{%- endfor %}
+{% for entry in site.covprops %}
+  [covprop {{entry.shortname | default: entry.title}}]: {{entry.url}}
+{%- endfor %}
+{% for entry in site.covapps %}
+  [covapp {{entry.shortname | default: entry.title}}]: {{entry.url}}
 {%- endfor %}
 
 {% comment %}<!-- reused (or likely to be reused) external links, alphabetical order -->{% endcomment %}

--- a/_layouts/covapp.html
+++ b/_layouts/covapp.html
@@ -104,13 +104,14 @@ layout: post
     {% assign evidence = "✓✓" %}
   {% endif %}
 
-  {% if prop_status.enabled == true %}
+  {% if prop_status.enabled == "true" %}
   <details markdown="block"><summary markdown="span">**{{prop.shorttitle}}&nbsp;{{evidence}}**</summary>
   {{prop.excerpt}}
 
   [Learn more about {{prop.shorttitle}}]({{prop.url}})
   </details>
-  {%- elsif prop_status.enabled != false -%}
+  {%- elsif prop_status.enabled == "unknown" -%}
+  {%- elsif prop_status.enabled != "false" -%}
   ERROR_PROP_STATUS_NOT_DEFINED={{prop.id}}
   {% endif %}
   {% endfor %}

--- a/_layouts/covapp.html
+++ b/_layouts/covapp.html
@@ -1,0 +1,164 @@
+---
+layout: post
+---
+{% capture newline %}
+{% endcapture %}
+{% capture /dev/null %}
+  <!-- Get links for previous and next pages -->
+  {% assign topics_list = site.topics | natural_sort: "title" %}
+  {% capture first_link %}[{{topics_list[0].title}}]({{topics_list[0].url}}){% endcapture %}
+  {% capture last_link %}[{{topics_list[-1].title}}]({{topics_list[-1].url}}){% endcapture %}
+  {% for entry in topics_list %}
+    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
+    {% if prev_link %}
+      {% assign next_link = entry_link %}
+      {% break %}
+    {% endif %}
+    {% if entry.url == page.url %}
+      {% assign prev_link = prev_entry | default: last_link %}
+    {% endif %}
+    {% assign prev_entry = entry_link %}
+  {% endfor %}
+
+  <!-- Build natural sentence-style list of aliases for this page's topic -->
+  {% if page.aliases != nil %}
+    {% assign num_aliases = page.aliases | size %}
+    {% capture aliases %}{:.center}{{newline}}*Also covering&nbsp;{% endcapture %}
+    {% if num_aliases > 2 %}
+      {% for alias in page.aliases %}
+        {% if forloop.last %}
+          {% capture aliases %}{{aliases}}, and {{alias}}{% endcapture %}
+        {% elsif forloop.first %}
+          {% capture aliases %}{{aliases}}{{alias}}{% endcapture %}
+        {% else %}
+          {% capture aliases %}{{aliases}}, {{alias}}{% endcapture %}
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      {% capture aliases %}{{aliases}}{{page.aliases | join: ' and '}}{% endcapture %}
+    {% endif %}
+    {% assign aliases = aliases | append: '*' %}
+  {% endif %}
+
+  <!-- Build list of primary sources -->
+  {% for source in page.primary_sources %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture primary_sources %}{{primary_sources}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of internal optech mentions -->
+  {% assign references = '' %}
+  {% for mention in page.optech_mentions %}
+    {% if mention.feature == true %}
+      {% assign bold = '{:.bold}' %}
+    {% else %}
+      {% assign bold='' %}
+    {% endif %}
+    {% include functions/get-mention-date.md %}
+    {% capture references %}{{references}}{{date}}- [{{mention.title}}]({{mention.url}}){{bold}}ENDENTRY{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of see also entries -->
+  {% for source in page.see_also %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture see_also %}{{see_also}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Variable for use in links -->
+  {% capture gh_base %}https://github.com/{{site.github_username}}/{{site.repository_name}}{% endcapture %}
+
+  <!-- whether or not to display a stub notice -->
+  {% assign word_count = page.content | number_of_words %}
+  {% if page.stub != false %}
+    <!-- if any words, not a stub.  We may increase word count later -->
+    {% if word_count < 1 or page.stub == true %}
+      {% capture notices %}{{notices}}{% include snippets/stub-topic.md %}{% endcapture %}
+    {% endif %}
+  {% endif %}
+
+{% endcapture %}
+
+<!-- Actual page content -->
+{% capture content %}
+  {% include references.md %}
+  {{aliases}}
+
+  {{page.excerpt}}
+
+  {{page.content}}
+
+  {{notices | default: newline}}
+
+  {{- '## Enabling proposals' }}
+
+  *Proposals to change Bitcoin that would enable {{page.title}}.  Click
+  any application name to see more information. ✓ = code available; ✓✓ =
+  example transactions available.*
+
+  {% for prop in site.covprops %}
+  {% assign prop_status = prop.covenant_based_apps[page.uid] %}
+
+  {% assign evidence = "" %}
+  {% assign evidence_details = "" %}
+  {% if prop_status.example_code contains "http" %}
+    {% assign evidence = "✓" %}
+    {% capture evidence_details %}- [Example code]({{prop_status.example_code}}) using {{page.shorttitle}} to enable {{app.title}}{% endcapture %}
+  {% endif %}
+  {% if prop_status.example_txes contains "http" %}
+    {% assign evidence = "✓✓" %}
+  {% endif %}
+
+  {% if prop_status.enabled == true %}
+  <details markdown="block"><summary markdown="span">**{{prop.shorttitle}}&nbsp;{{evidence}}**</summary>
+  {{prop.excerpt}}
+
+  [Learn more about {{prop.shorttitle}}]({{prop.url}})
+  </details>
+  {%- elsif prop_status.enabled != false -%}
+  ERROR_PROP_STATUS_NOT_DEFINED={{prop.id}}
+  {% endif %}
+  {% endfor %}
+
+
+  {%- if page.primary_sources and page.primary_sources != '' -%}
+    ## Primary code and documentation
+
+    {{primary_sources}}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.optech_mentions and page.optech_mentions != '' -%}
+    ## Optech newsletter and website mentions
+
+    {% assign sorted_references = references | split: 'ENDENTRY' | sort | reverse %}
+    {%- for reference in sorted_references -%}
+      {%- assign current_ref_year = reference | slice: 0, 4 -%}
+      {%- if current_ref_year != last_ref_year -%}
+        {{newline}}{{newline}}**{{current_ref_year}}**
+      {%- endif -%}
+      {{newline}}{{reference | slice: 10, 9999999999 }}
+      {%- assign last_ref_year = current_ref_year -%}
+    {%- endfor -%}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.see_also and page.see_also != '' -%}
+    ## See also
+
+    {{see_also}}
+  {% endif %}
+
+  <br>{{newline}}{{newline}}
+<span class="float-left" markdown="1">**Previous Topic:**<br>{{prev_link}}</span>
+<span class="float-right" markdown="1">**Next Topic:**<br>{{next_link | default: first_link }}</span>
+
+  {:.center}
+  [Edit page]({{gh_base}}/edit/master/{{page.path}})<br>
+  [Report Issue]({{gh_base}}/issues/new?body={{'Source file: ' | append: page.path | url_escape }})
+{% endcapture %}{{ content | markdownify }}

--- a/_layouts/covapp.html
+++ b/_layouts/covapp.html
@@ -5,20 +5,7 @@ layout: post
 {% endcapture %}
 {% capture /dev/null %}
   <!-- Get links for previous and next pages -->
-  {% assign topics_list = site.topics | natural_sort: "title" %}
-  {% capture first_link %}[{{topics_list[0].title}}]({{topics_list[0].url}}){% endcapture %}
-  {% capture last_link %}[{{topics_list[-1].title}}]({{topics_list[-1].url}}){% endcapture %}
-  {% for entry in topics_list %}
-    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
-    {% if prev_link %}
-      {% assign next_link = entry_link %}
-      {% break %}
-    {% endif %}
-    {% if entry.url == page.url %}
-      {% assign prev_link = prev_entry | default: last_link %}
-    {% endif %}
-    {% assign prev_entry = entry_link %}
-  {% endfor %}
+    {% include linkers/prevnext.md entries=site.covapps %}
 
   <!-- Build natural sentence-style list of aliases for this page's topic -->
   {% if page.aliases != nil %}
@@ -99,9 +86,10 @@ layout: post
 
   {{- '## Enabling proposals' }}
 
-  *Proposals to change Bitcoin that would enable {{page.title}}.  Click
-  any application name to see more information. ✓ = code available; ✓✓ =
-  example transactions available.*
+  *Proposals to change Bitcoin that would enable {{page.title}} or
+  provide significant benefits to using them.  Click any application
+  name to see more information. ✓ = code available; ✓✓ = example
+  transactions available.*
 
   {% for prop in site.covprops %}
   {% assign prop_status = prop.covenant_based_apps[page.uid] %}

--- a/_layouts/covprop.html
+++ b/_layouts/covprop.html
@@ -130,13 +130,14 @@ layout: post
 
   {% endfor %}
 
-  {%- if page.implementations.size > 0 -%}
-  ## Implementations
 
-    {% for implementation in page.implementations %}
-      * [{{implementation.name}}]({{implementation.reference}}){% if implementation.can_lose_significant_money == true %}(production){% endif %}
-    {% endfor %}
-  {% endif %}
+  {%- if page.implementations.size > 0 -%}
+  <h2>Implementations</h2>
+
+    {%- for implementation in page.implementations -%}
+      * [{{implementation.name}}]({{implementation.reference}}){% if implementation.can_lose_significant_money == true %} (production){% endif %}{{newline}}
+    {%- endfor -%}
+  {%- endif -%}
 
 
   {%- if page.primary_sources and page.primary_sources != '' -%}

--- a/_layouts/covprop.html
+++ b/_layouts/covprop.html
@@ -5,20 +5,7 @@ layout: post
 {% endcapture %}
 {% capture /dev/null %}
   <!-- Get links for previous and next pages -->
-  {% assign topics_list = site.topics | natural_sort: "title" %}
-  {% capture first_link %}[{{topics_list[0].title}}]({{topics_list[0].url}}){% endcapture %}
-  {% capture last_link %}[{{topics_list[-1].title}}]({{topics_list[-1].url}}){% endcapture %}
-  {% for entry in topics_list %}
-    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
-    {% if prev_link %}
-      {% assign next_link = entry_link %}
-      {% break %}
-    {% endif %}
-    {% if entry.url == page.url %}
-      {% assign prev_link = prev_entry | default: last_link %}
-    {% endif %}
-    {% assign prev_entry = entry_link %}
-  {% endfor %}
+  {% include linkers/prevnext.md entries=site.covprops %}
 
   <!-- Build natural sentence-style list of aliases for this page's topic -->
   {% if page.aliases != nil %}

--- a/_layouts/covprop.html
+++ b/_layouts/covprop.html
@@ -1,0 +1,175 @@
+---
+layout: post
+---
+{% capture newline %}
+{% endcapture %}
+{% capture /dev/null %}
+  <!-- Get links for previous and next pages -->
+  {% assign topics_list = site.topics | natural_sort: "title" %}
+  {% capture first_link %}[{{topics_list[0].title}}]({{topics_list[0].url}}){% endcapture %}
+  {% capture last_link %}[{{topics_list[-1].title}}]({{topics_list[-1].url}}){% endcapture %}
+  {% for entry in topics_list %}
+    {% capture entry_link %}[{{entry.title}}]({{entry.url}}){% endcapture %}
+    {% if prev_link %}
+      {% assign next_link = entry_link %}
+      {% break %}
+    {% endif %}
+    {% if entry.url == page.url %}
+      {% assign prev_link = prev_entry | default: last_link %}
+    {% endif %}
+    {% assign prev_entry = entry_link %}
+  {% endfor %}
+
+  <!-- Build natural sentence-style list of aliases for this page's topic -->
+  {% if page.aliases != nil %}
+    {% assign num_aliases = page.aliases | size %}
+    {% capture aliases %}{:.center}{{newline}}*Also covering&nbsp;{% endcapture %}
+    {% if num_aliases > 2 %}
+      {% for alias in page.aliases %}
+        {% if forloop.last %}
+          {% capture aliases %}{{aliases}}, and {{alias}}{% endcapture %}
+        {% elsif forloop.first %}
+          {% capture aliases %}{{aliases}}{{alias}}{% endcapture %}
+        {% else %}
+          {% capture aliases %}{{aliases}}, {{alias}}{% endcapture %}
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      {% capture aliases %}{{aliases}}{{page.aliases | join: ' and '}}{% endcapture %}
+    {% endif %}
+    {% assign aliases = aliases | append: '*' %}
+  {% endif %}
+
+  <!-- Build list of primary sources -->
+  {% for source in page.primary_sources %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture primary_sources %}{{primary_sources}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of internal optech mentions -->
+  {% assign references = '' %}
+  {% for mention in page.optech_mentions %}
+    {% if mention.feature == true %}
+      {% assign bold = '{:.bold}' %}
+    {% else %}
+      {% assign bold='' %}
+    {% endif %}
+    {% include functions/get-mention-date.md %}
+    {% capture references %}{{references}}{{date}}- [{{mention.title}}]({{mention.url}}){{bold}}ENDENTRY{% endcapture %}
+  {% endfor %}
+
+  <!-- Build list of see also entries -->
+  {% for source in page.see_also %}
+    {%- if source.link contains 'http://' or source.link contains 'https://' -%}
+      {% capture reference %}[{{source.title}}]({{source.link}}){% endcapture %}
+    {%- else -%}
+      {% capture reference %}[{{source.title}}][{{source.link}}]{% endcapture %}
+    {%- endif -%}
+    {% capture see_also %}{{see_also}}{{newline}}- {{reference}}{% endcapture %}
+  {% endfor %}
+
+  <!-- Variable for use in links -->
+  {% capture gh_base %}https://github.com/{{site.github_username}}/{{site.repository_name}}{% endcapture %}
+
+  <!-- whether or not to display a stub notice -->
+  {% assign word_count = page.content | number_of_words %}
+  {% if page.stub != false %}
+    <!-- if any words, not a stub.  We may increase word count later -->
+    {% if word_count < 1 or page.stub == true %}
+      {% capture notices %}{{notices}}{% include snippets/stub-topic.md %}{% endcapture %}
+    {% endif %}
+  {% endif %}
+
+{% endcapture %}
+
+<!-- Actual page content -->
+{% capture content %}
+  {% include references.md %}
+  {{aliases}}
+
+  {{page.excerpt}}
+
+  [Learn more]({{page.topic_page_or_best_reference}})
+
+  {{page.content}}
+
+  {{notices | default: newline}}
+
+  {{- '## Applications enabled' }}
+
+  *Applications that would be enabled if {{page.shortname}} was added to
+  Bitcoin.  Click any application name to see more information.  ✓ =
+  code available; ✓✓ = example transactions available.*
+
+  {% for app in site.covapps %}
+  {% assign app_status = page.covenant_based_apps[app.uid] %}
+
+  {% assign evidence = "" %}
+  {% assign evidence_details = "" %}
+  {% if app_status.example_code contains "http" %}
+    {% assign evidence = "✓" %}
+    {% capture evidence_details %}- [Example code]({{app_status.example_code}}) using {{page.shortname}} to enable {{app.title}}{% endcapture %}
+  {% endif %}
+  {% if app_status.example_txes contains "http" %}
+    {% assign evidence = "✓✓" %}
+  {% endif %}
+
+  {% if app_status.enabled == true %}
+  <details markdown="block"><summary markdown="span">**{{app.title}}&nbsp;{{evidence}}**</summary>
+  {{app.excerpt}}
+
+  [Learn more about {{app.title}}]({{app.url}})<br>
+  </details>
+  {%- elsif app_status.enabled != false -%}
+  ERROR_APP_STATUS_NOT_DEFINED={{app.title}}
+  {% endif %}
+
+  {% endfor %}
+
+  {%- if page.implementations.size > 0 -%}
+  ## Implementations
+
+    {% for implementation in page.implementations %}
+      * [{{implementation.name}}]({{implementation.reference}}){% if implementation.can_lose_significant_money == true %}(production){% endif %}
+    {% endfor %}
+  {% endif %}
+
+
+  {%- if page.primary_sources and page.primary_sources != '' -%}
+    ## Primary code and documentation
+
+    {{primary_sources}}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.optech_mentions and page.optech_mentions != '' -%}
+    ## Optech newsletter and website mentions
+
+    {% assign sorted_references = references | split: 'ENDENTRY' | sort | reverse %}
+    {%- for reference in sorted_references -%}
+      {%- assign current_ref_year = reference | slice: 0, 4 -%}
+      {%- if current_ref_year != last_ref_year -%}
+        {{newline}}{{newline}}**{{current_ref_year}}**
+      {%- endif -%}
+      {{newline}}{{reference | slice: 10, 9999999999 }}
+      {%- assign last_ref_year = current_ref_year -%}
+    {%- endfor -%}
+  {% endif %}{{newline}}{{newline}}
+
+  {%- if page.see_also and page.see_also != '' -%}
+    ## See also
+
+    {{see_also}}
+  {% endif %}
+
+  <br>{{newline}}{{newline}}
+<span class="float-left" markdown="1">**Previous Topic:**<br>{{prev_link}}</span>
+<span class="float-right" markdown="1">**Next Topic:**<br>{{next_link | default: first_link }}</span>
+
+  {:.center}
+  [Edit page]({{gh_base}}/edit/master/{{page.path}})<br>
+  [Report Issue]({{gh_base}}/issues/new?body={{'Source file: ' | append: page.path | url_escape }})
+{% endcapture %}{{ content | markdownify }}

--- a/_layouts/covprop.html
+++ b/_layouts/covprop.html
@@ -105,13 +105,14 @@ layout: post
     {% assign evidence = "✓✓" %}
   {% endif %}
 
-  {% if app_status.enabled == true %}
+  {% if app_status.enabled == "true" %}
   <details markdown="block"><summary markdown="span">**{{app.title}}&nbsp;{{evidence}}**</summary>
   {{app.excerpt}}
 
   [Learn more about {{app.title}}]({{app.url}})<br>
   </details>
-  {%- elsif app_status.enabled != false -%}
+  {%- elsif app_status.enabled == "unknown" -%}
+  {%- elsif app_status.enabled != "false" -%}
   ERROR_APP_STATUS_NOT_DEFINED={{app.title}}
   {% endif %}
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -206,11 +206,11 @@ div.xoverflow {
     animation-duration: 7s;
 }
 
-td.compat_yes {
+td.compat_yes, td.status_true {
   background-color: $compatibility-feature-yes;
 }
 
-td.compat_no {
+td.compat_no, td.status_false {
   background-color: $compatibility-feature-no;
 }
 

--- a/en/lore.md
+++ b/en/lore.md
@@ -1,0 +1,42 @@
+---
+layout: page
+lang: en
+title: Lore
+name: publications
+permalink: /en/lore/
+share: false
+version: 1
+---
+{:.center}
+Various information collected and curated by Optech.
+
+- **[Topics][]**<br>
+  {{site.topics | size}} different topics related to Bitcoin development
+  with summaries of each topic and links to every significant mention of
+  that topic in an Optech newsletter.
+
+- **[Compatibility matrix][compat]**<br>
+  {{site.data.compatibility | size}} different wallets and services
+  listed by their support for implementing several Bitcoin best
+  practices.
+
+- **[Dashboard][]**<br>
+  Live-updated statistical dashboard with various infomation about the
+  use of different Bitcoin technology, such as segwit, transaction
+  batching, and replace-by-fee.
+
+- **[Transaction size calculator][]**<br>
+  Tool for estimating the size of different classes of transactions
+  using different transaction types (such as legacy, segwit, or
+  taproot).
+
+- **[Covenants][]**<br>
+  {{site.covprops | size}} different covenant proposals summarized and
+  associated with the up to {{site.covapps | size}} different
+  applications they would enable.
+
+[topics]: /en/topics/
+[compat]: /en/compatibility/
+[dashboard]: https://dashboard.bitcoinops.org/
+[transaction size calculator]: /en/tools/calc-size/
+[covenants]: /en/lore/covenants/

--- a/en/lore/covenants.md
+++ b/en/lore/covenants.md
@@ -19,10 +19,9 @@ bitcoins to either her cold wallet or her favorite exchange.
   covenant-based applications (or to make existing applications more
   powerful)
 
-Not every proposal enables every application, so we've cross-referenced
-each proposal by the applications it would enabled (and each application
-by the proposals that would enable it), making it easier to compare
-different ideas.
+- [Analysis][] draws insights from the data available on individual
+  applications and proposals.
 
 [applications]: /en/lore/covenants/apps/
 [proposals]: /en/lore/covenants/proposals/
+[analysis]: /en/lore/covenants/analysis/

--- a/en/lore/covenants.md
+++ b/en/lore/covenants.md
@@ -1,0 +1,28 @@
+---
+layout: page
+lang: en
+title: Covenants
+name: publications
+permalink: /en/lore/covenants/
+share: false
+version: 1
+---
+Covenants are constraints the receiver of bitcoins places on their
+ability to spend those bitcoins to the next receiver.  For example,
+Alice can use a covenant to only allow her hot wallet to send her
+bitcoins to either her cold wallet or her favorite exchange.
+
+- [Applications][] are ideas for enhancing efficiency, privacy, or both
+  using covenants
+
+- [Proposals][] are ideas for changing Bitcoin's rules to enable
+  covenant-based applications (or to make existing applications more
+  powerful)
+
+Not every proposal enables every application, so we've cross-referenced
+each proposal by the applications it would enabled (and each application
+by the proposals that would enable it), making it easier to compare
+different ideas.
+
+[applications]: /en/lore/covenants/apps/
+[proposals]: /en/lore/covenants/proposals/

--- a/en/lore/covenants/analysis/enable-table.md
+++ b/en/lore/covenants/analysis/enable-table.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Applications Enabled by Proposals
+permalink: /en/lore/covenants/analysis/enable-table/
+nowrap: true
+
+indicators:
+  "true":  '<span class="feature-yes"><strong>✓</strong></span>'
+  "false": '<span class="feature-no"><strong>✕</strong></span>'
+  unknown: '<strong>?</strong>'
+
+---
+<style>
+th, td { text-align: center; }
+h1, h2, h3, h4, h5, h6 { text-align: center; }
+</style>
+
+{% assign proposals_sorted = site.covprops | sort: 'shorttitle' %}
+{% assign apps_sorted = site.covapps | sort: 'title' %}
+<table class="compatibility">
+  <tr>
+    <th>Applications</th>
+    {% for prop in proposals_sorted %}
+    <th><a href="{{prop.url}}">{{prop.shorttitle}}</a></th>
+    {% endfor %}
+  </tr>
+
+  {% for app in apps_sorted %}
+  <tr>
+    <th><a href="{{app.url}}">{{app.title}}</a></th>
+    {% for prop in proposals_sorted %}
+      {% assign app_status = prop.covenant_based_apps[app.uid].enabled %}
+      <td class="status_{{app_status}}">{{page.indicators[app_status]}}</td>
+    {% endfor %}
+  </tr>
+  {% endfor %}
+
+</table>
+
+<br/>
+<br/>
+_Contributions and corrections are welcome. Please see the [contibuting
+guidelines](https://github.com/bitcoinops/bitcoinops.github.io/blob/master/CONTRIBUTING.md)
+for details._
+{: style="text-align: center;"}

--- a/en/lore/covenants/analysis/index.md
+++ b/en/lore/covenants/analysis/index.md
@@ -1,0 +1,14 @@
+---
+title: Analysis
+layout: page
+---
+Analysis of the various applications and proposals for Bitcoin
+covenants.  All information automatically extracted from the individual
+[application][] and [proposal][] pages.
+
+- [Applications enabled by proposal][enable table]: a table summarizing
+  which applications are enabled by the various covenant proposals.
+
+[enable table]: /en/lore/covenants/analysis/enable-table/
+[application]: /en/lore/covenants/apps/
+[proposal]: /en/lore/covenants/proposals/

--- a/en/lore/covenants/apps.md
+++ b/en/lore/covenants/apps.md
@@ -1,0 +1,13 @@
+---
+layout: page
+lang: en
+title: Covenants
+name: publications
+permalink: /en/lore/covenants/apps/
+share: false
+version: 1
+---
+{% for app in site.covapps %}
+- [{{app.title}}]({{app.url}})
+{% endfor %}
+

--- a/en/lore/covenants/proposals.md
+++ b/en/lore/covenants/proposals.md
@@ -1,0 +1,13 @@
+---
+layout: page
+lang: en
+title: Covenants
+name: publications
+permalink: /en/lore/covenants/proposals/
+share: false
+version: 1
+---
+{% for prop in site.covprops %}
+- [{{prop.title}}]({{prop.url}})
+{% endfor %}
+


### PR DESCRIPTION
WIP PR to add a collection of information about covenant proposals and covenant-enabled applications to the site.  Seeking concept-level feedback at this time, particularly opinions about the per-entry data and presentation, since changing the templates later will be much harder than changing them now.

### Previews

- Entrypoint: /en/lore/covenants/
- Example covenant-enabled application: /en/lore/covenants/apps/channel-factories/
- Example covenant proposal: /en/lore/covenants/proposals/cat+csfs/
- Example table aggregating covenant info: /en/lore/covenants/analysis/enable-table/

### TODO

- [ ] Fill in remaining information, mainly based on [this sketch](https://gist.github.com/harding/dae085605fa962339358d05e54468c53)
- [ ] Organize commits for review
- [ ] Integrate proposal/application pages with corresponding topic pages
- [ ] Write announcement blog post