### PR TITLE
add zero-conf to compound words list

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -122,6 +122,7 @@ beginning of a sentence).
 | single-sig | singlesig | |
 | soft fork/hard fork | softfork/hardfork or soft-fork/hard-fork | soft-fork/hard-fork may be used as compound adjectives (eg "Foo proposed a soft-fork change") |
 | Stack Exchange | StackExchange | as the website spells itself |
+| zero-conf | zeroconf, zero conf, 0-conf | unconfirmed transaction |
 | 2-of-3 | 2 of 3 | |
 
 ### Spelling


### PR DESCRIPTION
Check this PR -- I'm unsure if "zero-conf" is the convention we actually want. LMK if not and I can update this PR. The command
```
$ grep -i zero.*conf _posts/en/*/*md
```
shows several forms, `zero-conf`, `zeroconf`, and `zero conf`, so we haven't been very consistent.