### PR TITLE
Topics: responsible disclosures: add 2020 fee ransom attack

### DIFF
--- a/_topics/en/responsible-disclosures.md
+++ b/_topics/en/responsible-disclosures.md
@@ -60,6 +60,9 @@ optech_mentions:
   - title: "Saleem Rashid disclosed to Trezor an issue previously identified by Greg Sanders"
     url: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
 
+  - title: "René Pickhardt disclosed fee ransom attack affecting multiple LN implementations"
+    url: /en/newsletters/2020/06/24/#ln-fee-ransom-attack
+
 ## Optional.  Same format as "primary_sources" above
 # see_also:
 #   - title:


### PR DESCRIPTION
This adds a responsible disclosure we previously reported on but which I missed in compiling the entries for the initial topic page.  My appologies to @renepickhardt

I plan to merge shortly after the tests pass.