### PR TITLE
News212: German translation format fix

### DIFF
--- a/_posts/de/newsletters/2022-08-10-newsletter.md
+++ b/_posts/de/newsletters/2022-08-10-newsletter.md
@@ -173,9 +173,9 @@ Proposals (BIPs)][bips repo], und [Lightning BOLTs][bolts repo].*
   Spend, wenn es dazu in der Lage war, sowie zusätzlich für alle
   Skriptpfade, für die Schlüssel zur Verfügung standen.
 
- [BOLTs #911][] erweitert LN-Knoten mit der Fähigkeit einen DNS Hostnamen
- bekanntzugeben, der in seine IP-Adresse aufgelöst wird. Eine frühere Diskussion
- dieser Idee wurde in [Newsletter #167][news167 ln dns] erwähnt.
+- [BOLTs #911][] erweitert LN-Knoten mit der Fähigkeit einen DNS Hostnamen
+  bekanntzugeben, der in seine IP-Adresse aufgelöst wird. Eine frühere
+  Diskussion dieser Idee wurde in [Newsletter #167][news167 ln dns] erwähnt.
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="25610,24584,5071,645,911,13922,9527" %}


### PR DESCRIPTION
Caused a missing bullet which is unlinkable in future references (like https://github.com/bitcoinops/bitcoinops.github.io/pull/843/files#diff-a621ae1e11f09c21fcec55111f696ebbe0627357553f2c4fd21a0f15b3e7e39aR134)