### PR TITLE
update v3relay article from stub to article

### DIFF
--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -19,7 +19,7 @@ categories:
 excerpt: >
   **Version 3 transaction relay** is a proposal to allow transactions
   to opt-in to a modified set of transaction relay policies designed to
-  prevent pinning attacks. Combined with package relay, these policies help enable 
+  prevent pinning attacks. Combined with package relay, these policies help enable
   the use of dynamic feerates with LN onchain transactions.
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
@@ -56,16 +56,16 @@ see_also:
 ---
 V3 transaction relay is a superset of standard transaction policy.
 That is, V3 transactions follow all rules for standard transactions
-(e.g. minimum and max transaction weight) while also adding some 
-non-standard rules designed to allow transaction replacement 
-while precluding transaction-pinning attacks. V3 transactions also 
-require minor changes to the Package RBF policy in order to maintain 
+(e.g. minimum and max transaction weight) while also adding some
+non-standard rules designed to allow transaction replacement
+while precluding transaction-pinning attacks. V3 transactions also
+require minor changes to the Package RBF policy in order to maintain
 incentive compatibility with miners.
 
 V3 transaction relay solves rule 3 [transaction pinning][topic version 3 transaction relay]
 and may allow the removal of the CPFP carve-out.
 
-Version 3 transactions are used by [ephemeral anchors][topic ephemeral anchors]. 
+Version 3 transactions are used by [ephemeral anchors][topic ephemeral anchors].
 
 {% include references.md %}
 {% include linkers/issues.md issues="" %}

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -46,20 +46,24 @@ see_also:
 
   - title: Anchor outputs
     link: topic anchor outputs
-
-## Optional.  Force the display (true) or non-display (false) of stub
-## topic notice.  Default is to display if the page.content is below a
-## threshold word count
-#stub: false
-
-## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
-## Should be less than 500 characters
-excerpt: >
-  **Version 3 transaction relay** is a proposal to allow transactions to
-  opt-in to a modified set of transaction relay policies designed to prevent
-  pinning attacks. Combined with package relay, these policies help enable
-  the use of dynamic feerates with LN onchain transactions.
-
 ---
+**Version 3 transaction relay** is a proposal to allow transactions to
+opt-in to a modified set of transaction relay policies designed to prevent
+pinning attacks. Combined with package relay, these policies help enable
+the use of dynamic feerates with LN onchain transactions.
+ 
+V3 transaction relay is a superset of standard transaction policy.
+That is, V3 transactions follow all rules for standard transactions
+(e.g. minimum and max transaction weight) while also adding some 
+non-standard rules designed to allow transaction replacement 
+while precluding transaction-pinning attacks. V3 transactions also 
+require minor changes to the Package RBF policy in order to maintain 
+incentive compatibility with miners.
+
+V3 transaction relay solves rule 3 [transaction pinning][topic version 3 transaction relay]
+and may allow the removal of the CPFP carve-out.
+
+Version 3 transactions are used by [ephemeral anchors][topic ephemeral anchors]. 
+
 {% include references.md %}
 {% include linkers/issues.md issues="" %}

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -15,6 +15,13 @@ categories:
   - Contract Protocols
   - Transaction Relay Policy
 
+## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
+excerpt: >
+**Version 3 transaction relay** is a proposal to allow transactions to
+opt-in to a modified set of transaction relay policies designed to prevent
+pinning attacks. Combined with package relay, these policies help enable
+the use of dynamic feerates with LN onchain transactions.
+
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
@@ -47,11 +54,6 @@ see_also:
   - title: Anchor outputs
     link: topic anchor outputs
 ---
-**Version 3 transaction relay** is a proposal to allow transactions to
-opt-in to a modified set of transaction relay policies designed to prevent
-pinning attacks. Combined with package relay, these policies help enable
-the use of dynamic feerates with LN onchain transactions.
- 
 V3 transaction relay is a superset of standard transaction policy.
 That is, V3 transactions follow all rules for standard transactions
 (e.g. minimum and max transaction weight) while also adding some 

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -57,7 +57,7 @@ see_also:
 V3 transaction relay is a superset of standard transaction policy.
 That is, V3 transactions follow all rules for standard transactions
 (e.g. minimum and max transaction weight) while also adding some
-non-standard rules designed to allow transaction replacement
+additional rules designed to allow [transaction replacement][topic rbf]
 while precluding transaction-pinning attacks. V3 transactions also
 require minor changes to the Package RBF policy in order to maintain
 incentive compatibility with miners.

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -59,11 +59,11 @@ That is, V3 transactions follow all rules for standard transactions
 (e.g. minimum and max transaction weight) while also adding some
 additional rules designed to allow [transaction replacement][topic rbf]
 while precluding transaction-pinning attacks. V3 transactions also
-require minor changes to the Package RBF policy in order to maintain
+require minor changes to the [Package RBF][topic package relay] policy in order to maintain
 incentive compatibility with miners.
 
-V3 transaction relay solves rule 3 [transaction pinning][topic version 3 transaction relay]
-and may allow the removal of the CPFP carve-out.
+V3 transaction relay solves rule 3 [transaction pinning][topic transaction pinning]
+and may allow the removal of the [CPFP carve-out][topic cpfp carve out].
 
 Version 3 transactions are used by [ephemeral anchors][topic ephemeral anchors].
 

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -17,10 +17,10 @@ categories:
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
-**Version 3 transaction relay** is a proposal to allow transactions to
-opt-in to a modified set of transaction relay policies designed to prevent
-pinning attacks. Combined with package relay, these policies help enable
-the use of dynamic feerates with LN onchain transactions.
+  **Version 3 transaction relay** is a proposal to allow transactions
+  to opt-in to a modified set of transaction relay policies designed to
+  prevent pinning attacks. Combined with package relay, these policies help enable 
+  the use of dynamic feerates with LN onchain transactions.
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"


### PR DESCRIPTION
Currently fails -> [text][topic version 3 transaction relay] doesn't want to formulate into html for some reason.

I hope the content of update is something the reviewers are happy with. Not a huge change, just added more details from what I could understand from the Sept/Oct 2022 bdev mailing lists.

