### PR TITLE
Fix broken link to coin selection work

### DIFF
--- a/_topics/en/coin-selection.md
+++ b/_topics/en/coin-selection.md
@@ -59,8 +59,9 @@ optech_mentions:
 
 ## Optional.  Same format as "primary_sources" above
 see_also:
-  - title: Simulation-based Evaluation of Coin Selection Strategies
-    link: http://murch.one/wp-content/uploads/2016/09/CoinSelection.pdf
+  - title: An Evaluation of Coin Selection Strategies
+    link: https://murch.one/erhardt2016coinselection.pdf
+
 ---
 Most early Bitcoin wallets implemented relatively simple coin
 selection strategies, such as spending UTXOs in the order they were


### PR DESCRIPTION
I was made aware that the link titled “Simulation-based Evaluation of Coin Selection Strategies” on the Coin Selection page was broken. I removed wordpress from my website earlier this year and added a softlink for my thesis from the old location of the file to the new, but didn't realize that someone might link to my 2-page talk proposal for Scaling Bitcoin, so I broke that link.

My Scaling Bitcoin talk proposal was moved from http://murch.one/wp-content/uploads/2016/09/CoinSelection.pdf to https://murch.one/CoinSelection.pdf.

However, I was wondering whether this was perhaps meant to be a link to my thesis instead: https://murch.one/erhardt2016coinselection.pdf