### PR TITLE
Podcast: simplify newsletter references

### DIFF
--- a/_includes/functions/podcast-callout.md
+++ b/_includes/functions/podcast-callout.md
@@ -1,2 +1,0 @@
-[<i class="fa fa-headphones"
-title="Listen to our discussion of this on the podcast"></i>][{{include.url}}]

--- a/_includes/functions/podcast-note.md
+++ b/_includes/functions/podcast-note.md
@@ -1,8 +1,0 @@
-{% auto_anchor %}
-- **{{include.title}}** (<a title="Play this segment of the podcast" onClick="seek('{{include.timestamp}}')"
-class="seek">{{include.timestamp}}</a><noscript>{{include.timestamp}}</noscript>) {% if include.url != "" %}[<i class="fa fa-link"
-title="Link to related content"></i>][{{include.url}}]{% endif %}
-  <!--<a onClick="seek('{{include.timestamp}}')" class="seek"><i class="fa
-  fa-headphones" title="Play this segment of the podcast"></i></a>-->
-  {% if include.anchor != "" %}[<i class="fa fa-file-text-o" title="Read this segment of the transcription"></i>](#{{include.anchor}}){% endif %}
-{% endauto_anchor %}

--- a/_includes/newsletter-references.md
+++ b/_includes/newsletter-references.md
@@ -1,0 +1,32 @@
+{% assign newsletter_sections = page.references | group_by:"header" %}
+{% assign header_names = newsletter_sections | map: "name" %}
+{% unless header_names contains "News" %}
+## News
+*No significant news this week was found on the Bitcoin-Dev or Lightning-Dev mailing lists.*
+{% endunless %}
+
+{% for section in newsletter_sections %}
+## {{ section.name }}
+<ul>
+  {% for reference in section.items %}
+  {% assign podcast_slug = reference.podcast_slug | default: reference.slug %}
+  <li id="{{ podcast_slug | slice: 1, podcast_slug.size }}" class="anchor-list">
+    <p>
+      <a href="{{ podcast_slug }}" class="anchor-list-link">●</a>
+      {{ reference.title }}
+      (<a title="Play this segment of the podcast" onClick="seek('{{reference.timestamp}}')" class="seek">{{reference.timestamp}}</a><noscript>{{reference.timestamp}}</noscript>)
+      <a href="{{page.reference}}{{reference.slug}}">
+        <i class="fa fa-link" title="Link to related content"></i>
+      </a>
+      <!--<a onClick="seek('{{include.timestamp}}')" class="seek"><i class="fa
+  fa-headphones" title="Play this segment of the podcast"></i></a>-->
+      {% if reference.has_transcript_section %}
+      <a href="{{reference.slug}}-transcript">
+        <i class="fa fa-file-text-o" title="Read this segment of the transcription"></i>
+      </a>
+      {% endif %}
+    </p>
+  </li>
+  {% endfor %}
+</ul>
+{% endfor %}

--- a/_plugins/auto-anchor.rb
+++ b/_plugins/auto-anchor.rb
@@ -16,10 +16,7 @@ def auto_anchor(content)
         ## No match, pass item through unchanged
         string
       else
-        ## Remove double-quotes from titles before attempting to slugify
-        title.gsub!('"', '')
-        ## Use Liquid/Jekyll slugify filter to choose our id
-        slug = "\#{{ \"#{title}\" | slugify: 'latin' }}"
+        slug = generate_slug(title)
         id_prefix = "- {:#{slug} .anchor-list} <a href=\"#{slug}\" class=\"anchor-list-link\">●</a>"
         string.sub!(/-/, id_prefix)
       end

--- a/_plugins/common_utils.rb
+++ b/_plugins/common_utils.rb
@@ -1,0 +1,10 @@
+def generate_slug(title)
+  ## Remove double-quotes from titles before attempting to slugify
+  title.gsub!('"', '')
+  ## Use Liquid/Jekyll slugify filter to choose our id
+  liquid_string = "\#{{ \"#{title}\" | slugify: 'latin' }}"
+  slug = Liquid::Template.parse(liquid_string)
+  # An empty context is used here because we only need to parse the liquid
+  # string and don't require any additional variables or data.
+  slug.render(Liquid::Context.new) 
+end

--- a/_plugins/recap_references_generator.rb
+++ b/_plugins/recap_references_generator.rb
@@ -30,17 +30,6 @@ class RecapReferencesGenerator < Jekyll::Generator
     end
   end
 
-  def generate_slug(title)
-    ## Remove double-quotes from titles before attempting to slugify
-    title.gsub!('"', '')
-    ## Use Liquid/Jekyll slugify filter to choose our id
-    liquid_string = "\#{{ \"#{title}\" | slugify: 'latin' }}"
-    slug = Liquid::Template.parse(liquid_string)
-    # An empty context is used here because we only need to parse the liquid
-    # string and don't require any additional variables or data.
-    slug.render(Liquid::Context.new) 
-  end
-
   def find_title(string, in_list=true, slugify=true)
     # this conditional prefix is for the special case of the review club section
     # which is not a list item (no dash (-) at the start of the line)

--- a/_plugins/recap_references_generator.rb
+++ b/_plugins/recap_references_generator.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Regex pattern to match "{% assign timestamp="xx:xx:xx" %}"
+$podcast_reference_mark = /\{%\s*assign\s+timestamp\s*=\s*"([^"]+)"\s*%\}/
+
+# Create the podcast recap references by parsing the referenced newsletter for
+# podcast reference marks (timestamps)
+class RecapReferencesGenerator < Jekyll::Generator
+  def generate(site)
+    podcast_pages = site.documents.select { |doc| doc.data["type"] == "podcast"}
+    podcast_pages.each do |podcast|
+      # podcast episodes have a "reference" field that indicates the related newsletter page 
+      unless podcast.data["reference"].nil?
+        reference_page = site.documents.detect { |page| page.url == podcast.data["reference"] }
+        
+        # override the content of the reference page (newsletter) to now include
+        # the links to the related podcast items
+        reference_page.content,
+        # keep all the references in a podcast page variable to use them later 
+        # during the podcast page creation
+        podcast.data["references"] = get_podcast_references(reference_page.content, podcast.url)
+        
+        # Each podcast transcript splits into segements using the paragraph title
+        # as the title of the segment. These segment splits are added manually but
+        # we can avoid the need to also manually add their anchors by doing that here
+        podcast.data["references"].each do |reference|
+          reference["has_transcript_section"] = podcast.content.sub!(/^(_.*?#{Regexp.escape(reference["title"])}.*?_)/, "{:#{reference["slug"]}-transcript}\n \\1")
+        end
+      end
+    end
+  end
+
+  def generate_slug(title)
+    ## Remove double-quotes from titles before attempting to slugify
+    title.gsub!('"', '')
+    ## Use Liquid/Jekyll slugify filter to choose our id
+    liquid_string = "\#{{ \"#{title}\" | slugify: 'latin' }}"
+    slug = Liquid::Template.parse(liquid_string)
+    # An empty context is used here because we only need to parse the liquid
+    # string and don't require any additional variables or data.
+    slug.render(Liquid::Context.new) 
+  end
+
+  def find_title(string, in_list=true, slugify=true)
+    # this conditional prefix is for the special case of the review club section
+    # which is not a list item (no dash (-) at the start of the line)
+    prefix = in_list ? / *- / : // 
+
+    # Find shortest match for **bold**, or [markdown][links]
+    # note: when we are matching the title in `auto-anchor.rb` we also match *italics*
+    # but on the newsletter sections nested bullets have *italics* titles therefore
+    # by ignoring *italics* we are able to easier link to the outer title
+    title = string.match(/^#{prefix}(?:\*\*(.*?):?\*\*|\[(.*?):?\][(\[])/)&.captures&.compact&.[](0) || ""
+    if title.empty?
+      {}
+    else
+      result = {"title"=> title}
+      slug = slugify ? {"slug"=> generate_slug(title)} : {}
+      result.merge!(slug)
+    end
+  end
+
+  # This method searches the content for paragraphs that indicate that they are
+  # part of a podcast recap. When a paragraph is part of a recap we:
+  # - postfix with a link to the related podcast item 
+  # - get the header, title and title slug of the paragraph to create
+  #   the references for the podcast
+  def get_podcast_references(content, target_page_url)
+    # The logic here assumes that:
+    # - paragraphs have headers
+    # - each block of text (paragraph) is seperated by an empty line 
+      
+    # Split the content into paragraphs
+    paragraphs = content.split(/\n\n+/)
+    # Find all the headers in the content
+    headers = content.scan(/^#+\s+(.*)$/).flatten
+
+    # Create an array of hashes containing:
+    # - the paragraph's title
+    # - the paragraph's title slug
+    # - the associated header
+    # - the timestamp of the podcast in which this paragraph is discussed
+    podcast_references = []
+    current_header = 0
+    current_title = {}
+    in_review_club_section = false
+
+    # Iterate over all paragraphs to find those with a podcast reference mark
+    paragraphs.each do |p|
+      # a title might have multiple paragraphs associated with it
+      # the podcast reference mark might be at the end of an isolated
+      # paragraph snippet that cannot access the title, therefore
+      # we keep this information to be used in the link to the podcast recap
+      title = find_title(p, !in_review_club_section)
+      if !title.empty?
+        # paragraph has title
+        current_title = title
+      end
+
+      # If the current paragraph contains the podcast reference mark,
+      # capture the timestamp, add paragraph to references and replace 
+      # the mark with link to the related podcast item
+      p.gsub!($podcast_reference_mark) do |match|
+        if in_review_club_section
+          # the newsletter's review club section is the only section that does
+          # not have a list item to use as anchor so we use the header
+          current_title["podcast_slug"] = "#pr-review-club" # to avoid duplicate anchor
+          current_title["slug"] = "#bitcoin-core-pr-review-club"
+        end
+        podcast_reference = {"header"=> headers[current_header], "timestamp"=> $1}
+        podcast_reference.merge!(current_title)
+        podcast_references << podcast_reference
+
+        # Replace the whole match with the link
+        headphones_link = "[<i class='fa fa-headphones' title='Listen to our discussion of this on the podcast'></i>]"
+        replacement_link_to_podcast_item = "#{headphones_link}(#{target_page_url}#{current_title["podcast_slug"] || current_title["slug"]})"
+      end
+
+      # update to the next header when parse through it
+      if p.sub(/^#+\s*/, "") == headers[(current_header + 1) % headers.length()]
+        current_header += 1
+        in_review_club_section = headers[current_header] == "Bitcoin Core PR Review Club"
+      end
+
+    end
+
+    # Join the paragraphs back together to return the modified content
+    updated_content = paragraphs.join("\n\n")
+
+    [updated_content, podcast_references]
+  end
+end

--- a/_posts/en/newsletters/2023-02-15-newsletter.md
+++ b/_posts/en/newsletters/2023-02-15-newsletter.md
@@ -69,7 +69,7 @@ technical documentation and discussion.
       more than 83 bytes of arbitrary data.  They reasoned that other
       methods for storing large amounts of data are currently in use and
       there would be no additional harm from `OP_RETURN` being used
-      instead.  {% include functions/podcast-callout.md url="pod238 storage" %}
+      instead. {% assign timestamp="1:02" %}
 
 - **Fee dilution in multiparty protocols:** Yuval Kogman
   [posted][kogman dilution] to the Bitcoin-Dev mailing list the
@@ -104,7 +104,7 @@ technical documentation and discussion.
   Kogman describes several mitigations in his post, although all of them
   involve tradeoffs.  In a [second post][kogman dilution2], he notes
   that he's unaware of any currently deployed protocol that's
-  vulnerable. {% include functions/podcast-callout.md url="pod238 dilution" %}
+  vulnerable. {% assign timestamp="27:29" %}
 
 - **Tapscript signature malleability:** in an aside to the above-mentioned
   conversation about fee dilution, developer Russell O'Connor
@@ -133,8 +133,7 @@ technical documentation and discussion.
    opened an [issue][bitcoin inquisition #19] to the Bitcoin
    Inquisition repository being used to test [SIGHASH_ANYPREVOUT][topic
    sighash_anyprevout] (APO) to consider having APO commit to additional
-   data to prevent this issue for users of that extension. {% include
-   functions/podcast-callout.md url="pod238 tapscript" %}
+   data to prevent this issue for users of that extension. {% assign timestamp="33:47" %}
 
 ## Changes to services and client software
 
@@ -143,34 +142,30 @@ wallets and services.*
 
 - **Liana wallet adds multisig:**
   [Liana][news234 liana]'s [0.2 release][liana 0.2] adds multisig support using
-  [descriptors][topic descriptors]. {% include functions/podcast-callout.md
-  url="pod238 sc1" %}
+  [descriptors][topic descriptors]. {% assign timestamp="37:35" %}
 
 - **Sparrow wallet 1.7.2 released:**
   Sparrow's [1.7.2 release][sparrow 1.7.2] adds [taproot][topic taproot]
   support, [BIP329][] import and export features (see [Newsletter #235][news235
-  bip329]), and additional support for hardware signing devices. {% include
-  functions/podcast-callout.md url="pod238 sc2" %}
+  bip329]), and additional support for hardware signing devices. {% assign timestamp="38:46" %}
 
 - **Bitcoinex library adds schnorr support:**
   [Bitcoinex][bitcoinex github] is a Bitcoin utility library for the Elixir
-  functional programming language. {% include functions/podcast-callout.md
-  url="pod238 sc3" %}
+  functional programming language. {% assign timestamp="39:20" %}
 
 - **Libwally 0.8.8 released:**
   [Libwally 0.8.8][] adds [BIP340][] tagged hash support, additional sighash
   support including [BIP118][] ([SIGHASH_ANYPREVOUT][topic SIGHASH_ANYPREVOUT]), and
   additional [miniscript][topic miniscript], descriptor, and [PSBT][topic psbt]
-  functions. {% include functions/podcast-callout.md url="pod238 sc4" %}
+  functions. {% assign timestamp="39:59" %}
 
 ## Optech Recommends
 
-[BitcoinSearch.xyz][] is a recently-launched search engine for Bitcoin
+- [BitcoinSearch.xyz][] is a recently-launched search engine for Bitcoin
 technical documentation and discussions.  It was used to quickly find
 several of the sources linked in this newsletter, a vast improvement
 over other more laborious methods we've previously used.  Contributions
-to its [code][bitcoinsearch repos] are welcome. {% include
-functions/podcast-callout.md url="pod238 bitcoinsearch" %}
+to its [code][bitcoinsearch repos] are welcome. {% assign timestamp="40:40" %}
 
 ## Releases and release candidates
 
@@ -179,20 +174,17 @@ projects.  Please consider upgrading to new releases or helping to test
 release candidates.*
 
 - [Core Lightning 23.02rc2][] is a release candidate for a new
-  maintenance version of this popular LN implementation. {% include
-functions/podcast-callout.md url="pod238 cln" %}
+  maintenance version of this popular LN implementation. {% assign timestamp="42:21" %}
 
 - [BTCPay Server 1.7.11][] is a new release.  Since the last release we
   covered (1.7.1), several new features have been added and many bug
   fixes and improvements have been made.  Especially notable, several
   aspects related to plugins and third-party integrations have been
   changed, a migration path away from legacy MySQL and SQLite has been
-  added, and a cross-site scripting vulnerability has been fixed. {% include
-functions/podcast-callout.md url="pod238 btcpay" %}
+  added, and a cross-site scripting vulnerability has been fixed. {% assign timestamp="47:49" %}
 
 - [BDK 0.27.0][] is an update to this library for building Bitcoin
-  wallets and applications. {% include
-functions/podcast-callout.md url="pod238 bdk" %}
+  wallets and applications. {% assign timestamp="49:32" %}
 
 ## Notable code and documentation changes
 
@@ -214,7 +206,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   backups].  The merged PR adds support for creating, storing, and retrieving
   the encrypted backups.  As noted in the commit messages, the feature
   hasn't yet been fully specified or adopted by other LN
-  implementations. {% include functions/podcast-callout.md url="pod238 cln5361" %}
+  implementations. {% assign timestamp="49:51" %}
 
 - [Core Lightning #5670][] and [#5956][core lightning #5956] make
   various updates to its implementation of [dual funding][topic dual
@@ -222,7 +214,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   #851] and comments from interoperability testers.  Additionally, an
   `upgradewallet` RPC is added to move all funds in P2SH-wrapped outputs
   to native segwit outputs, which is required for interactive channel
-  opens. {% include functions/podcast-callout.md url="pod238 cln5670" %}
+  opens. {% assign timestamp="54:45" %}
 
 - [Core Lightning #5697][] adds a `signinvoice` RPC that will sign a
   [BOLT11][] invoice.  Previously, CLN would only sign an invoice when
@@ -235,20 +227,20 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   your node can claim that payment before it arrives.  That not only
   steals your money but, because you signed the invoice, generates very
   convincing evidence that you were paid (this evidence is so convincing
-  that many LN developers call it *proof of payment*). {% include functions/podcast-callout.md url="pod238 cln5697" %}
+  that many LN developers call it *proof of payment*). {% assign timestamp="56:23" %}
 
 - [Core Lightning #5960][] adds a [security policy][cln security.md]
-  that includes contact addresses and PGP keys. {% include functions/podcast-callout.md url="pod238 cln5960" %}
+  that includes contact addresses and PGP keys. {% assign timestamp="57:38" %}
 
 - [LND #7171][] upgrades the `signrpc` RPC <!--sic--> to support the
   latest [draft BIP][musig draft bip] for [MuSig2][topic musig].  The RPC now creates
   sessions linked to a MuSig2 protocol version number so that all
   operations within a session will use the correct protocol.  A
   security issue with an older version of the MuSig2 protocol was
-  mentioned in [Newsletter #222][news222 musig2]. {% include functions/podcast-callout.md url="pod238 lnd7171" %}
+  mentioned in [Newsletter #222][news222 musig2]. {% assign timestamp="58:54" %}
 
 - [LDK #2002][] adds support for automatically resending [spontaneous
-  payments][topic spontaneous payments] that don't initially succeed. {% include functions/podcast-callout.md url="pod238 ldk2002" %}
+  payments][topic spontaneous payments] that don't initially succeed. {% assign timestamp="1:00:01" %}
 
 - [BTCPay Server #4600][] updates the [coin selection][topic coin selection] for its [payjoin][topic payjoin]
   implementation to try to avoid creating transactions with *unnecessary
@@ -257,7 +249,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   regular single-spender, single-receiver payment: the largest input
   would have provided sufficient payment for the payment output and no
   additional inputs would have been added.
-  This PR was partly inspired by a [paper analyzing payjoins][]. {% include functions/podcast-callout.md url="pod238 btcpay4600" %}
+  This PR was partly inspired by a [paper analyzing payjoins][]. {% assign timestamp="1:00:59" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="5361,5670,5956,851,5697,5960,7171,2002,4541,4600" %}
@@ -288,21 +280,3 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 [news235 bip329]: /en/newsletters/2023/01/25/#bips-1383
 [bitcoinex github]: https://github.com/RiverFinancial/bitcoinex
 [libwally 0.8.8]: https://github.com/ElementsProject/libwally-core/releases/tag/release_0.8.8
-[pod238 storage]: /en/podcast/2023/02/16/#continued-discussion-about-block-chain-data-storage
-[pod238 dilution]: /en/podcast/2023/02/16/#fee-dilution-in-multiparty-protocols
-[pod238 tapscript]: /en/podcast/2023/02/16/#tapscript-signature-malleability
-[pod238 sc1]: /en/podcast/2023/02/16/#liana-wallet-adds-multisig
-[pod238 sc2]: /en/podcast/2023/02/16/#sparrow-wallet-1-7-2-released
-[pod238 sc3]: /en/podcast/2023/02/16/#bitcoinex-library-adds-schnorr-support
-[pod238 sc4]: /en/podcast/2023/02/16/#libwally-0-8-8-released
-[pod238 bitcoinsearch]: /en/podcast/2023/02/16/#bitcoinsearch-xyz
-[pod238 cln]: /en/podcast/2023/02/16/#core-lightning-23-02rc2
-[pod238 btcpay]: /en/podcast/2023/02/16/#btcpay-server-1-7-11
-[pod238 bdk]: /en/podcast/2023/02/16/#bdk-0-27-0
-[pod238 cln5361]: /en/podcast/2023/02/16/#core-lightning-5361
-[pod238 cln5670]: /en/podcast/2023/02/16/#core-lightning-5670-and-5956
-[pod238 cln5697]: /en/podcast/2023/02/16/#core-lightning-5697
-[pod238 cln5960]: /en/podcast/2023/02/16/#core-lightning-5960
-[pod238 lnd7171]: /en/podcast/2023/02/16/#lnd-7171
-[pod238 ldk2002]: /en/podcast/2023/02/16/#ldk-2002
-[pod238 btcpay4600]: /en/podcast/2023/02/16/#btcpay-server-4600

--- a/_posts/en/newsletters/2023-02-22-newsletter.md
+++ b/_posts/en/newsletters/2023-02-22-newsletter.md
@@ -25,7 +25,7 @@ of notable changes to popular Bitcoin infrastructure software.
   #234][news234 vault]).  He also announced that he'll be attempting to
   get the code merged into Bitcoin Inquisition, a project for testing
   major proposed changes to Bitcoin's consensus and network protocol
-  rules. {% include functions/podcast-callout.md url="pod239 op_vault" %}
+  rules. {% assign timestamp="1:18" %}
 
 - **LN quality of service flag:** Joost Jager [posted][jager qos] to the
   Lightning-Dev mailing list a proposal to allow nodes to signal that a
@@ -61,8 +61,7 @@ of notable changes to popular Bitcoin infrastructure software.
     spender fail.  This reduces the need for spenders to be able to
     easily find highly available channels.  The challenge of this
     approach is building a mechanism that prevents receivers from
-    keeping any overpayment that arrives. {% include
-    functions/podcast-callout.md url="pod239 ln qos" %}
+    keeping any overpayment that arrives. {% assign timestamp="4:15" %}
 
 - **Feedback requested on LN good neighbor scoring:** Carla Kirk-Cohen
   and Clara Shikhelman [posted][ckc-cs reputation] to the Lightning-Dev
@@ -79,8 +78,7 @@ of notable changes to popular Bitcoin infrastructure software.
     forwarding it to the next channel.  As described in a prior paper
     co-authored by Shikhelman (see
     [Newsletter #226][news226 jam]), this is part of a proposal to
-    mitigate [channel jamming attacks][topic channel jamming attacks]. {%
-    include functions/podcast-callout.md url="pod239 good neighbor" %}
+    mitigate [channel jamming attacks][topic channel jamming attacks]. {% assign timestamp="13:58" %}
 
 - **Proposed BIP for Codex32 seed encoding scheme:** Russell O'Connor
   and Andrew Poelstra (using anagrams of their names) [proposed][op codex32] a BIP for
@@ -125,7 +123,7 @@ of notable changes to popular Bitcoin infrastructure software.
     investigate its [website][codex32 website] or watch a
     [video][codex32 video] by one of its authors.  With the draft BIP,
     the authors hope to see wallets begin to add support for using
-    Codex32-encoded seeds. {% include functions/podcast-callout.md url="pod239 codex32" %}
+    Codex32-encoded seeds. {% assign timestamp="20:27" %}
 
 ## Selected Q&A from Bitcoin Stack Exchange
 
@@ -143,26 +141,26 @@ answers posted since our last update.*
   that is both (a) before the assumevalid point and (b) sufficiently buried to
   be past the prune point, there is indeed little to gain from having it". There
   is currently a [draft PR][Bitcoin Core #27050] open to address this and [a PR
-  Review Club][pr review 27050] covering the proposed change. {% include functions/podcast-callout.md url="pod239 se1" %}
+  Review Club][pr review 27050] covering the proposed change. {% assign timestamp="36:40" %}
 
 - [Can Bitcoin's P2P network relay compressed data?]({{bse}}116999)
   Pieter Wuille links to two mailing list discussions about compression (one about
   [specialized compression for headers sync][] and one about [general LZO-based
   compression][]) and points out that Blockstream Satellite uses a custom
-  transaction compression scheme. {% include functions/podcast-callout.md url="pod239 se2" %}
+  transaction compression scheme. {% assign timestamp="40:39" %}
 
 - [How does one become a DNS seed for Bitcoin Core?]({{bse}}116931)
   User Paro explains the requirements for someone wanting to become a [DNS
-  seed][news66 dns seed] to provide new nodes with initial peers. {% include functions/podcast-callout.md url="pod239 se3" %}
+  seed][news66 dns seed] to provide new nodes with initial peers. {% assign timestamp="41:18" %}
 
 - [Where can I learn about open research topics in Bitcoin?]({{bse}}116898)
   Michael Folkson provides a variety of resources including [Chaincode Labs
-  Research][] and [Bitcoin Problems][], among others. {% include functions/podcast-callout.md url="pod239 se4" %}
+  Research][] and [Bitcoin Problems][], among others. {% assign timestamp="44:00" %}
 
 - [What is the maximum size transaction that will be relayed by bitcoin nodes using the default configuration?]({{bse}}117277)
   Pieter Wuille points out Bitcoin Core's 400,000 [weight unit][] standardness
   policy rule, notes that it is not currently configurable, and explains the
-  intended benefits of that limit including DoS protections. {% include functions/podcast-callout.md url="pod239 se5" %}
+  intended benefits of that limit including DoS protections. {% assign timestamp="47:55" %}
 
 - [Understanding how ordinals work with in Bitcoin. What is exactly stored on the blockchain?]({{bse}}117018)
   Vojtěch Strnad clarifies that Ordinals Inscriptions do not use `OP_RETURN`,
@@ -175,13 +173,13 @@ answers posted since our last update.*
     <data pushes>
     OP_ENDIF
     ```
-    {% include functions/podcast-callout.md url="pod239 se6" %}
+    {% assign timestamp="50:07" %}
 
 - [Why doesn't the protocol allow unconfirmed transactions to expire at a given height?]({{bse}}116926)
   Larry Ruane references Satoshi on why it wouldn't be prudent for
   transactions to have the seemingly useful ability to specify an
   expiration height, that is, a height after which the transaction,
-  if not yet mined, is no longer valid (and therefore can't be mined). {% include functions/podcast-callout.md url="pod239 se7" %}
+  if not yet mined, is no longer valid (and therefore can't be mined). {% assign timestamp="51:00" %}
 
 ## Releases and release candidates
 
@@ -193,10 +191,10 @@ release candidates.*
   "sometimes [...] allows an array-bounds overflow when large string
   were input into SQLite's printf function".  Only software using BDK's
   optional SQLite's database feature needs to be updated.  See the
-  [vulnerability report][RUSTSEC-2022-0090] for additional details. {% include functions/podcast-callout.md url="pod239 bdk" %}
+  [vulnerability report][RUSTSEC-2022-0090] for additional details. {% assign timestamp="52:44" %}
 
 - [Core Lightning 23.02rc3][] is a release candidate for a new
-  maintenance version of this popular LN implementation. {% include functions/podcast-callout.md url="pod239 cln" %}
+  maintenance version of this popular LN implementation. {% assign timestamp="53:16" %}
 
 ## Notable code and documentation changes
 
@@ -216,7 +214,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   wallet cannot yet estimate the input weight for some descriptors
   before signing and cannot yet sign [PSBTs][topic PSBT] in some
   edge-cases. Miniscript support for P2TR outputs is also still
-  pending. {% include functions/podcast-callout.md url="pod239 bc24149" %}
+  pending. assign timestamp="53:57"
 
 - [Bitcoin Core #25344][] updates the `bumpfee` and `psbtbumpfee` RPCs
   for creating [Replace By Fee][topic rbf] (RBF) fee bumps.  The update
@@ -225,7 +223,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   different set of outputs than the transaction being replaced.  This
   can be used to add new outputs (e.g. for iterative [payment
   batching][topic payment batching]) or to remove outputs (e.g. for
-  attempting to cancel an unconfirmed payment). {% include functions/podcast-callout.md url="pod239 bc25344" %}
+  attempting to cancel an unconfirmed payment). {% assign timestamp="56:10" %}
 
 - [Eclair #2596][] limits the number of times a peer attempting to open
   a [dual funded][topic dual funding] channel can [RBF][topic rbf] fee
@@ -238,21 +236,21 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   fees.  However, the dual funding protocol expects a node to store
   even those fee bumps it can't fully validate, meaning an attacker
   could create an unlimited number of invalid fee bump transactions that
-  will never confirm and never cost it any transaction fees. {% include functions/podcast-callout.md url="pod239 ec2596" %}
+  will never confirm and never cost it any transaction fees. {% assign timestamp="58:09" %}
 
 - [Eclair #2595][] continues the project's work on adding support for
   [splicing][topic splicing], in this case with updates to the functions
-  used for constructing transactions. {% include functions/podcast-callout.md url="pod239 ec2595" %}
+  used for constructing transactions. {% assign timestamp="59:31" %}
 
 - [Eclair #2479][] adds support for paying [offers][topic offers] in the following flow: a
   user receives an offer, tells Eclair to pay it, Eclair uses the offer
   to fetch an invoice from the receiver, verifies the invoice contains
-  the expected parameters, and pays the invoice. {% include functions/podcast-callout.md url="pod239 ec2479" %}
+  the expected parameters, and pays the invoice. {% assign timestamp="59:45" %}
 
 - [LND #5988][] adds a new optional probability estimator for finding
   payment paths.  It is partly based on previous pathfinding research
   (see [Newsletter #192][news192 pp]) with additional input from other
-  approaches. {% include functions/podcast-callout.md url="pod239 lnd5988" %}
+  approaches. {% assign timestamp="1:00:09" %}
 
 - [Rust Bitcoin #1636][] adds a `predict_weight()` function.  Input to
   the function is a template for the transaction to construct; output is the expected
@@ -261,7 +259,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   transaction, the fee amount needs to be known, but to determine
   the fee amount, the size of the transaction needs to be known.
   The function can provide a reasonable size estimate without actually
-  having to construct a candidate transaction. {% include functions/podcast-callout.md url="pod239 rb1636" %}
+  having to construct a candidate transaction. {% assign timestamp="1:00:42" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="24149,25344,2596,2595,2479,5988,1636,27050" %}
@@ -292,23 +290,3 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 [Chaincode Labs Research]: https://research.chaincode.com/research-intro/
 [Bitcoin Problems]: https://bitcoinproblems.org/
 [weight unit]: https://en.bitcoin.it/wiki/Weight_units
-[pod239 op_vault]: /en/podcast/2023/02/23/#draft-bip-for-op-vault
-[pod239 ln qos]: /en/podcast/2023/02/23/#ln-quality-of-service-flag
-[pod239 good neighbor]: /en/podcast/2023/02/23/#feedback-requested-on-ln-good-neighbor-scoring
-[pod239 codex32]: /en/podcast/2023/02/23/#proposed-bip-for-codex32-seed-encoding-scheme
-[pod239 se1]: /en/podcast/2023/02/23/#why-is-witness-data-downloaded-during-ibd-in-prune-mode
-[pod239 se2]: /en/podcast/2023/02/23/#can-bitcoin-s-p2p-network-relay-compressed-data
-[pod239 se3]: /en/podcast/2023/02/23/#how-does-one-become-a-dns-seed-for-bitcoin-core
-[pod239 se4]: /en/podcast/2023/02/23/#where-can-i-learn-about-open-research-topics-in-bitcoin
-[pod239 se5]: /en/podcast/2023/02/23/#what-is-the-maximum-size-transaction-that-will-be-relayed-by-bitcoin-nodes-using-the-default-configuration
-[pod239 se6]: /en/podcast/2023/02/23/#understanding-how-ordinals-work-with-in-bitcoin-what-is-exactly-stored-on-the-blockchain
-[pod239 se7]: /en/podcast/2023/02/23/#why-doesn-t-the-protocol-allow-unconfirmed-transactions-to-expire-at-a-given-height
-[pod239 bdk]: /en/podcast/2023/02/23/#bdk-0-27-1
-[pod239 cln]: /en/podcast/2023/02/23/#core-lightning-23-02rc3
-[pod239 bc24149]: /en/podcast/2023/02/23/#bitcoin-core-24149
-[pod239 bc25344]: /en/podcast/2023/02/23/#bitcoin-core-25344
-[pod239 ec2596]: /en/podcast/2023/02/23/#eclair-2596
-[pod239 ec2595]: /en/podcast/2023/02/23/#eclair-2595
-[pod239 ec2479]: /en/podcast/2023/02/23/#eclair-2479
-[pod239 lnd5988]: /en/podcast/2023/02/23/#lnd-5988
-[pod239 rb1636]: /en/podcast/2023/02/23/#rust-bitcoin-1636

--- a/_posts/en/newsletters/2023-03-01-newsletter.md
+++ b/_posts/en/newsletters/2023-03-01-newsletter.md
@@ -50,7 +50,7 @@ summaries of notable changes to popular Bitcoin infrastructure software.
     full Codex32 verification.  No changes are required to Codex32 to
     obtain the reinforcing quick check property, although Codex32's
     documentation will need to be updated to provide the necessary
-    tables and worksheets in order to make it usable. {% include functions/podcast-callout.md url="pod240 checksums" %}
+    tables and worksheets in order to make it usable. {% assign timestamp="2:31" %}
 
 ## Releases and release candidates
 
@@ -59,13 +59,13 @@ projects.  Please consider upgrading to new releases or helping to test
 release candidates.*
 
 - [HWI 2.2.1][] is a maintenance release of this application for
-  allowing software wallets to interface with hardware signing devices. {% include functions/podcast-callout.md url="pod240 hwi" %}
+  allowing software wallets to interface with hardware signing devices. {% assign timestamp="10:17" %}
 
 - [Core Lightning 23.02rc3][] is a release candidate for a new
-  maintenance version of this popular LN implementation. {% include functions/podcast-callout.md url="pod240 cln" %}
+  maintenance version of this popular LN implementation. {% assign timestamp="11:38" %}
 
 - [lnd v0.16.0-beta.rc1][] is a release candidate for a new major
-  version of this popular LN implementation. {% include functions/podcast-callout.md url="pod240 lnd" %}
+  version of this popular LN implementation. {% assign timestamp="12:03" %}
 
 ## Notable code and documentation changes
 
@@ -83,12 +83,12 @@ be unspendable (one with an `OP_RETURN`, an invalid opcode, or
 exceeding the maximum script size) and whose value is greater than
 `maxburnamount`, it will not be submitted to the mempool.  By default,
 the amount is set to zero, protecting users from unintentionally burning
-funds. {% include functions/podcast-callout.md url="pod240 bc25943" %}
+funds. {% assign timestamp="12:59" %}
 
 - [Bitcoin Core #26595][] adds `wallet_name` and `passphrase` parameters to the
   [`migratewallet`][news217 migratewallet] RPC in order to support migrating
   encrypted legacy wallets and wallets not currently loaded into
-  [descriptor][topic descriptors] wallets. {% include functions/podcast-callout.md url="pod240 bc26595" %}
+  [descriptor][topic descriptors] wallets. {% assign timestamp="15:11" %}
 
 - [Bitcoin Core #27068][] updates how Bitcoin Core handles passphrase
   entry.  Previously, a passphrase containing an ASCII null character
@@ -100,7 +100,7 @@ funds. {% include functions/podcast-callout.md url="pod240 bc25943" %}
   enters a passphrase containing null characters which fails to decrypt
   an existing wallet, indicating they may have set a passphrase under
   the old behavior, they'll be provided with instructions for a
-  workaround. {% include functions/podcast-callout.md url="pod240 bc27068" %}
+  workaround. {% assign timestamp="16:51" %}
 
 - [LDK #1988][] adds limits for peer connections and unfunded channels
   to prevent denial of service resource exhaustion attacks.  The new
@@ -113,13 +113,13 @@ funds. {% include functions/podcast-callout.md url="pod240 bc25943" %}
       channel with the local node.
 
     - A maximum of 4 channels that have not yet been funded from a
-      single peer. {% include functions/podcast-callout.md url="pod240 ldk1988" %}
+      single peer. {% assign timestamp="18:37" %}
 
 - [LDK #1977][] makes public its structures for serializing and parsing
   [offers][topic offers] as defined in [draft BOLT12][bolts #798].  LDK
   doesn't yet have support for [blinded paths][topic rv routing], so it
   can't currently send or receive offers directly, but this PR allows
-  developers to begin experimenting with them. {% include functions/podcast-callout.md url="pod240 ldk1977" %}
+  developers to begin experimenting with them. {% assign timestamp="20:15" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="25943,26595,27068,1988,1977,798" %}
@@ -130,12 +130,3 @@ funds. {% include functions/podcast-callout.md url="pod240 bc25943" %}
 [todd codex32]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-February/021498.html
 [o'connor codex32]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-February/021504.html
 [news217 migratewallet]: /en/newsletters/2022/09/14/#bitcoin-core-19602
-[pod240 checksums]: /en/podcast/2023/03/02/#faster-seed-backup-checksums
-[pod240 hwi]: /en/podcast/2023/03/02/#hwi-2-2-1
-[pod240 cln]: /en/podcast/2023/03/02/#core-lightning-23-02rc3
-[pod240 lnd]: /en/podcast/2023/03/02/#lnd-v0-16-0-beta-rc1
-[pod240 bc25943]: /en/podcast/2023/03/02/#bitcoin-core-25943
-[pod240 bc26595]: /en/podcast/2023/03/02/#bitcoin-core-26595
-[pod240 bc27068]: /en/podcast/2023/03/02/#bitcoin-core-27068
-[pod240 ldk1988]: /en/podcast/2023/03/02/#ldk-1988
-[pod240 ldk1977]: /en/podcast/2023/03/02/#ldk-1977

--- a/_posts/en/newsletters/2023-03-08-newsletter.md
+++ b/_posts/en/newsletters/2023-03-08-newsletter.md
@@ -96,14 +96,14 @@ popular Bitcoin infrastructure software.
   safe.  Subsequent to our writing the above, the author of the
   `OP_VAULT` proposal, James O'Beirne, replied favorably to Sanders's
   ideas.  O'Beirne also had ideas for additional changes which we'll
-  describe in a future newsletter. {% include functions/podcast-callout.md url="pod241 op_vault" %}
+  describe in a future newsletter. {% assign timestamp="0:41" %}
 
 - **New Optech Podcast:** the weekly Optech Audio Recap hosted on
   Twitter Spaces is now available as a podcast.  Each episode will be
   available on all popular podcast platforms and on the Optech website
   as a transcript.  For more details, including why we think this is a
   major step forward in Optech's mission to improve Bitcoin technical
-  communication, please see our [blog post][podcast post]. {% include functions/podcast-callout.md url="pod241 podcast" %}
+  communication, please see our [blog post][podcast post]. {% assign timestamp="23:29" %}
 
 ## Bitcoin Core PR Review Club
 
@@ -124,8 +124,7 @@ and time-consuming to activate, requiring the careful building of (human)
 consensus and an elaborate [soft fork activation][topic soft fork activation]
 mechanism -- on a test network activating these changes can be streamlined.
 The PR also implements a way to deactivate changes that turn out to be buggy
-or undesired, which is a major departure from mainnet. {% include
-functions/podcast-callout.md url="pod241 pr review" %}
+or undesired, which is a major departure from mainnet. {% assign timestamp="24:33" %}
 
 {% include functions/details-list.md
   q0="Why do we want to deploy consensus changes that aren’t merged
@@ -181,21 +180,21 @@ release candidates.*
   support for peer storage of backup data (see [Newsletter
   #238][news238 peer storage]) and updates experimental support for [dual
   funding][topic dual funding] and [offers][topic offers].  Also
-  included are several other improvements and bug fixes. {% include functions/podcast-callout.md url="pod241 cln" %}
+  included are several other improvements and bug fixes. {% assign timestamp="38:01" %}
 
 - [LDK v0.0.114][] is a release for a new version of this library for
   building LN-enabled wallets and applications.  It fixes several
   security-related bugs and includes the ability to parse [offers][topic
-  offers]. {% include functions/podcast-callout.md url="pod241 ldk" %}
+  offers]. {% assign timestamp="40:00" %}
 
 - [BTCPay 1.8.2][] is the latest release for this popular self-hosted
   payment processing software for Bitcoin.  The release notes for
   version 1.8.0 say, "this version brings custom checkout forms, store
   branding options, a redesigned Point of Sale keypad view, new
-  notification icons and address labeling." {% include functions/podcast-callout.md url="pod241 btcpay" %}
+  notification icons and address labeling." {% assign timestamp="40:52" %}
 
 - [LND v0.16.0-beta.rc2][] is a release candidate for a new major
-  version of this popular LN implementation. {% include functions/podcast-callout.md url="pod241 lnd" %}
+  version of this popular LN implementation. {% assign timestamp="41:40" %}
 
 ## Notable code and documentation changes
 
@@ -207,7 +206,7 @@ Server][btcpay server repo], [BDK][bdk repo], [Bitcoin Improvement
 Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 
 - [LND #7462][] allows the creation of watch-only wallets with remote
-  signing and the use of the stateless init feature. {% include functions/podcast-callout.md url="pod241 lnd7462" %}
+  signing and the use of the stateless init feature. {% assign timestamp="42:48" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="7462" %}
@@ -225,11 +224,3 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 [bitcoin inquisition]: https://github.com/bitcoin-inquisition/bitcoin
 [heretical deployments]: https://github.com/bitcoin-inquisition/bitcoin/wiki/Heretical-Deployments
 [bip9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
-[pod241 op_vault]: /en/podcast/2023/03/09/#alternative-design-for-op-vault
-[pod241 podcast]: /en/podcast/2023/03/09/#new-optech-podcast
-[pod241 pr review]: /en/podcast/2023/03/09/#bitcoin-inquisition-activation-logic-for-testing-consensus-changes
-[pod241 cln]: /en/podcast/2023/03/09/#core-lightning-23-02
-[pod241 ldk]: /en/podcast/2023/03/09/#ldk-v0-0-114
-[pod241 btcpay]: /en/podcast/2023/03/09/#btcpay-1-8-2
-[pod241 lnd]: /en/podcast/2023/03/09/#lnd-v0-16-0-beta-rc2
-[pod241 lnd7462]: /en/podcast/2023/03/09/#lnd-7462

--- a/_posts/en/newsletters/2023-03-15-newsletter.md
+++ b/_posts/en/newsletters/2023-03-15-newsletter.md
@@ -23,7 +23,7 @@ release candidates, and describes a merged Bitcoin Core pull request.
   node (without any reduction in security).  A Utreexo node needs to
   receive extra data when it receives an unconfirmed transaction (or a block full of
   confirmed transactions), so the service bit will help a node find peers capable
-  of providing the extra data. {% include functions/podcast-callout.md url="pod242 utreexo" %}
+  of providing the extra data. {% assign timestamp="1:28"%}
 
 ## Releases and release candidates
 
@@ -33,13 +33,13 @@ release candidates.*
 
 - [Core Lightning v23.02.2][] is a maintenance release of this LN node
   software.  It reverts a change to the `pay` RPC that cause problems
-  for other software and includes several other changes. {% include functions/podcast-callout.md url="pod242 cln" %}
+  for other software and includes several other changes. {% assign timestamp="22:04"%}
 
 - [Libsecp256k1 0.3.0][] of this cryptographic library.  It includes an
-  API change which breaks ABI compatibility. {% include functions/podcast-callout.md url="pod242 lsp" %}
+  API change which breaks ABI compatibility. {% assign timestamp="25:47"%}
 
 - [LND v0.16.0-beta.rc3][] is a release candidate for a new major
-  version of this popular LN implementation. {% include functions/podcast-callout.md url="pod242 lnd" %}
+  version of this popular LN implementation. {% assign timestamp="29:01"%}
 
 ## Notable code and documentation changes
 
@@ -61,7 +61,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   validated them in a different order than a standard node.  The special
   chainstate used to perform the verification of older blocks is deleted
   the next time the node starts, freeing disk space.  Other parts of the
-  [assumeUTXO project][] still need to be merged before it will be usable. {% include functions/podcast-callout.md url="pod242 bc25740" %}
+  [assumeUTXO project][] still need to be merged before it will be usable. {% assign timestamp="30:01"%}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="25740" %}
@@ -70,8 +70,3 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 [core lightning v23.02.2]: https://github.com/ElementsProject/lightning/releases/tag/v23.02.2
 [kim utreexo]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-March/021515.html
 [assumeutxo project]: https://github.com/bitcoin/bitcoin/projects/11
-[pod242 utreexo]: /en/podcast/2023/03/16/#service-bit-for-utreexo
-[pod242 cln]: /en/podcast/2023/03/16/#core-lightning-v23-02-2
-[pod242 lsp]: /en/podcast/2023/03/16/#libsecp256k1-0-3-0
-[pod242 lnd]: /en/podcast/2023/03/16/#lnd-v0-16-0-beta-rc3
-[pod242 bc25740]: /en/podcast/2023/03/16/#bitcoin-core-25740

--- a/_posts/en/newsletters/2023-03-22-newsletter.md
+++ b/_posts/en/newsletters/2023-03-22-newsletter.md
@@ -23,44 +23,44 @@ wallets and services.*
 
 - **Xapo Bank supports Lightning:**
   Xapo Bank [announced][xapo lightning blog] its customers can now send outgoing
-  Lightning payments from the Xapo Bank mobile apps, using underlying infrastructure from Lightspark. {% include functions/podcast-callout.md url="pod243 sc1" %}
+  Lightning payments from the Xapo Bank mobile apps, using underlying infrastructure from Lightspark. {% assign timestamp="1:41" %}
 
 - **TypeScript library for miniscript descriptors released:**
   The TypeScript-based [Bitcoin Descriptors Library][github descriptors library]
   has support for [PSBTs][topic psbt], [descriptors][topic descriptors],
   and [miniscript][topic miniscript].  This includes support for signing
-  directly or when using certain hardware signing devices. {% include functions/podcast-callout.md url="pod243 sc2" %}
+  directly or when using certain hardware signing devices. {% assign timestamp="3:02" %}
 
 - **Breez Lightning SDK announced:**
   In a recent [blog post][breez blog], Breez announced the open source [Breez
   SDK][github breez sdk] for mobile developers who want to integrate Bitcoin and
   Lightning payments. The SDK includes support for [Greenlight][blockstream
-  greenlight], Lightning Service Provider (LSP) features, and other services. {% include functions/podcast-callout.md url="pod243 sc3" %}
+  greenlight], Lightning Service Provider (LSP) features, and other services. {% assign timestamp="6:48" %}
 
 - **PSBT-based exchange OpenOrdex launches:**
   The [open source][github openordex] exchange software allows sellers to create
   an order book of Ordinal satoshis using [PSBTs][topic psbt] and buyers to sign
-  and broadcast to complete the trade. {% include functions/podcast-callout.md url="pod243 sc4" %}
+  and broadcast to complete the trade. {% assign timestamp="10:48" %}
 
 - **BTCPay Server coinjoin plugin released:**
   The Wasabi Wallet [announcement][wasabi blog] notes that any BTCPay Server
   merchant can activate the optional plugin which supports the
-  [WabiSabi][news102 wabisabi] protocol for [coinjoins][topic coinjoin]. {% include functions/podcast-callout.md url="pod243 sc5" %}
+  [WabiSabi][news102 wabisabi] protocol for [coinjoins][topic coinjoin]. {% assign timestamp="14:01" %}
 
 - **mempool.space explorer enhances CPFP support:**
   The mempool.space [explorer][topic block explorers] announced [additional
-  support][mempool tweet] for [CPFP][topic cpfp]-related transactions. {% include functions/podcast-callout.md url="pod243 sc6" %}
+  support][mempool tweet] for [CPFP][topic cpfp]-related transactions. {% assign timestamp="18:46" %}
 
 - **Sparrow v1.7.3 released:**
   Sparrow's [v1.7.3 release][sparrow v1.7.3] includes [BIP129][] support for multisig wallets (see
-  [Newsletter #136][news136 bsms]) and custom block explorer support among other features. {% include functions/podcast-callout.md url="pod243 sc7" %}
+  [Newsletter #136][news136 bsms]) and custom block explorer support among other features. {% assign timestamp="21:38" %}
 
 - **Stack Wallet adds coin control, BIP47:**
   Recent releases of the [Stack Wallet][github stack wallet] add [coin
-  control][topic coin selection] features and [BIP47][] support. {% include functions/podcast-callout.md url="pod243 sc8" %}
+  control][topic coin selection] features and [BIP47][] support. {% assign timestamp="24:22" %}
 
 - **Wasabi Wallet v2.0.3 released:**
-  Wasabi's [v2.0.3 release][Wasabi v2.0.3] includes taproot coinjoin signing and taproot change outputs,opt-in manual coin control for sending, improved wallet loading speed and more. {% include functions/podcast-callout.md url="pod243 sc9" %}
+  Wasabi's [v2.0.3 release][Wasabi v2.0.3] includes taproot coinjoin signing and taproot change outputs,opt-in manual coin control for sending, improved wallet loading speed and more. {% assign timestamp="26:26" %}
 
 ## Releases and release candidates
 
@@ -69,7 +69,7 @@ projects.  Please consider upgrading to new releases or helping to test
 release candidates.*
 
 - [LND v0.16.0-beta.rc3][] is a release candidate for a new major
-  version of this popular LN implementation. {% include functions/podcast-callout.md url="pod243 lnd" %}
+  version of this popular LN implementation. {% assign timestamp="28:32" %}
 
 ## Notable code and documentation changes
 
@@ -92,13 +92,13 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   amended to rebroadcast any transactions that the node had expected to
   have been included in the prior block. Until then, it is the responsibility
   of every wallet to ensure the presence of transactions of interest in
-  mempools. {% include functions/podcast-callout.md url="pod243 lnd7448" %}
+  mempools. {% assign timestamp="29:16" %}
 
 - [BDK #793][] is a major restructuring of the library based on the work
   of the [bdk_core sub-project][].  According to the PR description, it
   "maintains the existing wallet API as much as possible and adds very
   little."  Three API endpoints with seemingly minor changes are listed in the PR
-  description. {% include functions/podcast-callout.md url="pod243 bdk793" %}
+  description. {% assign timestamp="36:03" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="7448,793" %}
@@ -118,15 +118,3 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 [sparrow v1.7.3]: https://github.com/sparrowwallet/sparrow/releases/tag/1.7.3
 [github stack wallet]: https://github.com/cypherstack/stack_wallet
 [Wasabi v2.0.3]: https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.3
-[pod243 sc1]: /en/podcast/2023/03/23/#xapo-bank-supports-lightning
-[pod243 sc2]: /en/podcast/2023/03/23/#typescript-library-for-miniscript-descriptors-released
-[pod243 sc3]: /en/podcast/2023/03/23/#breez-lightning-sdk-announced
-[pod243 sc4]: /en/podcast/2023/03/23/#psbt-based-exchange-openordex-launches
-[pod243 sc5]: /en/podcast/2023/03/23/#btcpay-server-coinjoin-plugin-released
-[pod243 sc6]: /en/podcast/2023/03/23/#mempool-space-explorer-enhances-cpfp-support
-[pod243 sc7]: /en/podcast/2023/03/23/#sparrow-v1-7-3-released
-[pod243 sc8]: /en/podcast/2023/03/23/#stack-wallet-adds-coin-control-bip47
-[pod243 sc9]: /en/podcast/2023/03/23/#wasabi-wallet-v2-0-3-released
-[pod243 lnd]: /en/podcast/2023/03/23/#lnd-v0-16-0-beta-rc3
-[pod243 lnd7448]: /en/podcast/2023/03/23/#lnd-7448
-[pod243 bdk793]: /en/podcast/2023/03/23/#bdk-793

--- a/_posts/en/newsletters/2023-03-29-newsletter.md
+++ b/_posts/en/newsletters/2023-03-29-newsletter.md
@@ -186,7 +186,7 @@ software.
     lower the cost to forward payments over LN.
 
     As of this writing, tunable penalties and Law's various proposals for
-    using them have not received much public discussion. {% include functions/podcast-callout.md url="pod244 factories" %}
+    using them have not received much public discussion. {% assign timestamp="1:00" %}
 
 ## Selected Q&A from Bitcoin Stack Exchange
 
@@ -202,28 +202,28 @@ answers posted since our last update.*
 - [Why isn't the taproot deployment buried in Bitcoin Core?]({{bse}}117569)
   Andrew Chow explains the rationale for the taproot soft fork
   [deployment][topic soft fork activation] not being [buried][BIP90] as [others
-  have][bitcoin buried deployments]. {% include functions/podcast-callout.md url="pod244 se1" %}
+  have][bitcoin buried deployments]. {% assign timestamp="28:06" %}
 
 - [What restrictions does the version field in the block header have?]({{bse}}117530)
   Murch notes an increase in [blocks][explorer block 779960] mined using [overt
   ASICBoost][topic ASICBoost], lists restrictions on the version field, and
-  walks through examples of [block header version fields][FCAT block header blog]. {% include functions/podcast-callout.md url="pod244 se2" %}
+  walks through examples of [block header version fields][FCAT block header blog]. {% assign timestamp="32:23" %}
 
 - [What is the relation between transaction data and ids?]({{bse}}117453)
   Pieter Wuille explains the legacy transaction serialization format covered by
   `txid` identifier, the witness extended serialization format covered by the `hash` and
   `wtxid` identifiers, and points out in a [separate answer][se117577] that
-  hypothetical additional transaction data would be covered by the `hash` identifier. {% include functions/podcast-callout.md url="pod244 se3" %}
+  hypothetical additional transaction data would be covered by the `hash` identifier. {% assign timestamp="39:04" %}
 
 - [Can I request tx messages from other peers?]({{bse}}117546)
   User RedGrittyBrick points to resources explaining the [performance][wiki getdata] and
   [privacy][Bitcoin Core #18861] reasons that arbitrary requests for
-  transactions from peers is not supported by Bitcoin Core's P2P layer. {% include functions/podcast-callout.md url="pod244 se4" %}
+  transactions from peers is not supported by Bitcoin Core's P2P layer. {% assign timestamp="43:33" %}
 
 - [Eltoo: Does the relative locktime on the first UTXO set the lifetime of the channel?]({{bse}}117468)
   Murch confirms that the question's example [eltoo][topic eltoo]-constructed LN channel
   has a limited lifetime but points to mitigations from the [eltoo
-  whitepaper][] that keep the timeouts from expiring. {% include functions/podcast-callout.md url="pod244 se5" %}
+  whitepaper][] that keep the timeouts from expiring. {% assign timestamp="47:34" %}
 
 ## Releases and release candidates
 
@@ -234,14 +234,14 @@ release candidates.*
 - [Rust Bitcoin 0.30.0][] is the latest release of this library for
   using data structures related to Bitcoin.  The [release notes][rb rn]
   mention a [new website][rust-bitcoin.org] and a large number of API
-  changes. {% include functions/podcast-callout.md url="pod244 rb" %}
+  changes. {% assign timestamp="52:23" %}
 
 - [LND v0.16.0-beta.rc5][] is a release candidate for a new major
-  version of this popular LN implementation. {% include functions/podcast-callout.md url="pod244 lnd" %}
+  version of this popular LN implementation. {% assign timestamp="53:43" %}
 
 - [BDK 1.0.0-alpha.0][] is a test release of the major changes to BDK
   described in [last week's newsletter][news243 bdk].  Developers of
-  downstream projects are encouraged to begin integration testing. {% include functions/podcast-callout.md url="pod244 bdk" %}
+  downstream projects are encouraged to begin integration testing. {% assign timestamp="54:16" %}
 
 ## Notable code and documentation changes
 
@@ -279,51 +279,51 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   add up to two new lines per block (although future PRs may reduce it
   to just one line), which was considered to be a small enough
   additional overhead to help detect selfish mining attacks and other
-  problems associated with critical block relay. {% include functions/podcast-callout.md url="pod244 bc27278" %}
+  problems associated with critical block relay. {% assign timestamp="54:45" %}
 
 - [Bitcoin Core #26531][] adds tracepoints for monitoring events
   affecting the mempool using the Extended Berkeley Packet Filter (eBPF)
   as implemented in previous PRs (see [Newsletter #133][news133 usdt]).
   A script is also added for using the tracepoints for monitoring
-  mempool statistics and activity in real time. {% include functions/podcast-callout.md url="pod244 bc26531" %}
+  mempool statistics and activity in real time. {% assign timestamp="1:00:26" %}
 
 - [Core Lightning #5898][] updates its dependency on [libwally][] to a
   more recent version (see [Newsletter #238][news238 libwally]), which allows adding support for [taproot][topic
   taproot], version 2 [PSBT][topic psbt] (see [Newsletter #128][news128
-  psbt2]), and affects support for LN on Elements-style sidechains. {% include functions/podcast-callout.md url="pod244 cln5898" %}
+  psbt2]), and affects support for LN on Elements-style sidechains. {% assign timestamp="1:03:23" %}
 
 - [Core Lightning #5986][] updates RPCs which return values in msats to
   no longer include the string "msat" as part of the result.  Instead,
   all returned values are integers.  This completes a deprecation begun
-  several releases ago, see [Newsletter #206][news206 msat]. {% include functions/podcast-callout.md url="pod244 cln5986" %}
+  several releases ago, see [Newsletter #206][news206 msat]. {% assign timestamp="1:05:21" %}
 
 - [Eclair #2616][] adds support for opportunistic [zero-conf
   channels][topic zero-conf channels]---if the remote peer sends the
   `channel_ready` message before the expected number of confirmations,
   Eclair will verify that the funding transaction was entirely created
   by the local node (so the remote peer can't get a conflicting
-  transaction confirmed) and then will allow the channel to be used. {% include functions/podcast-callout.md url="pod244 ec2616" %}
+  transaction confirmed) and then will allow the channel to be used. {% assign timestamp="1:07:43" %}
 
 - [LDK #2024][] begins including route hints for channels which have
   been opened but which are too immature to have been publicly announced
-  yet, such as [zero-conf channels][topic zero-conf channels]. {% include functions/podcast-callout.md url="pod244 ldk2024" %}
+  yet, such as [zero-conf channels][topic zero-conf channels]. {% assign timestamp="1:10:36" %}
 
 - [Rust Bitcoin #1737][] adds a [security reporting policy][rb sec] for the
-  project. {% include functions/podcast-callout.md url="pod244 rb1737" %}
+  project. {% assign timestamp="1:12:43" %}
 
 - [BTCPay Server #4608][] allows plugins to expose their features as an
-  app in the BTCPay user interface. {% include functions/podcast-callout.md url="pod244 btcpay4608" %}
+  app in the BTCPay user interface. {% assign timestamp="1:13:03" %}
 
 - [BIPs #1425][] assigns [BIP93][] to the codex32 scheme for encoding
   [BIP32][] recovery seeds using Shamir's Secret Sharing Scheme (SSSS)
   algorithm, a checksum, and a 32-character alphabet as described in
-  [Newsletter #239][news239 codex32]. {% include functions/podcast-callout.md url="pod244 bips1425" %}
+  [Newsletter #239][news239 codex32]. {% assign timestamp="1:15:43" %}
 
 - [Bitcoin Inquisition #22][] adds an `-annexcarrier` runtime option which
   allows pushing from 0 to 126 bytes of data a taproot input's annex
   field.  The author of the PR is planning to use the feature to allow
   people to begin experimenting on signet with [eltoo][topic eltoo]
-  using a fork of Core Lightning. {% include functions/podcast-callout.md url="pod244 bi22" %}
+  using a fork of Core Lightning. {% assign timestamp="1:16:51" %}
 
 ## Footnotes
 
@@ -388,22 +388,3 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
 [se117577]: https://bitcoin.stackexchange.com/a/117577/87121
 [wiki getdata]: https://en.bitcoin.it/wiki/Protocol_documentation#getdata
 [eltoo whitepaper]: https://blockstream.com/eltoo.pdf#page=15
-[pod244 factories]: /en/podcast/2023/03/30/#preventing-stranded-capital-with-multiparty-channels-and-channel-factories
-[pod244 se1]: /en/podcast/2023/03/30/#why-isn-t-the-taproot-deployment-buried-in-bitcoin-core
-[pod244 se2]: /en/podcast/2023/03/30/#what-restrictions-does-the-version-field-in-the-block-header-have
-[pod244 se3]: /en/podcast/2023/03/30/#what-is-the-relation-between-transaction-data-and-ids
-[pod244 se4]: /en/podcast/2023/03/30/#can-i-request-tx-messages-from-other-peers
-[pod244 se5]: /en/podcast/2023/03/30/#eltoo-does-the-relative-locktime-on-the-first-utxo-set-the-lifetime-of-the-channel
-[pod244 rb]: /en/podcast/2023/03/30/#rust-bitcoin-0-30-0
-[pod244 lnd]: /en/podcast/2023/03/30/#lnd-v0-16-0-beta-rc5
-[pod244 bdk]: /en/podcast/2023/03/30/#bdk-1-0-0-alpha-0
-[pod244 bc27278]: /en/podcast/2023/03/30/#bitcoin-core-27278
-[pod244 bc26531]: /en/podcast/2023/03/30/#bitcoin-core-26531
-[pod244 cln5898]: /en/podcast/2023/03/30/#core-lightning-5898
-[pod244 cln5986]: /en/podcast/2023/03/30/#core-lightning-5986
-[pod244 ec2616]: /en/podcast/2023/03/30/#eclair-2616
-[pod244 ldk2024]: /en/podcast/2023/03/30/#ldk-2024
-[pod244 rb1737]: /en/podcast/2023/03/30/#rust-bitcoin-1737
-[pod244 btcpay4608]: /en/podcast/2023/03/30/#btcpay-server-4608
-[pod244 bips1425]: /en/podcast/2023/03/30/#bips-1425
-[pod244 bi22]: /en/podcast/2023/03/30/#bitcoin-inquisition-22

--- a/_posts/en/newsletters/2023-04-05-newsletter.md
+++ b/_posts/en/newsletters/2023-04-05-newsletter.md
@@ -48,7 +48,7 @@ popular Bitcoin infrastructure software.
     data structure.  Some accumulators allow deleting elements from the
     set without rebuilding.  In a
     [gist][segura watchtowers gist], Delgado outlines several different
-    accumulator constructions worth considering. {% include functions/podcast-callout.md url="pod245 watchtowers" %}
+    accumulator constructions worth considering. {% assign timestamp="0:36" %}
 
 ## Releases and release candidates
 
@@ -58,11 +58,11 @@ release candidates.*
 
 - [LND v0.16.0-beta][] is beta release of a new major version of this popular LN
   implementation.  Its [release notes][lnd rn] mention numerous new
-  features, bug fixes, and performance improvements. {% include functions/podcast-callout.md url="pod245 lnd" %}
+  features, bug fixes, and performance improvements. {% assign timestamp="21:37" %}
 
 - [BDK 1.0.0-alpha.0][] is a test release of the major changes to BDK
   described in [Newsletter #243][news243 bdk].  Developers of
-  downstream projects are encouraged to begin integration testing. {% include functions/podcast-callout.md url="pod245 bdk" %}
+  downstream projects are encouraged to begin integration testing. {% assign timestamp="22:06" %}
 
 ## Notable code and documentation changes
 
@@ -76,7 +76,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
 
 - [Core Lightning #5967][] adds a `listclosedchannels` RPC that provides data
   about the node's closed channels, including the cause of channel being closed.
-  Information about old peers is also retained now. {% include functions/podcast-callout.md url="pod245 cln5967" %}
+  Information about old peers is also retained now. {% assign timestamp="22:59" %}
 
 - [Eclair #2566][] adds support for accepting offers.  Offers must be
   registered by a plugin that provides a handler for responding to
@@ -85,7 +85,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   payments satisfy the protocol requirements---the handler only needs to
   decide whether the item or service being purchased can be provided.
   This allows code for marshaling offers to become arbitrarily complex
-  without affecting Eclair's internal logic. {% include functions/podcast-callout.md url="pod245 ec2566" %}
+  without affecting Eclair's internal logic. {% assign timestamp="23:43" %}
 
 - [LDK #2062][] implements [BOLTs #1031][] (see [Newsletter
   #226][news226 bolts1031]), [#1032][bolts #1032] (see [Newsletter
@@ -103,25 +103,24 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   both of the paths she chooses require 500 sat minimum amounts. With
   this specification change, she can now send two 500 sat payments,
   choosing to overpay by a total of 100 sats in order to use her
-  preferred route. {% include functions/podcast-callout.md url="pod245 ldk2062" %}
+  preferred route. {% assign timestamp="24:57" %}
 
 - [LDK #2125][] adds helper functions to determine the amount of
-  time until an invoice expires. {% include functions/podcast-callout.md url="pod245 ldk2125" %}
+  time until an invoice expires. {% assign timestamp="27:18" %}
 
 - [BTCPay Server #4826][] allows service hooks to create and retrieve [LNURL][]
   invoices.  This was done to add support for NIP-57 zaps to BTCPay Server’s
-  lightning address features. {% include functions/podcast-callout.md url="pod245 btcpay4826" %}
+  lightning address features. {% assign timestamp="27:56" %}
 
 - [BTCPay Server #4782][] adds [proof of payment][topic proof of
   payment] on the receipt page for each payment.  For onchain payments,
   the proof is the transaction ID.  For LN payments, the proof is the
-  preimage to the [HTLC][topic htlc]. {% include functions/podcast-callout.md url="pod245 btcpay4782" %}
+  preimage to the [HTLC][topic htlc]. {% assign timestamp="29:51" %}
 
 - [BTCPay Server #4799][] adds the ability to export [wallet
   labels][topic wallet labels] for transactions in the format specified
   by [BIP329][].  Future PRs may add support for exporting other wallet
-  data, such as labels for addresses. {% include functions/podcast-callout.md
-  url="pod245 btcpay4799" %}
+  data, such as labels for addresses. {% assign timestamp="30:15" %}
 
 - [BOLTs #765][] adds [route blinding][topic rv routing] to the LN
   specification.  Route blinding, which we first described in
@@ -136,7 +135,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   hop begins the process of decrypting the next hop, forwarding the
   payment to it, having that hop decrypt the subsequent hop, etc,
   until the receiver accepts the payment without their node being
-  disclosed to the spender or sender. {% include functions/podcast-callout.md url="pod245 bolt765" %}
+  disclosed to the spender or sender. {% assign timestamp="31:37" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="5967,2566,2062,1031,1032,1040,2125,4826,4782,4799,765" %}
@@ -150,14 +149,3 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
 [news243 bdk]: /en/newsletters/2023/03/22/#bdk-793
 [lnd rn]: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.16.0.md
 [lnurl]: https://github.com/lnurl/luds
-[pod245 watchtowers]: /en/podcast/2023/04/06/#watchtower-accountability-proofs
-[pod245 lnd]: /en/podcast/2023/04/06/#lnd-v0-16-0-beta
-[pod245 bdk]: /en/podcast/2023/04/06/#bdk-1-0-0-alpha-0
-[pod245 cln5967]: /en/podcast/2023/04/06/#core-lightning-5967
-[pod245 ec2566]: /en/podcast/2023/04/06/#eclair-2566
-[pod245 ldk2062]: /en/podcast/2023/04/06/#ldk-2062
-[pod245 ldk2125]: /en/podcast/2023/04/06/#ldk-2125
-[pod245 btcpay4826]: /en/podcast/2023/04/06/#btcpay-server-4826
-[pod245 btcpay4782]: /en/podcast/2023/04/06/#btcpay-server-4782
-[pod245 btcpay4799]: /en/podcast/2023/04/06/#btcpay-server-4799
-[pod245 bolt765]: /en/podcast/2023/04/06/#bolts-765

--- a/_posts/en/newsletters/2023-04-12-newsletter.md
+++ b/_posts/en/newsletters/2023-04-12-newsletter.md
@@ -73,14 +73,14 @@ software.
     amounts, e.g. "200,000 sats" indicates Alice will splice in that
     amount and "-50,000 sats" indicates she wants to splice out that
     amount.  He also mentions a concern involving zero-conf splicing but
-    does not go into detail about it.
+    does not go into detail about it. {% assign timestamp="1:24" %}
 
 - **Proposed BIP for transaction terminology:** Mark "Murch" Erhardt
   [posted][erhardt terms] the draft of an [informational BIP][terms bip]
   to the Bitcoin-Dev mailing list that suggests a vocabulary to use for
   referring to parts of transactions and concepts relating to them.  As
   of this writing, all replies to the proposal were supportive of the
-  effort.
+  effort. {% assign timestamp="40:49" %}
 
 ## Bitcoin Core PR Review Club
 
@@ -92,7 +92,7 @@ question below to see a summary of the answer from the meeting.*
 is a PR by Niklas Gögge (dergoegge) that improves the performance of Initial Block Download
 (IBD) by not downloading witness data on nodes that are configured to both
 [prune block data][docs pruning] and use [assumevalid][docs assume valid]. This
-optimization was discussed in a recent [stack exchange question][se117057].
+optimization was discussed in a recent [stack exchange question][se117057]. {% assign timestamp="43:42" %}
 
 {% include functions/details-list.md
   q0="If assume-valid is enabled but not pruning, why does the node need
@@ -155,11 +155,11 @@ release candidates.*
   compiled with Clang version 14 or higher.  The vulnerability may leave
   affected applications vulnerable to timing [side-channel
   attacks][topic side channels].  The authors strongly recommend
-  updating affected applications.
+  updating affected applications. {% assign timestamp="53:10" %}
 
 - [BDK 1.0.0-alpha.0][] is a test release of the major changes to BDK
   described in [Newsletter #243][news243 bdk].  Developers of
-  downstream projects are encouraged to begin integration testing.
+  downstream projects are encouraged to begin integration testing. {% assign timestamp="58:08" %}
 
 ## Notable code and documentation changes
 
@@ -176,23 +176,23 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   #26][news26 pyln-client]) that allow it to better work
   with CLN's gossip store.  The changes allow building better analysis tools
   for gossip and will make it easier to develop plugins that use gossip
-  data.
+  data. {% assign timestamp="58:33" %}
 
 - [Core Lightning #6124][] adds the ability to blacklist runes with
   [commando][commando plugin] and maintain a list of all runes, which is
-  useful for tracking and disabling compromised ones.
+  useful for tracking and disabling compromised ones. {% assign timestamp="1:02:01" %}
 
 - [Eclair #2607][] adds a new `listreceivedpayments` RPC that lists all
-  payments received by the node.
+  payments received by the node. {% assign timestamp="1:03:06" %}
 
 - [LND #7437][] adds support for backing up just a single channel to a
-  file.
+  file. {% assign timestamp="1:04:05" %}
 
 - [LND #7069][] allows a client to send a message to its
   [watchtower][topic watchtowers] asking for a session to be deleted.
   This allows the watchtower to stop monitoring for onchain transactions
   which close the channel in a revoked state.  This reduces the storage
-  and CPU requirements for both the watchtower and the client.
+  and CPU requirements for both the watchtower and the client. {% assign timestamp="1:04:43" %}
 
 - [BIPs #1372][] assigns [BIP327][] to the [MuSig2][topic musig]
   protocol for creating [multisignatures][topic multisignature] which
@@ -204,7 +204,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   possible with additional setup between the participants.  The protocol
   is compatible with all of the advantages of any multisignature scheme,
   such as significantly reducing onchain data and enhancing privacy---both
-  for participants and for users of the network in general.
+  for participants and for users of the network in general. {% assign timestamp="1:06:18" %}
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="6012,6124,2607,7437,7069,1372,863" %}

--- a/_posts/en/podcast/2023-02-16-newsletter-recap.md
+++ b/_posts/en/podcast/2023-02-16-newsletter-recap.md
@@ -1,6 +1,7 @@
 ---
 title: 'Bitcoin Optech Newsletter #238 Recap Podcast'
 permalink: /en/podcast/2023/02/16/
+reference: /en/newsletters/2023/02/15/
 name: 2023-02-16-recap
 slug: 2023-02-16-recap
 type: podcast
@@ -8,59 +9,13 @@ layout: podcast-episode
 lang: en
 ---
 Mark "Murch" Erhardt and Mike Schmidt are joined by AJ Towns, Yuval Kogman, Alex
-Myers, and Vivek Kasarabada to discuss [Newsletter #238][news238].
+Myers, and Vivek Kasarabada to discuss [Newsletter #238]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/66951337/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-2-20%2F5ea97eb6-f7fd-fa9e-2906-a6095c271e8d.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Continued discussion about block chain data storage" url="news238 storage" anchor="storage" timestamp="1:02" %}
-{% include functions/podcast-note.md title="Fee dilution in multiparty protocols" url="news238 dilution" anchor="dilution" timestamp="27:29" %}
-{% include functions/podcast-note.md title="Tapscript signature malleability" url="news238 tapscript" anchor="tapscript" timestamp="33:47" %}
-
-## Changes to services and client software
-
-{% include functions/podcast-note.md title="Liana wallet adds multisig"
-  url="news238 sc1" anchor="sc1" timestamp="37:35" %}
-{% include functions/podcast-note.md title="Sparrow wallet 1.7.2 released"
-  url="news238 sc2" anchor="sc2" timestamp="38:46" %}
-{% include functions/podcast-note.md title="Bitcoinex library adds schnorr support"
-  url="news238 sc3" anchor="sc3" timestamp="39:20" %}
-{% include functions/podcast-note.md title="Libwally 0.8.8 released"
-  url="news238 sc4" anchor="sc4" timestamp="39:59" %}
-
-## Optech Recommends
-
-{% include functions/podcast-note.md title="BitcoinSearch.xyz"
-  url="news238 bitcoinsearch" anchor="bitcoinsearch" timestamp="40:40" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="Core Lightning 23.02rc2"
-  url="news238 cln" anchor="cln" timestamp="42:21" %}
-{% include functions/podcast-note.md title="BTCPay Server 1.7.11"
-  url="news238 btcpay" anchor="btcpay" timestamp="47:49" %}
-{% include functions/podcast-note.md title="BDK 0.27.0"
-  url="news238 bdk" anchor="bdk" timestamp="49:32" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Core Lightning #5361"
-  url="news238 cln5361" anchor="cln5361" timestamp="49:51" %}
-{% include functions/podcast-note.md title="Core Lightning #5670 and #5956"
-  url="news238 cln5670" anchor="cln5670" timestamp="54:45" %}
-{% include functions/podcast-note.md title="Core Lightning #5697"
-  url="news238 cln5697" anchor="cln5697" timestamp="56:23" %}
-{% include functions/podcast-note.md title="Core Lightning #5960"
-  url="news238 cln5960" anchor="cln5960" timestamp="57:38" %}
-{% include functions/podcast-note.md title="LND #7171"
-  url="news238 lnd7171" anchor="lnd7171" timestamp="58:54" %}
-{% include functions/podcast-note.md title="LDK #2002"
-  url="news238 ldk2002" anchor="ldk2002" timestamp="1:00:01" %}
-{% include functions/podcast-note.md title="BTCPay Server #4600"
-  url="news238 btcpay4600" anchor="btcpay4600" timestamp="1:00:59" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -98,7 +53,6 @@ section.  Murch, any announcements before we jump in?
 
 **Mark Erhardt**: No.
 
-{:#storage}
 _Continued discussion about block chain data storage_
 
 **Mike Schmidt**: All right, let's do it.  Well, the first news item this week
@@ -565,7 +519,6 @@ place?
 **Mike Schmidt**: All right, we can move on.  Quite a discussion there on our
 first news item.
 
-{:#dilution}
 _Fee dilution in multiparty protocols_
 
 The next news item here is fee dilution in multiparty protocols, and you've all
@@ -666,7 +619,6 @@ think is really contrived, but if you are able to do that, then yeah, you can
 extract a positive payoff that only has to do with how much you end up directly
 paying for block space, I do think is still kind of interesting.
 
-{:#tapscript}
 _Tapscript signature malleability_
 
 **Mike Schmidt**: Murch, Yuval mentioned the spinoff discussion that we noted in
@@ -727,7 +679,6 @@ technology, and so we like to highlight that here for users that are familiar
 with those projects and to give a pat on the back to those projects for adopting
 those different pieces of tech.
 
-{:#sc1}
 _Liana wallet adds multisig_
 
 So, the first one we had this month is the Liana wallet adding multisig.  So we
@@ -749,7 +700,6 @@ exciting thing to me about the Liana wallet, is the miniscript use.
 **Mike Schmidt**: Yeah, they seem to be moving fast and on the cutting edge, so
 round of applause for those guys.
 
-{:#sc2}
 _Sparrow wallet 1.7.2 released_
 
 The next one we highlighted in the newsletter this week was Sparrow wallet, and
@@ -762,7 +712,6 @@ there's additional support for hardware signing devices.
 **Mark Erhardt**: In fact, the author of Sparrow wallet is also the author of
 BIP329.
 
-{:#sc3}
 _Bitcoinex library adds schnorr support_
 
 **Mike Schmidt**: It's a wonder they got it done so quickly.  The folks at River
@@ -777,7 +726,6 @@ Murch, are you doing any functional programming using Elixir?
 programming languages at university.  The simulation for coin selection for my
 master thesis was in Scala.
 
-{:#sc4}
 _Libwally 0.8.8 released_
 
 **Mike Schmidt**: Oh, cool.  And then the last highlight for this segment was
@@ -795,7 +743,6 @@ libwally these days, and that's what instagibbs is working on for L2.
 
 **Mark Erhardt**: LN symmetry!
 
-{:#bitcoinsearch}
 _BitcoinSearch.xyz_
 
 **Mike Schmidt**: We have an Optech Recommends segment this week, and this is
@@ -826,7 +773,6 @@ at the end, site:bitcoinops.org.  So, I think instead of doing that, I could add
 a little shortcut to use this search engine and just type my query in there, so
 looking forward to using this more.
 
-{:#cln}
 _Core Lightning 23.02rc2_
 
 Next segment of the newsletter is Releases and Release Candidates, and the first
@@ -927,7 +873,6 @@ this one.  But yeah, you've got to wear it in the meetings!
 **Mike Schmidt**: Nice!  We'll jump back to some of the Core Lightning PRs
 shortly.  Let's wrap up the Release Candidate and Releases section.
 
-{:#btcpay}
 _BTCPay Server 1.7.11_
 
 BTCPay Server 1.7.11.  The last release we covered in the newsletter was 1.7.1,
@@ -953,7 +898,6 @@ for example on 1.7.4, there's a note for the integrators, for the people that
 work on RaspiBlitz and Umbrel.  Anyway, those people that directly work with the
 project should be reading all of the release notes definitely.
 
-{:#bdk}
 _BDK 0.27.0_
 
 **Mike Schmidt**: The last release that we noted was a maintenance release for
@@ -966,7 +910,6 @@ saw anything else notable?
 
 **Mike Schmidt**: All right, Notable Code and Documentation Changes.
 
-{:#cln5361}
 _Core Lightning #5361_
 
 Alex, we'll bring you back in for this.  I think you had already talked about
@@ -1051,7 +994,6 @@ watchtower, one source where you could retrieve your static channel backup blob
 if everything else is lost.  That's really interesting, I'll have to look into
 that.
 
-{:#cln5670}
 _Core Lightning #5670 and #5956_
 
 **Mike Schmidt**: Alex, you talked a little bit about dual funding, which is the
@@ -1085,7 +1027,6 @@ re-evaluation of the protocol design questions.  I thought that was cool.
 works with, it doesn't get ratified until a second implementation goes through
 all the pain points and these issues arise.
 
-{:#cln5697}
 _Core Lightning #5697_
 
 **Mike Schmidt**: Alex, Core Lightning #5697 adds a signinvoice RPC that will
@@ -1110,7 +1051,6 @@ potentially collude to intercept a payment.  So, this might make more sense in
 maybe a PTLC world, but I think it will enable some neat things to be built on
 top of it, so I'm excited to see how it gets used.
 
-{:#cln5960}
 _Core Lightning #5960_
 
 **Mike Schmidt**: And then the last Core Lightning PR for this week's newsletter
@@ -1134,7 +1074,6 @@ newsletter, so if you want to comment on anything we've discussed or have a
 question to one of those things in a few minutes when we've done the last few
 items, we'll be able to take your comment.
 
-{:#lnd7171}
 _LND #7171_
 
 **Mike Schmidt**: LND #7171 upgrading the signrpc RPC to support the latest
@@ -1155,7 +1094,6 @@ close, it's coming soon, so we only have to wait 2 more weeks to 18 months.
 **Mike Schmidt**: At first I thought that you were real on the 2 weeks, but
 yeah, who knows what else might be found.
 
-{:#ldk2002}
 _LDK #2002_
 
 Our LDK PR which is next is actually incorrect.  Val actually okayed the change;
@@ -1175,7 +1113,6 @@ predict any timeline, but it's actually really close.
 
 **Mike Schmidt**: It's happening!
 
-{:#btcpay4600}
 _BTCPay Server #4600_
 
 The last PR for this week's newsletter if BTCPay Server #4600 and that updates
@@ -1221,22 +1158,3 @@ next week.
 **Alex Myers:** Thanks for having us.
 
 {% include references.md %}
-[news238]: /en/newsletters/2023/02/15/
-[news238 storage]: /en/newsletters/2023/02/15/#continued-discussion-about-block-chain-data-storage
-[news238 dilution]: /en/newsletters/2023/02/15/#fee-dilution-in-multiparty-protocols
-[news238 tapscript]: /en/newsletters/2023/02/15/#tapscript-signature-malleability
-[news238 sc1]: /en/newsletters/2023/02/15/#liana-wallet-adds-multisig
-[news238 sc2]: /en/newsletters/2023/02/15/#sparrow-wallet-1-7-2-released
-[news238 sc3]: /en/newsletters/2023/02/15/#bitcoinex-library-adds-schnorr-support
-[news238 sc4]: /en/newsletters/2023/02/15/#libwally-0-8-8-released
-[news238 bitcoinsearch]: /en/newsletters/2023/02/15/#optech-recommends
-[news238 cln]: /en/newsletters/2023/02/15/#core-lightning-23-02rc2
-[news238 btcpay]: /en/newsletters/2023/02/15/#btcpay-server-1-7-11
-[news238 bdk]: /en/newsletters/2023/02/15/#bdk-0-27-0
-[news238 cln5361]: /en/newsletters/2023/02/15/#core-lightning-5361
-[news238 cln5670]: /en/newsletters/2023/02/15/#core-lightning-5670
-[news238 cln5697]: /en/newsletters/2023/02/15/#core-lightning-5697
-[news238 cln5960]: /en/newsletters/2023/02/15/#core-lightning-5960
-[news238 lnd7171]: /en/newsletters/2023/02/15/#lnd-7171
-[news238 ldk2002]: /en/newsletters/2023/02/15/#ldk-2002
-[news238 btcpay4600]: /en/newsletters/2023/02/15/#btcpay-server-4600

--- a/_posts/en/podcast/2023-02-23-newsletter-recap.md
+++ b/_posts/en/podcast/2023-02-23-newsletter-recap.md
@@ -1,6 +1,7 @@
 ---
 title: 'Bitcoin Optech Newsletter #239 Recap Podcast'
 permalink: /en/podcast/2023/02/23/
+reference: /en/newsletters/2023/02/22/
 name: 2023-02-23-recap
 slug: 2023-02-23-recap
 type: podcast
@@ -8,60 +9,13 @@ layout: podcast-episode
 lang: en
 ---
 Mark "Murch" Erhardt and Mike Schmidt are joined by James O'Beirne,
-Christian Decker, and Russell O'Connor to discuss [Newsletter #239][news239].
+Christian Decker, and Russell O'Connor to discuss [Newsletter #239]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/65694485/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-1-27%2F8312452a-43df-af11-29e5-f4553e76d78c.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Draft BIP for OP_VAULT" url="news239 op_vault" anchor="op_vault" timestamp="1:18" %}
-{% include functions/podcast-note.md title="LN quality of service flag"
-  url="news239 ln qos" anchor="ln-qos" timestamp="4:15" %}
-{% include functions/podcast-note.md title="Feedback requested on LN good neighbor scoring"
-  url="news239 good neighbor" anchor="good-neighbor" timestamp="13:58" %}
-{% include functions/podcast-note.md title="Proposed BIP for Codex32 seed encoding scheme"
-  url="news239 codex32" anchor="codex32" timestamp="20:27" %}
-
-## Selected Q&A from Bitcoin Stack Exchange
-
-{% include functions/podcast-note.md title="Why is witness data downloaded during IBD in prune mode?"
-  url="news239 se1" anchor="se1" timestamp="36:40" %}
-{% include functions/podcast-note.md title="Can Bitcoin’s P2P network relay compressed data?"
-  url="news239 se2" anchor="se2" timestamp="40:39" %}
-{% include functions/podcast-note.md title="How does one become a DNS seed for Bitcoin Core?"
-  url="news239 se3" anchor="se3" timestamp="41:18" %}
-{% include functions/podcast-note.md title="Where can I learn about open research topics in Bitcoin?"
-  url="news239 se4" anchor="se4" timestamp="44:00" %}
-{% include functions/podcast-note.md title="What is the maximum size transaction that will be relayed by bitcoin nodes using the default configuration?"
-  url="news239 se5" anchor="se5" timestamp="47:55" %}
-{% include functions/podcast-note.md title="Understanding how ordinals work with in Bitcoin. What is exactly stored on the blockchain?" url="news239 se6" anchor="se6" timestamp="50:07" %}
-{% include functions/podcast-note.md title="Why doesn’t the protocol allow unconfirmed transactions to expire at a given height?" url="news239 se7" anchor="se7" timestamp="51:00" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="BDK 0.27.1"
-  url="news239 bdk" anchor="bdk" timestamp="52:44" %}
-{% include functions/podcast-note.md title="Core Lightning 23.02rc3"
-  url="news239 cln" anchor="cln" timestamp="53:16" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Bitcoin Core #24149"
-  url="news239 bc24149" anchor="bc24149" timestamp="53:57" %}
-{% include functions/podcast-note.md title="Bitcoin Core #25344"
-  url="news239 bc25344" anchor="bc25344" timestamp="56:10" %}
-{% include functions/podcast-note.md title="Eclair #2596"
-  url="news239 ec2596" anchor="ec2596" timestamp="58:09" %}
-{% include functions/podcast-note.md title="Eclair #2595"
-  url="news239 ec2595" anchor="ec2595" timestamp="59:31" %}
-{% include functions/podcast-note.md title="Eclair #2479"
-  url="news239 ec2479" anchor="ec2479" timestamp="59:45" %}
-{% include functions/podcast-note.md title="LND #5988"
-  url="news239 lnd5988" anchor="lnd5988" timestamp="1:00:09" %}
-{% include functions/podcast-note.md title="Rust Bitcoin #1636"
-  url="news239 rb1636" anchor="rb1636" timestamp="1:00:42" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -101,8 +55,7 @@ newsletter in this Spaces.  If folks want to follow along, you can read those
 tweets and also drill into the underlying newsletter to follow along with the
 content and associated links.
 
-{:#op_vault}
-_Draft BIP for `OP_VAULT`_
+_Draft BIP for OP_VAULT_
 
 Our first news item this week is Draft BIP for OP_VAULT, and I happened to see
 James was in the Space, so I added him as a speaker.  James, what's changed
@@ -159,7 +112,6 @@ approach, because Liquid already has covenants, so he said that he would have a
 simulation in Liquid and test it there.  I don't know, maybe if he gets that
 done, he could also put it in the Inquisition, just as another approach.
 
-{:#ln-qos}
 _LN quality of service flag_
 
 **Mike Schmidt**: Second item from the news section in this week's newsletter is
@@ -304,7 +256,6 @@ to our users, and as such should be prevented, in my mind at least.
 
 **Mark Erhardt**: Cool, thanks.
 
-{:#good-neighbor}
 _Feedback requested on LN good neighbor scoring_
 
 **Mike Schmidt**: There is a related item in the newsletter, which is the next
@@ -402,7 +353,6 @@ encoding scheme with James and Mike.
 anything else on either of these news items that you felt we should cover more
 deeply.
 
-{:#codex32}
 _Proposed BIP for Codex32 seed encoding scheme_
 
 **Mike Schmidt**: That's a nack!  Let's move on with the Codex32. Well, Russell,
@@ -674,7 +624,6 @@ joining us.  Murch, shall we move on to the Stack Exchange?
 **Mark Erhardt**: Yeah, I think we have a lot to go through still in this
 newsletter.  Let's go to the Stack Exchange questions.
 
-{:#se1}
 _Why is witness data downloaded during IBD in prune mode?_
 
 **Mike Schmidt**: Excellent.  Well, each month, the newsletter takes one week
@@ -744,8 +693,7 @@ invalid.
 checkpoints.  I think the last one was height 220,000, so what is that; seven
 years ago?  No, more.  Anyway…
 
-{:#se2}
-_Can Bitcoin’s P2P network relay compressed data?_
+_Can Bitcoin's P2P network relay compressed data?_
 
 **Mike Schmidt**: Next question from the Stack Exchange, "Can Bitcoin's P2P
 network relay compressed data?  And the question was specific about if there was
@@ -757,7 +705,6 @@ list, in which compression was discussed at the P2P level, and then also pointed
 out that Blockstream Satellite actually has its own custom transaction
 compression.
 
-{:#se3}
 _How does one become a DNS seed for Bitcoin Core?_
 
 Next question from the Stack Exchange, "How does one become a DNS seed for
@@ -806,7 +753,6 @@ didn't implement.  It comes up every couple of years; it's not a high churn
 project, so to speak, so I'd encourage everybody to run one because the more
 sources of nodes that we have, the less we are reliant on a single one.
 
-{:#se4}
 _Where can I learn about open research topics in Bitcoin?_
 
 **Mike Schmidt**: Next question from the Bitcoin Stack Exchange was, "Where can
@@ -874,7 +820,6 @@ smart people looking at Bitcoin and Lightning and realising that there are
 interesting problems here, that this is a real thing, and hopefully bring talent
 to the ecosystem.  So, take a look at those problems and pass it on.
 
-{:#se5}
 _What is the maximum size transaction that will be relayed by bitcoin nodes using the default configuration?_
 
 Next question from the Stack Exchange, "What is the maximum size transaction
@@ -911,7 +856,6 @@ when we overflow.
 It could be possible to make limits like the standardness weight limit on
 transactions configurable, but also that's probably just not a good idea.
 
-{:#se6}
 _Understanding how ordinals work with in Bitcoin. What is exactly stored on the blockchain?_
 
 **Mike Schmidt**: That makes sense and thank you for providing the rationale
@@ -929,8 +873,7 @@ IF_0 and then pushes in a bunch of data and then ends the IF statement.  There's
 a series of those types of pushes with the protocol, which is how that data gets
 put into the witness.
 
-{:#se7}
-_Why doesn’t the protocol allow unconfirmed transactions to expire at a given height?_
+_Why doesn't the protocol allow unconfirmed transactions to expire at a given height?_
 
 The last question here is, "Why doesn't the protocol allow unconfirmed
 transactions to expire at a given height?" and Larry both asked and answered
@@ -957,7 +900,6 @@ the best transactions will get picked into the new best chain.  But with the
 expiration, that just becomes more complicated, it opens up attack surfaces to
 steal from people.
 
-{:#bdk}
 _BDK 0.27.1_
 
 **Mike Schmidt**: Onto the releases and release candidates' section for the
@@ -970,7 +912,6 @@ this.  Any comments, Murch?
 
 **Mark Erhardt**: No, sounds good.  Upgrade if you're affected!
 
-{:#cln}
 _Core Lightning 23.02rc3_
 
 **Mike Schmidt**: And then, Core Lightning 23.02rc3, we had a couple of
@@ -985,7 +926,6 @@ find something breaking and I guess you already mentioned all of the headline
 features, so I will skip those since during the release process, no new features
 are added to the roster.  I probably can't tell you anything.
 
-{:#bc24149}
 _Bitcoin Core #24149_
 
 **Mark Erhardt**: Yeah.  Then I'm going to talk about Bitcoin Core #24149, which
@@ -1018,7 +958,6 @@ year since it was originally opened; so, nice to get that functionality merged.
 
 **Mark Erhardt**: Yeah, multiple years since work on miniscript started.
 
-{:#bc25344}
 _Bitcoin Core #25344_
 
 **Mike Schmidt**: Bitcoin Core #25344, which updates bumpfee and psbtbumpfee
@@ -1055,7 +994,6 @@ open up the floor for folks that have any questions.  Feel free to raise your
 hand or request speaker access, then once we wrap up going through the rest of
 these PRs, we can get to your question.
 
-{:#ec2596}
 _Eclair #2596_
 
 Eclair #2596, well I guess we're on the topic of RBF so, limiting the number of
@@ -1080,14 +1018,12 @@ attempts, because that would allow them to waste our bandwidth and DoS us.  So,
 this is just sort of a sanity limit that is placed into it to curb attack
 surface.
 
-{:#ec2595}
 _Eclair #2595_
 
 **Mike Schmidt**: Another Eclair PR is next #2595, and it seems to be some
 internal functions related to supporting splicing.  We've seen a flurry of these
 over the last few weeks, so it's good to see progress going on there.
 
-{:#ec2479}
 _Eclair #2479_
 
 Eclair #2479, adding support paying offers, and we outline in the newsletter a
@@ -1096,7 +1032,6 @@ Eclair uses the offer to fetch an invoice from the receiver and verifies the
 invoice meets the expected parameters, then pays the invoice.  So, a fairly
 standard paying offer flow there that is now supported in Eclair.
 
-{:#lnd5988}
 _LND #5988_
 
 LND #5988, adding a new optional probability estimator for finding payment
@@ -1107,7 +1042,6 @@ Pickhardt did, I believe.  And this is already in c-lightning and
 rust-lightning, and it's now taking into account channel capacity when doing
 path finding.
 
-{:#rb1636}
 _Rust Bitcoin #1636_
 
 Our last PR for this week is Rust Bitcoin #1636, which is adding a
@@ -1130,24 +1064,3 @@ Cheers.
 **Christian Decker**: Thank you very much.  Cheers.
 
 {% include references.md %}
-[news239]: /en/newsletters/2023/02/22/
-[news239 op_vault]: /en/newsletters/2023/02/22/#draft-bip-for-op-vault
-[news239 ln qos]: /en/newsletters/2023/02/22/#ln-quality-of-service-flag
-[news239 good neighbor]: /en/newsletters/2023/02/22/#feedback-requested-on-ln-good-neighbor-scoring
-[news239 codex32]: /en/newsletters/2023/02/22/#proposed-bip-for-codex32-seed-encoding-scheme
-[news239 se1]: /en/newsletters/2023/02/22/#why-is-witness-data-downloaded-during-ibd-in-prune-mode
-[news239 se2]: /en/newsletters/2023/02/22/#can-bitcoin-s-p2p-network-relay-compressed-data
-[news239 se3]: /en/newsletters/2023/02/22/#how-does-one-become-a-dns-seed-for-bitcoin-core
-[news239 se4]: /en/newsletters/2023/02/22/#where-can-i-learn-about-open-research-topics-in-bitcoin
-[news239 se5]: /en/newsletters/2023/02/22/#what-is-the-maximum-size-transaction-that-will-be-relayed-by-bitcoin-nodes-using-the-default-configuration
-[news239 se6]: /en/newsletters/2023/02/22/#understanding-how-ordinals-work-with-in-bitcoin-what-is-exactly-stored-on-the-blockchain
-[news239 se7]: /en/newsletters/2023/02/22/#why-doesn-t-the-protocol-allow-unconfirmed-transactions-to-expire-at-a-given-height
-[news239 bdk]: /en/newsletters/2023/02/22/#bdk-0-27-1
-[news239 cln]: /en/newsletters/2023/02/22/#core-lightning-23-02rc3
-[news239 bc24149]: /en/newsletters/2023/02/22/#bitcoin-core-24149
-[news239 bc25344]: /en/newsletters/2023/02/22/#bitcoin-core-25344
-[news239 ec2596]: /en/newsletters/2023/02/22/#eclair-2596
-[news239 ec2595]: /en/newsletters/2023/02/22/#eclair-2595
-[news239 ec2479]: /en/newsletters/2023/02/22/#eclair-2479
-[news239 lnd5988]:/en/newsletters/2023/02/22/#lnd-5988
-[news239 rb1636]: /en/newsletters/2023/02/22/#rust-bitcoin-1636

--- a/_posts/en/podcast/2023-03-02-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-02-newsletter-recap.md
@@ -1,43 +1,20 @@
 ---
 title: 'Bitcoin Optech Newsletter #240 Recap Podcast'
 permalink: /en/podcast/2023/03/02/
+reference: /en/newsletters/2023/03/01/
 name: 2023-03-02-recap
 slug: 2023-03-02-recap
 type: podcast
 layout: podcast-episode
 lang: en
 ---
-Mark "Murch" Erhardt and Mike Schmidt discuss [Newsletter #240][news240].
+Mark "Murch" Erhardt and Mike Schmidt discuss [Newsletter #240]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/66072343/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-2-6%2Fc7ab548d-fc59-cef8-9cad-b99e5a15ca54.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Faster seed backup checksums" url="news240 checksums" anchor="checksums" timestamp="2:31" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="HWI 2.2.1"
-  url="news240 hwi" anchor="hwi" timestamp="10:17" %}
-{% include functions/podcast-note.md title="Core Lightning 23.02rc3"
-  url="news240 cln" anchor="cln" timestamp="11:38" %}
-{% include functions/podcast-note.md title="lnd v0.16.0-beta.rc1"
-  url="news240 lnd" anchor="lnd" timestamp="12:03" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Bitcoin Core #25943"
-  url="news240 bc25943" anchor="bc25943" timestamp="12:59" %}
-{% include functions/podcast-note.md title="Bitcoin Core #26595"
-  url="news240 bc26595" anchor="bc26595" timestamp="15:11" %}
-{% include functions/podcast-note.md title="Bitcoin Core #27068"
-  url="news240 bc27068" anchor="bc27068" timestamp="16:51" %}
-{% include functions/podcast-note.md title="LDK #1988"
-  url="news240 ldk1988" anchor="ldk1988" timestamp="18:37" %}
-{% include functions/podcast-note.md title="LDK #1977"
-  url="news240 ldk1977" anchor="ldk1977" timestamp="20:15" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -85,7 +62,6 @@ week.  For those following along on Twitter Spaces, I've shared some tweets that
 are relevant to this week's newsletter and you can open up Newsletter #240 on
 the bitcoinops.org website as well to follow along.
 
-{:#checksums}
 _Faster seed backup checksums_
 
 We just have one news item this week, which is faster seed backup checksums, and
@@ -194,7 +170,6 @@ but it also scared some of the applied cryptographers that I was working with, h
 the MPC crypto was. And I may have made mistakes here, it was like three years
 ago that I talked to people about this.
 
-{:#hwi}
 _HWI 2.2.1_
 
 **Mike Schmidt**: So, we have three releases that we covered in the newsletter
@@ -216,7 +191,6 @@ of scriptpubkeys that have the same scheme, but different pubkeys plugged in.
 **Mike Schmidt**: Excellent, thank you for that overview.  So, those were the
 notable things in HWI.
 
-{:#cln}
 _Core Lightning 23.02rc3_
 
 The next notable release candidate is Core Lightning 23.02rc3, which we've had
@@ -225,7 +199,6 @@ Recap for #238, we had a couple of folks from Blockstream in the Core Lightning
 team that came on and gave us an overview of that release candidate, so I think
 you should reference that for more details.
 
-{:#lnd}
 _lnd v0.16.0-beta.rc1_
 
 And then the last release we had is LND v0.16.0 and this is a beta release
@@ -241,7 +214,6 @@ internal wallet for Taproot pubkeys in Tapscripts.  And then, there was a bunch
 of other RPC and wallet updates and bug fixes, so jump into the release notes
 there, it's really comprehensive there.
 
-{:#bc25943}
 _Bitcoin Core #25943_
 
 **Mark Erhardt**: Yeah, super.  So, #25943 basically protects users against
@@ -278,7 +250,6 @@ funds, but we would be able to assign funds to the script.
 
 **Mike Schmidt**: Got you!  Okay, that makes sense.  Thanks, Murch.
 
-{:#bc26595}
 _Bitcoin Core #26595_
 
 The next PR that we noted this week is Bitcoin Core #26595, and this pull
@@ -305,7 +276,6 @@ we do have an issue tracker on GitHub; let us know what you need.
 
 **Mike Schmidt**: Good plug.
 
-{:#bc27068}
 _Bitcoin Core #27068_
 
 Next PR here is Bitcoin Core #27068 and this is also related to passphrases.  It
@@ -336,8 +306,7 @@ your wallet".  Yeah, so I think you got it all.
 **Mike Schmidt**: The last two pull requests that we covered in this week's
 newsletter were related to the Lightning Development Kit, LDK.
 
-{:#ldk1988}
-LDK #1988
+_LDK #1988_
 
 The first PR is LDK #1988 which adds some limits for peer connections and
 unfunded channels to prevent denial of service attacks.  I believe that the
@@ -362,7 +331,6 @@ think that this sums up to over 300 connections already, plus all the
 connections that you have channels with.  That seems like a very generous amount
 of connections into the network.
 
-{:#ldk1977}
 _LDK #1977_
 
 **Mike Schmidt**: The last PR for this week is LDK #1977 and there's a couple of
@@ -394,13 +362,3 @@ a discussion of Newsletter #241.  Thanks, Murch.
 **Mark Erhardt**: Thanks, hear you soon.
 
 {% include references.md %}
-[news240]: /en/newsletters/2023/03/01/
-[news240 checksums]: /en/newsletters/2023/03/01/#faster-seed-backup-checksums
-[news240 hwi]: /en/newsletters/2023/03/01/#hwi-2-2-1
-[news240 cln]: /en/newsletters/2023/03/01/#core-lightning-23-02rc3
-[news240 lnd]: /en/newsletters/2023/03/01/#lnd-v0-16-0-beta-rc1
-[news240 bc25943]: /en/newsletters/2023/03/01/#bitcoin-core-25943
-[news240 bc26595]: /en/newsletters/2023/03/01/#bitcoin-core-26595
-[news240 bc27068]: /en/newsletters/2023/03/01/#bitcoin-core-27068
-[news240 ldk1988]: /en/newsletters/2023/03/01/#ldk-1988
-[news240 ldk1977]: /en/newsletters/2023/03/01/#ldk-1977

--- a/_posts/en/podcast/2023-03-09-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-09-newsletter-recap.md
@@ -1,6 +1,7 @@
 ---
 title: 'Bitcoin Optech Newsletter #241 Recap Podcast'
 permalink: /en/podcast/2023/03/09/
+reference: /en/newsletters/2023/03/08/
 name: 2023-03-09-recap
 slug: 2023-03-09-recap
 type: podcast
@@ -8,37 +9,13 @@ layout: podcast-episode
 lang: en
 ---
 Mark "Murch" Erhardt and Mike Schmidt are joined by James O'Beirne and Greg
-Sanders to discuss [Newsletter #241][news241].
+Sanders to discuss [Newsletter #241]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/66481895/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-2-13%2F2e2d3d8d-25d8-c037-24da-5193bdb1c466.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Alternative design for OP_VAULT" url="news241 op_vault" anchor="op_vault" timestamp="0:41" %}
-{% include functions/podcast-note.md title="New Optech Podcast" url="news241 podcast" anchor="podcast" timestamp="23:29" %}
-
-## Bitcoin Core PR Review Club
-
-{% include functions/podcast-note.md title="Bitcoin-inquisition: Activation logic for testing consensus changes" url="news241 pr review" anchor="pr-review"
-timestamp="24:33" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="Core Lightning 23.02"
-  url="news241 cln" anchor="cln" timestamp="38:01" %}
-{% include functions/podcast-note.md title="LDK v0.0.114"
-  url="news241 ldk" anchor="ldk" timestamp="40:00" %}
-{% include functions/podcast-note.md title="BTCPay 1.8.2"
-  url="news241 btcpay" anchor="btcpay" timestamp="40:52" %}
-{% include functions/podcast-note.md title="LND v0.16.0-beta.rc2"
-  url="news241 lnd" anchor="lnd" timestamp="41:40" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="LND #7462"
-  url="news241 lnd7462" anchor="lnd7462" timestamp="42:48" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -58,7 +35,6 @@ open-source developers.  Murch?
 
 **Greg Sanders**: Hi, I'm Greg instagibbs, Core Lightning engineer.
 
-{:#op_vault}
 _Alternative design for OP_VAULT_
 
 **Mike Schmidt**: Well, thank you special guests for joining us.  First and
@@ -448,7 +424,6 @@ if you want to hang on and chime in, feel free to do that as well.
 somewhat related to soft fork proposals, so maybe you'll have some thoughts on
 that too.
 
-{:#podcast}
 New Optech Podcast
 
 **Mike Schmidt**: Yeah, I'm sure we could use some insights.  One quick other
@@ -470,7 +445,6 @@ this.
 great venue for, you know, somewhat casual but still kind of in the weeds
 topics, so I'm really glad you guys do this on a weekly basis.
 
-{:#pr-review}
 _PR Review: Bitcoin-inquisition: Activation logic for testing consensus changes_
 
 **Mike Schmidt**: Awesome.  We have a monthly segment that we do for the
@@ -684,7 +658,6 @@ to the new rules.
 **Mike Schmidt**: Murch, we can move on to releases and release candidates for
 this week.
 
-{:#cln}
 _Core Lightning 23.02_
 
 We've covered Core Lightning 23.02 release candidates for some time, including a
@@ -714,7 +687,6 @@ So, this is notably not the full backup of the states of the channel, but it's
 more if the channel gets closed and you get paid out, you'll get back your
 money.
 
-{:#ldk}
 _LDK v0.0.114_
 
 **Mike Schmidt**: The next release that we covered this week was LDK v0.0.114,
@@ -731,7 +703,6 @@ offers with LDK now, so it's getting closer.  Murch, any LDK commentary?
 
 **Mark Erhardt**: No, I think you got it.
 
-{:#btcpay}
 _BTCPay 1.8.2_
 
 **Mike Schmidt**: We highlighted the BTCPay 1.8.2 release.  I think we've
@@ -749,7 +720,6 @@ labeling BIP or not; did you happen to see that?
 **Mike Schmidt**: Okay, I couldn't see that but perhaps they are adopting that
 new BIP fairly soon after it was official.
 
-{:#lnd}
 _LND v0.16.0-beta.rc2_
 
 The last release we have for this week is LND v0.16.0-beta.rc2.  I didn't pull
@@ -770,7 +740,6 @@ so I'll use this as an opportunity to solicit any questions or commentary from
 the listeners.  Feel free to raise your hand or request speaker access and we
 can get to you after we wrap up this LND PR.
 
-{:#lnd7462}
 _LND #7462_
 
 LND #7462, allowing the creation of watch-only wallets with remote signing and
@@ -797,12 +766,3 @@ at 14:00 UTC to discuss Newsletter #242.
 **Mike Schmidt**: Cheers, bye.
 
 {% include references.md %}
-[news241]: /en/newsletters/2023/03/08/
-[news241 op_vault]: /en/newsletters/2023/03/08/#alternative-design-for-op-vault
-[news241 podcast]: /en/newsletters/2023/03/08/#new-optech-podcast
-[news241 pr review]: /en/newsletters/2023/03/08/#bitcoin-core-pr-review-club
-[news241 cln]: /en/newsletters/2023/03/08/#core-lightning-23-02
-[news241 ldk]: /en/newsletters/2023/03/08/#ldk-v0-0-114
-[news241 btcpay]: /en/newsletters/2023/03/08/#btcpay-1-8-2
-[news241 lnd]: /en/newsletters/2023/03/08/#lnd-v0-16-0-beta-rc2
-[news241 lnd7462]: /en/newsletters/2023/03/08/#lnd-7462

--- a/_posts/en/podcast/2023-03-16-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-16-newsletter-recap.md
@@ -1,6 +1,7 @@
 ---
 title: 'Bitcoin Optech Newsletter #242 Recap Podcast'
 permalink: /en/podcast/2023/03/16/
+reference: /en/newsletters/2023/03/15/
 name: 2023-03-16-recap
 slug: 2023-03-16-recap
 type: podcast
@@ -8,29 +9,13 @@ layout: podcast-episode
 lang: en
 ---
 Mark "Murch" Erhardt and Mike Schmidt are joined by Calvin Kim, James O'Beirne,
-and Greg Sanders to discuss [Newsletter #242][news242].
+and Greg Sanders to discuss [Newsletter #242]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/67082119/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-2-22%2Fb61c45ac-e3fa-5bfb-1d03-9a6341f5be48.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Service bit for Utreexo" url="news242 utreexo" anchor="utreexo" timestamp="1:28" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="Core Lightning v23.02.2"
-  url="news242 cln" anchor="cln" timestamp="22:04" %}
-{% include functions/podcast-note.md title="Libsecp256k1 0.3.0"
-  url="news242 lsp" anchor="lsp" timestamp="25:47" %}
-{% include functions/podcast-note.md title="LND v0.16.0-beta.rc3"
-  url="news242 lnd" anchor="lnd" timestamp="29:01" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Bitcoin Core #25740"
-  url="news242 bc25740" anchor="bc25740" timestamp="30:01" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -72,7 +57,6 @@ thank you for getting through some of those audio difficulties.  We just have
 one news item and one pull request, but they're both related to projects you
 guys are working on, so it's great to have you guys on.
 
-{:#utreexo}
 _Service bit for Utreexo_
 
 The first news item is Service Bit for Utreexo.  Calvin, I think we probably
@@ -458,7 +442,6 @@ he might pop in.
 **Mike Schmidt**: You got lucky, Calvin!  Great.  Moving onto the Releases and
 Release Candidates section of the newsletter this week, we have three.
 
-{:#cln}
 _Core Lightning v23.02.2_
 
 The first one is Core Lightning v23.02.2, which is a maintenance release for
@@ -529,7 +512,6 @@ this issue have a very small number of staff and/or volunteers and it's probably
 hard to do all of this.  But yeah, companies that run into this issue, they
 should be testing the release candidate before they install it in production.
 
-{:#lsp}
 _Libsecp256k1 0.3.0_
 
 **Mike Schmidt**: The next release that we covered in the newsletter was
@@ -590,7 +572,6 @@ say an ABI is an API in some sense.
 
 **Mike Schmidt**: Yeah, thanks for explaining, James and Calvin.
 
-{:#lnd}
 _LND v0.16.0-beta.rc3_
 
 The last release candidate that we had is LND v0.16.0-beta.rc3, and a few weeks
@@ -615,7 +596,6 @@ really I'm not much of a Lightning expert!
 **Mike Schmidt**: Okay, well look forward to finding some people to join us on
 our Not Spaces next week!
 
-{:#bc25740}
 _Bitcoin Core #25740_
 
 We had one notable code and documentation change, a notable PR to Bitcoin Core,
@@ -911,9 +891,3 @@ everybody for listening on the podcasts, and likely we'll be doing this again in
 Google Hangouts, because this is actually quite a bit smoother.
 
 {% include references.md %}
-[news242]: /en/newsletters/2023/03/15/
-[news242 utreexo]: /en/newsletters/2023/03/15/#service-bit-for-utreexo
-[news242 cln]: /en/newsletters/2023/03/15/#core-lightning-v23-02-2
-[news242 lsp]: /en/newsletters/2023/03/15/#libsecp256k1-0-3-0
-[news242 lnd]: /en/newsletters/2023/03/15/#lnd-v0-16-0-beta-rc3
-[news242 bc25740]: /en/newsletters/2023/03/15/#bitcoin-core-25740

--- a/_posts/en/podcast/2023-03-23-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-23-newsletter-recap.md
@@ -1,54 +1,20 @@
 ---
 title: 'Bitcoin Optech Newsletter #243 Recap Podcast'
 permalink: /en/podcast/2023/03/23/
+reference: /en/newsletters/2023/03/22/
 name: 2023-03-23-recap
 slug: 2023-03-23-recap
 type: podcast
 layout: podcast-episode
 lang: en
 ---
-Mark "Murch" Erhardt and Mike Schmidt are joined by Alekos Filini to discuss [Newsletter #243][news243].
+Mark "Murch" Erhardt and Mike Schmidt are joined by Alekos Filini to discuss [Newsletter #243]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/67545048/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-2-29%2F2a4fe187-8895-deaf-5429-21ee45ce15f8.mp3" %}
 
-## News
-
-_No significant news this week was found on the Bitcoin-Dev or Lightning-Dev mailing lists._
-
-## Changes to services and client software
-
-{% include functions/podcast-note.md title="Xapo Bank supports Lightning"
-  url="news243 sc1" anchor="cs1" timestamp="1:41" %}
-{% include functions/podcast-note.md title="TypeScript library for miniscript descriptors released"
-  url="news243 sc2" anchor="cs2" timestamp="3:02" %}
-{% include functions/podcast-note.md title="Breez Lightning SDK announced"
-  url="news243 sc3" anchor="cs3" timestamp="6:48" %}
-{% include functions/podcast-note.md title="PSBT-based exchange OpenOrdex launches"
-  url="news243 sc4" anchor="cs4" timestamp="10:48" %}
-{% include functions/podcast-note.md title="BTCPay Server coinjoin plugin released"
-  url="news243 sc5" anchor="cs5" timestamp="14:01" %}
-{% include functions/podcast-note.md title="mempool.space explorer enhances CPFP support"
-  url="news243 sc6" anchor="cs6" timestamp="18:46" %}
-{% include functions/podcast-note.md title="Sparrow v1.7.3 released"
-  url="news243 sc7" anchor="cs7" timestamp="21:38" %}
-{% include functions/podcast-note.md title="Stack Wallet adds coin control, BIP47"
-  url="news243 sc8" anchor="cs8" timestamp="24:22" %}
-{% include functions/podcast-note.md title="Wasabi Wallet v2.0.3 released"
-  url="news243 sc9" anchor="cs9" timestamp="26:26" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="LND v0.16.0-beta.rc3"
-  url="news243 lnd" anchor="lnd" timestamp="28:32" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="LND #7448"
-  url="news243 lnd7448" anchor="lnd7448" timestamp="29:16" %}
-{% include functions/podcast-note.md title="BDK #793"
-  url="news243 bdk793" anchor="bdk793" timestamp="36:03" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -86,7 +52,6 @@ jump into that?
 
 **Mark Erhardt**: I don't have any.
 
-{:#cs1}
 _Xapo Bank supports Lightning_
 
 **Mike Schmidt**: All right.  Well, the first interesting client software update
@@ -113,7 +78,6 @@ to me like they first decided that they were going to do something with
 Lightning and then they tried to figure out what their product was going to be,
 so I think that might have added to the mystique.
 
-{:#cs2}
 _TypeScript library for miniscript descriptors released_
 
 **Mike Schmidt**: Perhaps.  The second thing that we noted in the newsletter was
@@ -177,7 +141,6 @@ you are fine with just that, you don't need a compiler in your project.
 fairly young project, so potentially some of that stuff could be added in the
 future.
 
-{:#cs3}
 _Breez Lightning SDK announced_
 
 The next item that we noted was Breez Lightning SDK being announced and we've
@@ -234,7 +197,6 @@ self-custodial Lightning to its users.  I think it's really nice to see how
 things are coming together slowly and products are getting more refined that
 way.
 
-{:#cs4}
 _PSBT-based exchange OpenOrdex launches_
 
 **Mike Schmidt**: The next piece of software that we spoke about in this segment
@@ -279,7 +241,6 @@ they're doing that.
 his tweet that I saw originally that was what brought this project to my
 attention.
 
-{:#cs5}
 _BTCPay Server coinjoin plugin released_
 
 The next item that we saw that was notable for the Bitcoin Optech community was
@@ -342,8 +303,7 @@ that I thought!
 **Mike Schmidt**: Yeah, that was great context.  Thanks for walking through
 that, Murch.
 
-{:#cs6}
-_Mempool.space explorer enhances CPFP support_
+_mempool.space explorer enhances CPFP support_
 
 The next item that we noted in the client and services updates section of the
 newsletter is mempool.space adding enhanced CPFP support.  So, mempool.space is
@@ -382,7 +342,6 @@ high-feerate child, it would look like the minimum feerate was lower in the
 block, but really it actually all fit because the child paid for it and it was
 sensible to include the transaction.
 
-{:#cs7}
 _Sparrow v1.7.3 released_
 
 **Mike Schmidt**: Next item from the newsletter that we noted was Sparrow v1.7.3
@@ -419,7 +378,6 @@ interested in having a standard on how to do this together.  I see names of
 people that work on Nunchuck, Coinkite, Shift Crypto, being a hardware wallet
 producer, I don't know who Aaron Chen is, but Rodolfo Novak also from COLDCARD.
 
-{:#cs8}
 _Stack Wallet adds coin control, BIP47_
 
 **Mike Schmidt**: The next piece of software we noted this week was Stack Wallet
@@ -454,7 +412,6 @@ angry, because we covered paynyms, which is like a Samourai thing, we've covered
 Wasabi and we've covered ordinals.  So, everybody can be angry about our
 coverage of software this week.
 
-{:#cs9}
 _Wasabi Wallet v2.0.3 released_
 
 The last one is Wasabi, so we noted Wasabi's WabiSabi plugin for BTCPay, and the
@@ -482,7 +439,6 @@ or allow you to label addresses when you receive, and then deduce context from
 that.  But yeah, it's a long road, we'll get there eventually and meanwhile,
 power users can do it manually.
 
-{:#lnd}
 _LND v0.16.0-beta.rc3_
 
 **Mike Schmidt**: We noted one release this week in the newsletter, which is LND
@@ -494,7 +450,6 @@ this is actually released, so we'll get them either next week or the week after,
 and I think they'll provide a better overview of this release than we could.
 So, I'm okay punting it again, Murch, if you are.  All right, great.
 
-{:#lnd7448}
 _LND #7448_
 
 Speaking of LND, the first notable code change, LND #7448, adds a new
@@ -589,7 +544,6 @@ LND rebroadcast PR?
 
 **Mark Erhardt**: No, I think that is all.
 
-{:#bdk793}
 _BDK #793_
 
 **Mike Schmidt**: Well, the last pull request that we highlighted in the
@@ -805,16 +759,3 @@ Bitcoin Optech Newsletter #243, and we'll talk to you guys next week.  Cheers.
 **Alekos Filini**: Bye, thank you.
 
 {% include references.md %}
-[news243]: /en/newsletters/2023/03/22/
-[news243 sc1]: /en/newsletters/2023/03/22/#xapo-bank-supports-lightning
-[news243 sc2]: /en/newsletters/2023/03/22/#typescript-library-for-miniscript-descriptors-released
-[news243 sc3]: /en/newsletters/2023/03/22/#breez-lightning-sdk-announced
-[news243 sc4]: /en/newsletters/2023/03/22/#psbt-based-exchange-openordex-launches
-[news243 sc5]: /en/newsletters/2023/03/22/#btcpay-server-coinjoin-plugin-released
-[news243 sc6]: /en/newsletters/2023/03/22/#mempool-space-explorer-enhances-cpfp-support
-[news243 sc7]: /en/newsletters/2023/03/22/#sparrow-v1-7-3-released
-[news243 sc8]: /en/newsletters/2023/03/22/#stack-wallet-adds-coin-control-bip47
-[news243 sc9]: /en/newsletters/2023/03/22/#wasabi-wallet-v2-0-3-released
-[news243 lnd]: /en/newsletters/2023/03/22/#lnd-v0-16-0-beta-rc3
-[news243 lnd7448]: /en/newsletters/2023/03/22/#lnd-7448
-[news243 bdk793]: /en/newsletters/2023/03/22/#bdk-793

--- a/_posts/en/podcast/2023-03-30-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-30-newsletter-recap.md
@@ -1,67 +1,20 @@
 ---
 title: 'Bitcoin Optech Newsletter #244 Recap Podcast'
 permalink: /en/podcast/2023/03/30/
+reference: /en/newsletters/2023/03/29/
 name: 2023-03-30-recap
 slug: 2023-03-30-recap
 type: podcast
 layout: podcast-episode
 lang: en
 ---
-Mark "Murch" Erhardt and Mike Schmidt are joined by Dave Harding to discuss [Newsletter #244][news244].
+Mark "Murch" Erhardt and Mike Schmidt are joined by Dave Harding to discuss [Newsletter #244]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/68149014/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-3-7%2F51c41810-d746-d516-29e7-b72c6ee34788.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Preventing stranded capital with multiparty channels and channel factories"
-  url="news244 factories" anchor="factories" timestamp="1:00" %}
-
-## Selected Q&A from Bitcoin Stack Exchange
-
-{% include functions/podcast-note.md title="Why isn’t the taproot deployment buried in Bitcoin Core?"
-  url="news244 se1" anchor="se1" timestamp="28:06" %}
-{% include functions/podcast-note.md title="What restrictions does the version field in the block header have?"
-  url="news244 se2" anchor="se2" timestamp="32:23" %}
-{% include functions/podcast-note.md title="What is the relation between transaction data and ids?"
-  url="news244 se3" anchor="se3" timestamp="39:04" %}
-{% include functions/podcast-note.md title="Can I request tx messages from other peers?"
-  url="news244 se4" anchor="se4" timestamp="43:33" %}
-{% include functions/podcast-note.md title="Eltoo: Does the relative locktime on the first UTXO set the lifetime of the channel?"
-  url="news244 se5" anchor="se5" timestamp="47:34" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="Rust Bitcoin 0.30.0"
-  url="news244 rb" anchor="rb" timestamp="52:23" %}
-{% include functions/podcast-note.md title="LND v0.16.0-beta.rc5"
-  url="news244 lnd" anchor="lnd" timestamp="53:43" %}
-{% include functions/podcast-note.md title="BDK 1.0.0-alpha.0"
-  url="news244 bdk" anchor="bdk" timestamp="54:16" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Bitcoin Core #27278"
-  url="news244 bc27278" anchor="bc27278" timestamp="54:45" %}
-{% include functions/podcast-note.md title="Bitcoin Core #26531"
-  url="news244 bc26531" anchor="bc26531" timestamp="1:00:26" %}
-{% include functions/podcast-note.md title="Core Lightning #5898"
-  url="news244 cln5898" anchor="cln5898" timestamp="1:03:23" %}
-{% include functions/podcast-note.md title="Core Lightning #5986"
-  url="news244 cln5986" anchor="cln5986" timestamp="1:05:21" %}
-{% include functions/podcast-note.md title="Eclair #2616"
-  url="news244 ec2616" anchor="ec2616" timestamp="1:07:43" %}
-{% include functions/podcast-note.md title="LDK #2024"
-  url="news244 ldk2024" anchor="ldk2024" timestamp="1:10:36" %}
-{% include functions/podcast-note.md title="Rust Bitcoin #1737"
-  url="news244 rb1737" anchor="rb1737" timestamp="1:12:43" %}
-{% include functions/podcast-note.md title="BTCPay Server #4608"
-  url="news244 btcpay4608" anchor="btcpay4608" timestamp="1:13:03" %}
-{% include functions/podcast-note.md title="BIPs #1425"
-  url="news244 bips1425" anchor="bips1425" timestamp="1:15:43" %}
-{% include functions/podcast-note.md title="Bitcoin Inquisition #22"
-  url="news244 bi22" anchor="bi22" timestamp="1:16:51" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
@@ -86,7 +39,6 @@ topics every month.  So, thank you for that, Dave.
 
 **David Harding**: You're welcome.
 
-{:#factories}
 _Preventing stranded capital with multiparty channels and channel factories_
 
 **Mike Schmidt**: We have one news item this week, which is about channel
@@ -479,7 +431,6 @@ go through the Bitcoin Stack Exchange and look for interesting questions and
 answers to highlight for the Optech audience, and this week we have five of
 those.
 
-{:#se1}
 _Why isn't the taproot deployment buried in Bitcoin Core?_
 
 The first one is, "Why isn't the taproot deployment buried in Bitcoin Core?" and
@@ -545,7 +496,6 @@ this more myself.
 **Mark Erhardt**: Thanks, and please report back, because I think I'm a little
 confused now too.
 
-{:#se2}
 _What restrictions does the version field in the block header have?_
 
 **Mike Schmidt**: The next question from the Stack Exchange that we highlighted
@@ -643,7 +593,6 @@ ASICBoost requires you to sort of have a collusion I think in coinbases, or let
 me not try to explain ASICBoost right now, I'd have to brush up on it.  But
 yeah, thank you for correcting me, is all what I'm trying to say!
 
-{:#se3}
 _What is the relation between transaction data and ids?_
 
 **Mike Schmidt**: The next question from the Stack Exchange is about the
@@ -710,7 +659,6 @@ heard that term before; I like it.
 
 **Mike Schmidt**: Oh, okay, I wasn't sure is that was formal jargon.
 
-{:#se4}
 _Can I request tx messages from other peers?_
 
 The next question from the Stack Exchange is, "Can I request tx messages from
@@ -771,7 +719,6 @@ a protocol that essentially is doing exactly these sort of proofs, which UTXOs
 still exist, which that transaction can validly spend, and all that.  So, if
 you're interested in that topic, check out our Recap two weeks ago.
 
-{:#se5}
 _Eltoo: Does the relative locktime on the first UTXO set the lifetime of the channel?_
 
 **Mike Schmidt**: Last question from the Stack Exchange involves eltoo, and the
@@ -838,7 +785,6 @@ more distinct name.
 **Mike Schmidt**: Understood; same technology, different name, rebranding.  The
 next section in the newsletter this week is releases and release candidates.
 
-{:#rb}
 _Rust Bitcoin 0.30.0_
 
 The first one noted here is Rust Bitcoin 0.30.0, and this release actually is
@@ -859,7 +805,6 @@ calls, how to upgrade or amend your use of those API calls with sometimes new
 parameters or a superseding API call.  So, I think that blogpost is probably the
 most helpful thing to look at if you're using it.
 
-{:#lnd}
 _LND v0.16.0-beta.rc5_
 
 **Mike Schmidt**: The next release that we highlighted here is the LND
@@ -869,7 +814,6 @@ that do want to come on and give us the nitty-gritty of this release, but they
 are waiting for the release to actually be official in order to jump on and
 discuss with us.
 
-{:#bdk}
 _BDK 1.0.0-alpha.0_
 
 So, we'll punt for another week on that, which will lead us to the next release,
@@ -879,7 +823,6 @@ been done there recently, that we highlighted in the newsletter last week.  So,
 if folks are curious about the details there, I would encourage you to revisit
 the Recap from last week, for newsletter #243, to get the details.
 
-{:#bc27278}
 _Bitcoin Core #27278_
 
 **Mike Schmidt**: The first PR that we covered this week was Bitcoin Core
@@ -966,7 +909,6 @@ place to collect that data.
 
 **Mark Erhardt**: It will just cover another item.
 
-{:#bc26531}
 _Bitcoin Core #26531_
 
 **Mike Schmidt**: Yeah, Bitcoin Core #26531.  In the last item that we just
@@ -1013,7 +955,6 @@ with certain aspects of Bitcoin Core.
 
 **Mike Schmidt**: I think that's a good summary.  Thanks, Murch.
 
-{:#cln5898}
 _Core Lightning #5898_
 
 Next PR this week is Core Lightning #5898, and it's updating its dependency on
@@ -1042,7 +983,6 @@ I'm very excited about, like P2TR-based channels, which look like single sig to
 everyone else, and maybe also PTLCs.  Yeah, so anyway, I think this is just part
 of the schnorrification of Lightning.
 
-{:#cln5986}
 _Core Lightning #5986_
 
 **Mike Schmidt**: There's another Core Lightning PR, #5986, which updates RPCs
@@ -1078,7 +1018,6 @@ Sometimes it feels a little bit like you're talking to an empty room, because of
 course we're mostly talking to ourselves up here.  So, if you have reactions,
 let us know what you like and that would be appreciated.
 
-{:#ec2616}
 _Eclair #2616_
 
 **Mike Schmidt**: Next PR is Eclair #2616, adding support for opportunistic
@@ -1128,7 +1067,6 @@ there's really no risk to the Eclair user, it would be the remote peer?
 
 **David Harding**: Exactly.
 
-{:#ldk2024}
 _LDK #2024_
 
 **Mike Schmidt**: Next PR is LDK #2024, including route hints for channels which
@@ -1162,7 +1100,6 @@ confirmations.  So, this allows an LDK node to receive a payment through a
 channel which can't yet be announced, but which they're probably planning to
 announce in the future.
 
-{:#rb1737}
 _Rust Bitcoin #1737_
 
 **Mike Schmidt**: Thanks, Dave.  Next PR is Rust Bitcoin #1737, adding a
@@ -1171,7 +1108,6 @@ encouraged best practices with regards to disclosures and it seems like a few
 projects in the last month have put up their security reporting policy, which is
 good to see.
 
-{:#btcpay4608}
 _BTCPay Server #4608_
 
 Next PR is BTCPay Server #4608, allowing plugins to expose their features as an
@@ -1210,7 +1146,6 @@ Some merchants only have an online presence, so they don't need a PoS app; some
 people might be using it as a mechanism to receive donations, so maybe they want
 the Crowfunding app.  That's just for color, I don't know more than this either.
 
-{:#bips1425}
 _BIPs #1425_
 
 **Mike Schmidt**: Next PR is to the BIPs repository, BIPs #1425, assigning the
@@ -1231,7 +1166,6 @@ question or comment to the thread that's associated with this Spaces, or feel
 free to raise your hand and request speaker access if you have a question or
 comment on our discussion today.
 
-{:#bi22}
 _Bitcoin Inquisition #22_
 
 The last PR is to Bitcoin Inquisition, and that's Bitcoin Inquisition #22, which
@@ -1309,23 +1243,3 @@ nice.
 **David Harding**: Thanks for having me, guys.
 
 {% include references.md %}
-[news244]: /en/newsletters/2023/03/29/
-[news244 factories]: /en/newsletters/2023/03/29/#preventing-stranded-capital-with-multiparty-channels-and-channel-factories
-[news244 se1]: /en/newsletters/2023/03/29/#why-isn-t-the-taproot-deployment-buried-in-bitcoin-core
-[news244 se2]: /en/newsletters/2023/03/29/#what-restrictions-does-the-version-field-in-the-block-header-have
-[news244 se3]: /en/newsletters/2023/03/29/#what-is-the-relation-between-transaction-data-and-ids
-[news244 se4]: /en/newsletters/2023/03/29/#can-i-request-tx-messages-from-other-peers
-[news244 se5]: /en/newsletters/2023/03/29/#eltoo-does-the-relative-locktime-on-the-first-utxo-set-the-lifetime-of-the-channel
-[news244 rb]: /en/newsletters/2023/03/29/#rust-bitcoin-0-30-0
-[news244 lnd]: /en/newsletters/2023/03/29/#lnd-v0-16-0-beta-rc5
-[news244 bdk]: /en/newsletters/2023/03/29/#bdk-1-0-0-alpha-0
-[news244 bc27278]: /en/newsletters/2023/03/29/#bitcoin-core-27278
-[news244 bc26531]: /en/newsletters/2023/03/29/#bitcoin-core-26531
-[news244 cln5898]: /en/newsletters/2023/03/29/#core-lightning-5898
-[news244 cln5986]: /en/newsletters/2023/03/29/#core-lightning-5986
-[news244 ec2616]: /en/newsletters/2023/03/29/#eclair-2616
-[news244 ldk2024]: /en/newsletters/2023/03/29/#ldk-2024
-[news244 rb1737]: /en/newsletters/2023/03/29/#rust-bitcoin-1737
-[news244 btcpay4608]: /en/newsletters/2023/03/29/#btcpay-server-4608
-[news244 bips1425]: /en/newsletters/2023/03/29/#bips-1425
-[news244 bi22]: /en/newsletters/2023/03/29/#bitcoin-inquisition-22

--- a/_posts/en/podcast/2023-04-06-newsletter-recap.md
+++ b/_posts/en/podcast/2023-04-06-newsletter-recap.md
@@ -1,63 +1,23 @@
 ---
 title: 'Bitcoin Optech Newsletter #245 Recap Podcast'
 permalink: /en/podcast/2023/04/06/
+reference: /en/newsletters/2023/04/05/
 name: 2023-04-06-recap
 slug: 2023-04-06-recap
 type: podcast
 layout: podcast-episode
 lang: en
 ---
-Mark "Murch" Erhardt and Mike Schmidt are joined by Sergi Delgado Segura to discuss [Newsletter #245][news245].
+Mark "Murch" Erhardt and Mike Schmidt are joined by Sergi Delgado Segura to discuss [Newsletter #245]({{page.reference}}).
 
 {% include functions/podcast-links.md %}
 
 {% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/68345636/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-3-10%2F3bdcea63-7ec8-0854-25fe-913e04492aeb.mp3" %}
 
-## News
-
-{% include functions/podcast-note.md title="Watchtower accountability proofs"
-  url="news245 watchtowers" anchor="" timestamp="0:36" %}
-
-## Releases and release candidates
-
-{% include functions/podcast-note.md title="LND v0.16.0-beta"
-  url="news245 lnd" anchor="" timestamp="21:37" %}
-{% include functions/podcast-note.md title="BDK 1.0.0-alpha.0"
-  url="news245 bdk" anchor="" timestamp="22:06" %}
-
-## Notable code and documentation changes
-
-{% include functions/podcast-note.md title="Core Lightning #5967"
-  url="news245 cln5967" anchor="" timestamp="22:59" %}
-{% include functions/podcast-note.md title="Eclair #2566"
-  url="news245 ec2566" anchor="" timestamp="23:43" %}
-{% include functions/podcast-note.md title="LDK #2062"
-  url="news245 ldk2062" anchor="" timestamp="24:57" %}
-{% include functions/podcast-note.md title="LDK #2125"
-  url="news245 ldk2125" anchor="" timestamp="27:18" %}
-{% include functions/podcast-note.md title="BTCPay Server #4826"
-  url="news245 btcpay4826" anchor="" timestamp="27:56" %}
-{% include functions/podcast-note.md title="BTCPay Server #4782"
-  url="news245 btcpay4782" anchor="" timestamp="29:51" %}
-{% include functions/podcast-note.md title="BTCPay Server #4799"
-  url="news245 btcpay4799" anchor="" timestamp="30:15" %}
-{% include functions/podcast-note.md title="BOLTs #765"
-  url="news245 bolt765" anchor="" timestamp="31:37" %}
+{% include newsletter-references.md %}
 
 ## Transcription
 
 _transcription coming soon_
 
 {% include references.md %}
-[news245]: /en/newsletters/2023/04/05/
-[news245 watchtowers]: /en/newsletters/2023/04/05/#watchtower-accountability-proofs
-[news245 lnd]: /en/newsletters/2023/04/05/#lnd-v0-16-0-beta
-[news245 bdk]: /en/newsletters/2023/04/05/#bdk-1-0-0-alpha-0
-[news245 cln5967]: /en/newsletters/2023/04/05/#core-lightning-5967
-[news245 ec2566]: /en/newsletters/2023/04/05/#eclair-2566
-[news245 ldk2062]: /en/newsletters/2023/04/05/#ldk-2062
-[news245 ldk2125]: /en/newsletters/2023/04/05/#ldk-2125
-[news245 btcpay4826]: /en/newsletters/2023/04/05/#btcpay-server-4826
-[news245 btcpay4782]: /en/newsletters/2023/04/05/#btcpay-server-4782
-[news245 btcpay4799]: /en/newsletters/2023/04/05/#btcpay-server-4799
-[news245 bolt765]: /en/newsletters/2023/04/05/#bolts-765

--- a/_posts/en/podcast/2023-04-06-newsletter-recap.md
+++ b/_posts/en/podcast/2023-04-06-newsletter-recap.md
@@ -18,6 +18,607 @@ Mark "Murch" Erhardt and Mike Schmidt are joined by Sergi Delgado Segura to disc
 
 ## Transcription
 
-_transcription coming soon_
+**Mike Schmidt**: Welcome everybody to Bitcoin Optech Newsletter #245 Recap on
+Twitter Spaces.  It's Thursday, April 6, 2023.  We'll do some quick
+introductions and jump into the newsletter.  I'm Mike Schmidt, contributor at
+Optech and Executive Director at Brink, where we're funding Bitcoin open-source
+developers.
+
+**Mark Erhardt**: Hi, I'm Murch, I work at Chaincode Labs.  This week, I have
+been looking at a BIP draft for transaction terminology.
+
+**Sergi Delgado Segura**: Hi, I'm Sergi, I'm an open-source dev supported by
+Spiral at the moment.  This week, I've been featured in the Optech regarding
+watchtowers and accumulators and stuff like that.
+
+_Watchtower accountability proofs_
+
+**Mike Schmidt**: Thank you for joining us.  Yeah, it's not every day that we
+have a watchtower expert on our podcast, and so thank you for joining.  And
+perhaps as we jump into it, you could maybe provide just a quick overview of
+what are watchtowers, and then maybe give your thoughts on the state of
+watchtowers these days.
+
+**Sergi Delgado Segura**: Sure.  I don't like the word "expert" by watchtower,
+by the way, I've never called myself something like that, but yeah, thank you!
+
+So, regarding watchtowers, for someone who is not familiar with the concept, the
+idea I think is pretty simple.  So, we all may know we are used to using
+Lightning, that when we use Lightning, we need to be either always online
+because we have a node and we host the node, and so on, or we are using a
+custodial solution where someone else is running the infrastructure for us and
+then they are always online so they can receive and send payments when we need
+to.
+
+This is quite different from the approach followed by, let's say standard
+Bitcoin itself, with no channels, and so on, mainly because you don't need to be
+online as long as you don't have to send a transaction.  I mean, you may not
+even need a node to receive transactions, as long as whoever wants to pay you
+has an address they can pay you to.  But through Lightning, it's not that easy.
+The idea is that your node has to be online in order to be able to accept those
+payments, meaning that if you are not online, then some nasty stuff may happen.
+The idea is that as long as you are not offline most of the time, or as long as
+you're not offline for long periods of time, you may be okay, because there are
+some mechanisms in place to prevent your counterparty trying to cheat and close
+a channel with an old state.
+
+So, the idea is that I would say we open the channel and we perform some
+transactions and then at some point, we want to close a channel.  Every single
+point between the opening and the close of the channel are valid transactions.
+So, if a counterparty's not there to claim what's a valid state or what's a
+later state, then the other party can just say, "Hey, this is the later state
+and I'm going to close the channel with this".  And as long as no one complains,
+that's going to be the truth for the rest of the network, because there's
+privacy involved here, so no one else knows what's the latest state.
+
+Then, how watchtowers come into the picture is mainly being an observer of those
+channels without actually knowing what's going on, but having enough information
+to see if someone is trying to close a channel with an old state.  And if that's
+the case, then the idea is that the tower will just react to that action being
+performed with proof that was actually not the latest state, and will penalize
+the closure, let's say, of the party that tried to close with the old state, by
+sending all the money from the channel to the counterparty, which is in
+principle the act that it has employed the watchtower to act on their behalf.
+So, that's give or take how it goes.
+
+**Mike Schmidt**: Perfect.  And what's the state of watchtowers in the ecosystem
+currently in terms of however you want to talk about that, adoption, different
+types of software, challenges?
+
+**Sergi Delgado Segura**: So, regarding software, as far as I know there are at
+least, or there's been at least four different implementations of watchtowers
+that have been dedicated to different projects.  So we have, in order of
+appearance, I would say, and as far as I know, the first watchtower to ever be
+implemented was done by Bitcoin Lightning Wallet, which is a soft fork that is
+no longer maintained or used.  That changed to Simple Bitcoin Wallet, and then I
+think now it's called OBW something like that.  I may have interchanged the
+order of the towers, and so on, I don't fully remember now.  I think it was
+Bitcoin Lightning Wallet, the first one.
+
+They had an implementation, called Olympus, which as far as I know was the first
+implementation of watchtowers ever to be deployed in the world.  After that, it
+came LND, with the LND watchtower, which followed give or take the same
+principle.  The main difference between one and the other was that Olympus was
+using some kind of tokens to pay for the storage of the watchtower; whereas, LND
+was using a completely altruistic watchtower.  Both of them were designed in a
+way that only worked with that implementation, so Olympus worked with Bitcoin
+Lightning Wallet and LND worked with LND's, so no interoperability there.
+
+Then there's the Eye of Satoshi, which is the implementation I've been working
+on for a while, which tried to put some solution in place for these
+interoperability issues.  So, the angle was, "Hey, let's have something that can
+work with any kind of node or wallet; no matter what you're using, you can have
+a watchtower and connect to it.  Currently, it's only working for C-Lightning,
+mainly because we don't have a standard or a common way of doing things, even
+though it's give or take the same what we are doing, but there are some
+differences and it looks like we haven't agreed on how to properly do things.
+
+Then the last one, which came give or take at the same time as the Eye of
+Satoshi is Electrum's.  They have their own implementation of watchtowers in
+Python, if I'm not mistaken.  And that's it for what I know.  There may be
+something else that I'm not aware of, but that's what I've heard of at least.
+
+**Mike Schmidt**: You mentioned there some incompatibility or differences in
+approach to watchtowers between these different pieces of software.  Is there
+discussion around a BOLT or a bLIP or some way to standardize that, or is
+everyone's paving their own path here?
+
+**Sergi Delgado Segura**: It feels like everyone was paving their own path at
+the beginning.  At some point when I started working on this, I tried to gather
+the people that were working on watchtowers and tried to write a BOLT for that.
+And I did; there's a proposal for BOLT 13, which was supposed to be the
+watchtower BOLT.  But apart from Antoine Riard and people from CLN, both Rusty
+and Christian, not many more people are fully engaged in the discussion of the
+BOLT.
+
+So at some point, I once tried to start implementing it with the ideas I've
+picked on from the ones that were already implemented, plus the idea they had to
+try to make it a little bit better, and there hasn't been much discussion
+regarding the BOLT after that.  Honestly, after seeing all the drama, let's say,
+regarding BOLT 12, it drove me off a little bit to try to push this further in
+terms of standardization.  It feels like if we want to do it, then that's kind
+of a bottom-up thing instead of a top-down approach.  It's not like, "Hey, I
+think this should be done in this way, so let's do it"; people need to really
+care about this.  And it feels like most of the node implementors, or node
+implementations are focused on other stuff they feel is more important or more
+relevant, so there hasn't been that much interaction, to be honest.
+
+**Mike Schmidt**: We can start shifting a bit towards your Lightning-Dev mailing
+list post here, and maybe before we go into the details, you could provide the
+answer to this question which is, if we're seeking accountability to
+watchtowers, I'm wondering if you're proposing this as a more proactive solution
+because it tends to be common that you need to prove accountability; or if this
+is something that is reactive and this is actively going on currently and you're
+trying to mitigate some misbehaviour or downtime from watchtowers?  And then,
+maybe we can get into some of the details.
+
+**Sergi Delgado Segura**: Well, I think currently there hasn't been that much
+use of towers generally, mainly because the main use for towers is for mobile
+devices instead of desktops or server nodes, where those may be mostly online or
+they may be more beefy in the sense that they may have redundancy in terms of
+both power supply or internet provider, and so on and so forth.  And since
+there's no implementation that actually works with mobile nodes or mobile
+wallets, the main use case, let's say, is not covered, or the use case that
+makes more sense is not covered.
+
+So, it's not like I'm trying to mitigate something that's going on, it's more
+like I'm trying to design something that may be useful in the case that this
+happens.  Because, if you think of a future where people are using towers, how
+do you decide what to use?  Are you going to trust blindly in someone who is
+providing a service without knowing if they are reliable in any way; or, are you
+just going to connect to a friend of yours who may be providing this service and
+you trust?  The latter doesn't scale.  It may be a solution for some, but if you
+are just trying to offer these as a service for the whole network, there should
+be a way of distinguishing between who is actually providing a good service and
+who is not.
+
+Imagine that you're trusting or blindly thinking that your watchtower's going to
+cover you if something bad happens, then at the end of the day they're not doing
+anything, then you may be lowering your security by trusting, which you
+shouldn't by the way, but trusting this watchtower to cover your back.  So
+that's the main idea.  You shouldn't be trusting any, but in order for them to
+be encouraged to behave, then there should be a way of calling them off if
+they're not behaving.
+
+**Mike Schmidt**: What is that way?  Maybe we can get into your proposal here a
+bit.
+
+**Sergi Delgado Segura**: The way I see it is the way that the Eye of Satoshi
+has been implemented since the very beginning.  So, putting in accountability is
+not something that is hard to do, you just have to have signed agreement between
+the thing that you're sending to a tower.  So, in the Eye of Satoshi, but there
+are other ways of doing it, the main idea is that the tower is covering you for
+a certain amount of time, let's say, I don't know, 1 million blocks, or
+something like that; and then when you register you agree with the tower on them
+covering you for that time and they sign a receipt saying, "Hey, I'm going to
+cover you from block 1 to block 1,000,001", then every time you send something
+to a tower, you can also sign it and the tower returns a signed receipt saying,
+"Hey, you have sent this to me and I'm supposed to respond if this happens".
+
+So, the idea is that both the user and the tower have signed receipts of the
+agreement of both parts, of the watching of this channel in these specific
+states.  And then in the end, if a breach is seen onchain and it belongs to
+something that the user knows it has sent to a tower, the user can always go and
+say, "There's this breach onchain, I've sent this piece of information to the
+tower", you can actually verify that this piece of information belongs to that
+breach.  And the tower was supposed to respond because I have the signature
+saying, "You have sent this to me", but the tower hasn't responded.  So, if
+that's the case, you can always call off the tower and say, "You're not doing
+your job so no one should be trusting you in doing so, because you're not".
+
+On the other hand, if the user has sent some data that doesn't make any sense to
+<!-- skip-duplicate-words-test --> the tower, the tower could also prove that that data was the one being sent and
+that's the reason why they couldn't respond.  Maybe the transaction sent to a
+tower had a ridiculously low fee, or it was actually invalid, or whatever the
+reason was that they were not able to respond.  So, it's like an insurance for
+both sides.  In one place, you have the user that can claim that the watchtower
+is misbehaving and no one should use it; and on the other hand, you have the
+tower that if they haven't responded for a good reason, they can prove that
+that's the case.
+
+The issue with that is obviously if you're going to be exchanging signatures for
+every exchange of information you're doing between the user and the tower,
+that's going to pile up at some point, especially on the user side.  The tower
+side is not that important, to be honest, because you're already storing a lot
+of information for the user.  But the user should be as light as possible, and
+having to store a signature for every exchange of information may end up being
+an issue that we would like to minimize as long as we can, or as much as we can.
+
+**Mike Schmidt**: And so I see that you've spoken with Calvin Kim, I know that
+he does some work on Utreexo and there's some work with accumulators there that
+helps decrease the amount of storage that's required.  Can you talk a little bit
+about that discussion and how you've come to think about accumulators as solving
+some of the space concerns?
+
+**Sergi Delgado Segura**: Yeah.  There are two things here that don't work,
+let's say, or two issues that arise when you try to follow this approach, in
+contrast with just not having accountability at all.  The first is what I was
+saying, right; data piles up and then you want to minimize as much as you can
+how much it piles up.  The other issue that arises when you try to work with
+accountability is data deletion, which is something that may be in the interest
+of both parties to allow.  Let's take out accountability for a second and see
+how this may work for a normal watchtower.
+
+The first thing to have in mind is that the watchtower doesn't know anything
+about channels.  The user is sending encrypted information to a tower, and there
+is some mechanism so they decrypt this information when it's needed and they use
+that to close channels when it's needed.  There's no need to enter into how this
+works, but the idea behind that is that the tower doesn't know what channel or
+channels it's looking at.  So, the idea is that when a channel is closed, the
+tower doesn't know.
+
+The only way for the tower to know that a channel is closed is by the user
+telling the tower, "I've closed this channel", but we don't want that because if
+we do, then the tower may be able to link all the data that the user has sent to
+a tower and say, "All this encrypted data that I've received actually belongs to
+this channel, so now at least I know how many payments were performed in that
+channel and the frequency, if I was let's say logging the timestamp of every
+single piece of data I had received from the user", and so on and so forth.  We
+don't want that.
+
+Neither do we want the tower to know if a channel was closed.  Imagine that it's
+a normal channel and it's closed not unilaterally, like both parts of the
+channel agreed on closing it.  In principle, no one should know that was a
+channel to begin with, and then if we tell the tower, "Hey, we've closed this
+channel", then they know.  So, we're trying to minimize the amount of
+information we give the tower, in the same way we're trying to minimize the
+amount of information we give any other actor in the network that needs not the
+two ends of the channel.
+
+So, long story short, we want to be able to tell the tower, "Delete this data
+because it's useless.  We've closed the channel, so we are not going to need
+this anymore, and then maybe I can use these logs that you provide me in my
+subscription, or whatever means I have paid you to look for my data, to host
+information for other channels, so I don't have to pay you again for more data
+if I can just collate all data and add more data".  Anyway, the idea is that if
+you are able to tell that to a tower without disclosing what channel you have
+closed, and so on, then you can reuse some of your slot or space in the tower.
+
+That, without accountability, is pretty straightforward.  You just tell a tower,
+"Delete this piece of data, that piece of data and the other piece of data", and
+the tower does, potentially, and that's it, there's nothing more to be done.
+But if the tower is being accountable, then there's an issue with this, because
+in order for the tower to delete something, it has to give proof that the user
+has requested this data deletion, because otherwise the user can just say, "Hey,
+delete this", the tower does and then the user later on shows a receipt saying
+that the tower was supposed to look for something and it hasn't.  So now, the
+tower has misbehaved but actually, the user requested some data deletion, just
+the tower didn't log that.
+
+So the issue with that is that in order to delete some data, you have to store
+some data.  I mean, it's mad, in the sense that you can build the storage of a
+tower just by saying, "Delete this and delete that", and that may need to be
+stored for a really long time.  So, that is something that is not idea.  So, you
+have these two things in place: first, data builds up; second, data deletion is
+a pain in the neck, so we want to mitigate this.
+
+One of the ways of doing so is actually using accumulators.  If we can have a
+structure in where we can prove membership and non-membership of data, then we
+can just, instead of storing signed receipts for every single interaction we
+have between the user and the tower, then we can just store the signature of all
+accumulated data.  And then at some point, if we need to, we can say, "Prove
+that this data belongs to the set or that this data doesn't belong to the set",
+for instance.
+
+If you want to prove that the tower has misbehaved and some data was supposed to
+be there, you say, "You were supposed to respond to this.  Prove that this piece
+of data was not in the set".  And if they cannot prove it, it's because it's in
+the set, and then it means that they are misbehaving.  Or, the other way around.
+<!-- skip-duplicate-words-test -->The tower can always say, "I can prove that that was not part of the set, so you
+never sent that data to me.  And since we both signed the head of the
+<!-- skip-duplicate-words-test -->accumulator, it means that you agreed that that was not in there at the very
+beginning, so you're actually lying".
+
+So, the main idea is that instead of having to change and keep that many
+signatures, we may do better just with one accumulator and the signature of the
+whole state.  That's why I got in touch with both Salvatore and Calvin, because
+they both work in hash-based accumulators, I don't fully remember the name, but
+it's hash-based accumulators in where addition is really easy.  I think it's
+additive hash-based accumulators, something like that; I don't fully remember
+the name.  It felt like that may be a solution for this, not a straightforward
+one, because it looks like for both Utreexo and Salvatore's accumulator,
+membership is easy to prove, but non-membership is not.  So, yeah, that's one of
+the reasons why I ended up sending the mail, because I'm not that familiar with
+all this, other people may be.  So, let's have a discussion and see if there's
+any construction that makes sense and can be optimized.
+
+**Mike Schmidt**: Murch, I've been monopolizing the questions, do you want to
+ask anything?
+
+**Mark Erhardt**: No, you've been doing a great job of asking.  It's very
+fascinating how complicated everything gets when you want to make sure that
+everybody's doing their job and everybody can prove that they're doing their job
+and haven't been cheating.  And all that to just make sure that nobody in a
+Lightning channel is cheating.
+
+We actually recorded a podcast episode with Sergi a few weeks ago, a couple of
+months ago maybe, on the Chaincode podcast, where we also went into watchtowers
+in depth.  So, if you're interested in the topic, you can also listen to that.
+I was curious mostly about the node deletion capability.  So, you're saying that
+the endlessly growing data that the watchtower and the user both have to store
+in order to prove that they gave the job to the watchtower, or that the job was
+rescinded by the user to the watchtower, you are kerbing the endless growth of
+that by having time limits on how long the watchtower is storing that; and also
+having in the signed message a timeout until when it is valid; is that right?
+
+**Sergi Delgado Segura**: Yeah, exactly.  It is that the user has a
+subscription, well at least in our approach; it has a subscription which is
+bounded and after that ends, then the tower ends up deleting that data.  So, if
+the user wants to renew that subscription, then they can just by paying again,
+and then the tower will store or keep that information for longer.  But once the
+subscription is expired, then there's actually some grace period, and so on,
+just in case the user forgets, but at some point, the tower will delete the
+data; I mean the time you have to complain about something, if you work with
+accumulators.  If you don't work with accumulators, you actually have data that
+you can prove for life, let's say.
+
+But if you're working with accumulators, the tower is the one that has to end up
+providing the data that they are supposed to be hosting, so at some point if you
+try to say, "Hey, you cheated me three years ago", it's like, "Yeah, I don't
+have the data anymore, so good luck trying to prove that".  That doesn't happen
+if you're not using accumulators, because the client may have all the data
+necessary to make this work, but it means that they also have to store way more
+data on their end, which we are trying to prevent, or improve.
+
+**Mark Erhardt**: Understood.
+
+**Mike Schmidt**: How has feedback been from the mailing list and elsewhere on
+your initial post and discussions you've had, either on the mailing list or
+outside of that?
+
+**Sergi Delgado Segura**: So, I got feedback from both Calvin and Salvatore
+since the very first day I was looking into this.  I pinged them directly before
+sending the email.  I don't think anyone has replied to the mailing list post,
+but as I was saying before, not many people are interested in watchtowers at the
+development level, so that's usual.  I'm checking the email just in case someone
+has replied and I haven't seen, but I don't think so.  It feels like everyone
+has a lot on their plates and if you don't ping them directly, or it's something
+that is related to their work, you may not get a reply.  But hey, listener, if
+you're listening to this and you're interested in watchtowers or accumulators,
+yeah, ping me, let's have a chat.
+
+**Mike Schmidt**: Great call to action.  Anything else you'd say before we wrap
+up on this news item?
+
+**Sergi Delgado Segura**: No, not really from my end.  I think we've covered
+most of what the proposal is about.  If anyone is more intrigued about how it
+is, there's a link on both the mailing list mail and the Optech newsletter.
+There's a gist about the proposal itself, so it's not that long to read.  I
+think you can read it in like ten minutes and understand it pretty
+straightforward.  So, yeah, give me a ping, or whatever.
+
+**Mike Schmidt**: Murch, anything before we move on?
+
+**Mark Erhardt**: No, I think that's all.
+
+**Mike Schmidt**: Well, thank you for joining us.  You're welcome to stay on, we
+have a bunch of Lightning-related PRs later in the newsletter if you care to
+comment on any of those.  But otherwise, if you're busy with other things,
+you're free to drop off as well.
+
+**Sergi Delgado Segura**: I'll stay around just in case.
+
+**Mike Schmidt**: Awesome.  Next section of the newsletter is releases and
+release candidates.
+
+_LND v0.16.0-beta_
+
+We have a couple that we've covered already: LND v0.16.0-beta, so I think we
+were at RC5 last week, now we're at the official beta.  We have promised that we
+will have LND folks on to explain this in depth in the future, so we can skip on
+from this I think from now.  Obviously, call to anybody who's using LND to try
+out the beta and make sure they provide feedback to that team.
+
+_BDK 1.0.0-alpha.0_
+
+The second release is BDK 1.0.0-alpha.0 and we actually had Alekos on
+previously, and that episode is published, it's from Newsletter #243, to get a
+little bit more detail on that release and the rearchitecting that they've been
+doing there.  Murch, any feedback on LND and BDK releases?
+
+**Mark Erhardt**: I think I just want to call to action in the sense that people
+that are using these projects downstream to build other projects, please do read
+release notes.  We had a little bit of an outcry about a CLN release a couple of
+months ago, maybe last month, because there was something being deprecated which
+was announced for a year and had been missed.  So I think when release notes
+come out, especially for major releases, you do want to go over them and read
+them if you depend on them.
+
+_Core Lightning #5967_
+
+**Mike Schmidt**: Our first PR this week is from Core Lightning #5967 adding a
+listclosedchannels RPC, and I think the impetus for this RPC was actually
+related to information about old peers being discarded.  And as part of
+retaining that data about old peers, there is an RPC added as well to be able to
+pull closed-channel information, which includes some of that peer-related
+information that was previously being discarded.  Murch, Core Lightning #5967
+thoughts?
+
+**Mark Erhardt**: It sounds good that you can now see what channels were closed,
+especially when they were closed while you weren't staring at your computer and
+still want to figure out what happened.
+
+_Eclair #2566_
+
+**Mike Schmidt**: Next PR is Eclair #2566, adding support for accepting offers.
+So I think previously, paying offers was supported by Eclair, but now there is
+capability to receive offers as well.  And as a reminder, offers are BOLT 12,
+and the implementation detail for Eclair here on accepting was there's a plugin
+that you need to implement, which handles the creating of the offer and also
+handling the invoice requests and payments associated with that.  And Eclair
+also notes in the PR, in the documentation, that offers are still experimental
+and the details can change, but feel free to play with that in Eclair now.
+
+**Mark Erhardt**: The way I understand this approach here is that they are
+putting it into a plugin so that they don't have to update their main program's
+logic, but can still already have this external determination of whether
+something should be accepted, and that way can start experimenting with them on
+the network.  So, it sounds to me that in the last few months especially, the
+speed on offers has been picking up and, I don't know, maybe this is the year of
+offers.
+
+_LDK #2062_
+
+**Mike Schmidt**: LDK #2062, which implements BOLT #1031, #1032 and #1040, and
+we note in the writeup here different newsletter coverage of each of those.  The
+idea here is that in Lightning, the final node in a route has stricter
+requirements on the Hash Time Locked Contract (HTLC) contents compared to
+intermediate nodes along that route, and that can allow for probing, which could
+be used to determine whether or not the next node is the destination of the
+payment, which is obviously not great from a privacy perspective.  So, a series
+of these changes, which allows overpayments, can help mitigate that probing
+attack, and that applies in a bunch of different scenarios that we outline here.
+
+Also in the newsletter, we provide the example of Alice wanting to split a 900
+sat payment into two parts, but in the case of the multipath payments, maybe the
+two routes that she was going to route through require 500 sat minimum amounts;
+and with the spec change, she can now send two different 500 sat payments
+totalling 1,000 sats instead of that 900 sats, and then that overpayment of 100
+sats can allow her to use her preferred route.  Murch, thoughts on this probing
+mitigations?
+
+**Mark Erhardt**: I was just wondering how often this would occur in practice,
+because I think when the forwarder fumbles an attempt and actually undershoots
+-- so the idea is basically if you have multiple routes, or if the sender wants
+to attach a few sats extra so that it's not an exact round amount and there
+might be plausible deniability for the receiver that they're not the final
+destination, but rather another hop.  But I was just wondering, if someone was
+actually probing in order to determine whether the next hop is the receiver,
+wouldn't the first time they attempt that and they forward an HTLC that is
+obviously short, wouldn't that be an obvious tell that they're trying to do this
+and we could just ban them?
+
+Anyway, this sounds like more privacy work, more being lenient on the end where
+overpaying is fine, we accept tips for a privacy benefit.  So sorry, I'm
+rambling.
+
+_LDK #2125_
+
+**Mike Schmidt**: I think we can move on for now.  LDK #2125, adding helper
+functions to determine the amount of time until an invoice expires, so a little
+helper PR that does three different things.  It will give you the unix timestamp
+for duration since the Unix Epoch, and that represents the time at which the
+invoice expires; there's another helper function for the time remaining until
+the invoice expires; and then there's another helper for duration remaining
+until the invoice expires if you give it a certain time, so the delta, the
+duration between those differences.  So, it seems good.  Murch, any thoughts?
+Thumbs up?
+
+**Mark Erhardt**: Yeah.
+
+_BTCPay Server #4826_
+
+**Mike Schmidt**: Okay, we've got three different BTCPay Server PRs.  The first
+one is #4826, allows service hooks to create and retrieve LNURL invoices.  It
+was mentioned that this was done to add support for NIP-57 zaps to BTCPay
+Server's Lightning address features.  Murch, what's a NIP?
+
+**Mark Erhardt**: I believe that stands for Nostra Improvement Proposal.  So,
+nostra is a messaging or short blogging platform that works on the basis of a
+federated system of -- well, not even federated; just relay stations that you
+can subscribe to and post your nostra messages to.  And then, whoever else is
+subscribed to these relay stations will receive the ones that they're interested
+in.  It's been quite popular in the past few months, I'm sure people must have
+heard about them since.
+
+Anyway, one of the things that's interesting there right now is that people are
+trying to implement Lightning payments as a means to encourage and thank for
+messages, sort of like a thumbs-up on Reddit, or the Like on Twitter; you would
+instead send a few sats, and the term for this is called a zap.  So, there was a
+little bit of a kerfuffle on Twitter last week where people noticed that almost
+all of these zaps are facilitated by custodial Lightning services and they
+wanted more support for non-custodial Bitcoin platforms to offer zaps.  So, I
+see BTCPay Server moving quickly to step in here.
+
+**Mike Schmidt**: So, essentially this NIP-57 is a way to standardize those
+Lightning zaps on nostr?.
+
+**Mark Erhardt**: I have actually not verified that but if you say so, I believe
+you.
+
+**Mike Schmidt**: We'll roll with that!
+
+_BTCPay Server #4782_
+
+Next BTCPay Server PR is #4782, adding proof of payment on the receipt page.
+And I think before this change with BTCPay, on the receipt page they would show
+the BOLT 11 as the proof of payment, whereas now that's been changed to add the
+preimage as an actual verifiable proof of payment on the receipt page now.  Any
+comments on that, Murch?
+
+**Mark Erhardt**: Not really; nothing from me.
+
+_BTCPay Server #4799_
+
+**Mike Schmidt**: And then the last BTCPay Server PR is #4799, adding the
+ability to export wallet labels for transactions specifically.  We had covered
+this in the newsletter as the BIP was proposed and then assigned.  So, this is
+actually BIP329 and it standardizes the way that wallets can assign labels to
+wallet-related information, so transactions, addresses and other pieces of
+wallet data.  And in this example, BTCPay has the export capability specifically
+for transaction data, so you can essentially say, "This transaction was for a
+payment to this merchant", or whatever sort of notes you might have about a
+transaction, and then you're able to export that in that standardized wallet
+label format.
+
+Then they also noted that BTCPay may add support for other wallet data, and I
+<!-- skip-duplicate-words-test -->believe they mentioned that that would be address information.  So, good to see
+adoption there.
+
+**Mark Erhardt**: Yeah, I just like the adoption of this, it will make it much
+easier to keep accounting intact because previously, even if you could recover
+all of your financial data, or the actual transaction data and UTXOs if you had
+a backup of the wallet, you would lose all the context, and context is very
+important for the whole accounting and maybe even reporting use cases.
+
+_BOLTs #765_
+
+**Mike Schmidt**: Last PR for this week is to the BOLTs repository, and that's
+#765, adding route blinding to the LN spec, yay!  I think that PR was originally
+opened over two years ago and we have talked about this a bit, different
+implementations, adding different support for route blinding.
+
+The benefits of route blinding, there's a few notable ones: providing sender and
+recipient anonymity when you're sending onion messages or receiving onion
+messages; and then recipient anonymity for BOLT 12 offers; and then recipient
+anonymity when receiving payments; and then allowing the use of unannounced
+channels in invoices, without actually revealing those unannounced channels; and
+then also, forcing a payment to go through a specific set of intermediaries, if
+for some reason you want those intermediaries to witness the payment.
+
+So, those are the benefits, it's nice to see that was merged.  Murch, do you
+have thoughts on that?
+
+**Mark Erhardt**: I just wanted to point out that it seems to be exactly the
+two-year birthday of that PR!  I think also, there were previous approaches that
+did not end up making it.  So, there was something called rendez-vous routing,
+and there's also trampoline payments.  I think trampoline payments are in use,
+but rendez-vous routing got superseded.  So, the idea is even much older.  I
+think it's just that under the name of route blinding, it's been around for at
+least two years now.
+
+**Mike Schmidt**: And the author of this PR, in one of the documentation pieces
+of this change, actually notes those competing proposals and pros and cons to
+those proposals against route blinding.  You mentioned rendez-vous routing, and
+I think there's also something called HORNET, that I guess is also contrasted in
+the actual route blinding marked-down file that is in this PR.  So, if you care
+just jump into that to see some of the differences.  Murch, any announcements or
+anything before we wrap up?
+
+**Mark Erhardt**: Nothing from me this week.
+
+**Mike Schmidt**: All right, we kept it to 45 minutes this week.  Thank you to
+my co-host, Murch, and thank you to Sergi for joining us and thank you all for
+listening.  If anybody has a question real quickly, feel free to request speaker
+access.  I think there was a comment here.  No, it looks like it was just an NFT
+spam in our Twitter thread.  So, any questions, comments?
+
+**Sergi Delgado Segura**: I just want to say thanks for inviting me by the way,
+guys.
+
+**Mike Schmidt**: Yeah, thank you for your insights.  All right, we'll see you
+all back here for next week #246.  Cheers.
+
+**Mark Erhardt**: Goodbye.
 
 {% include references.md %}

--- a/_posts/en/podcast/2023-04-13-newsletter-recap.md
+++ b/_posts/en/podcast/2023-04-13-newsletter-recap.md
@@ -1,0 +1,23 @@
+---
+title: 'Bitcoin Optech Newsletter #246 Recap Podcast'
+permalink: /en/podcast/2023/04/13/
+reference: /en/newsletters/2023/04/12/
+name: 2023-04-13-recap
+slug: 2023-04-13-recap
+type: podcast
+layout: podcast-episode
+lang: en
+---
+Mark "Murch" Erhardt and Mike Schmidt are joined by Lisa Neigut and Niklas Gögge to discuss [Newsletter #246]({{page.reference}}).
+
+{% include functions/podcast-links.md %}
+
+{% include functions/podcast-player.md url="https://anchor.fm/s/d9918154/podcast/play/68844979/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2023-3-18%2F9eda5cda-1b7a-6f75-0e30-338a49051222.mp3" %}
+
+{% include newsletter-references.md %}
+
+## Transcription
+
+_transcription coming soon_
+
+{% include references.md %}

--- a/_posts/zh/newsletters/2023-03-08-newsletter.md
+++ b/_posts/zh/newsletters/2023-03-08-newsletter.md
@@ -27,9 +27,9 @@ lang: zh
 
   与原始的 `OP_VAULT` 设计相比，这种方法的用户优势之一是 freeze leafscript 可以包含 Alice 想要指定的任何授权条件。在 `OP_VAULT` 提案中，任何知道 Alice 选择的参数的人都可以将她的资金用于冻结脚本。那不是安全问题，但可能很烦人。在 Sanders 的设计中，Alice 可能（例如）需要来自轻度保护的钱包的签名启动冻结——这可能足以防止大多数破坏性攻击的麻烦，但不足以阻止 Alice 快速在紧急情况下冻结她的资金。
 
-  其他几个优势旨在使共识强制的[保管协议][topic vaults] 更容易理解和验证是否安全。在我们写完上面的内容之后，`OP_VAULT` 提案的作者 James O'Beirne 对 Sanders 的想法做出了积极的回应。O'Beirne 还对我们将在未来的周报中描述的其他更改有想法。{% include functions/podcast-callout.md url="pod241 op_vault" %}
+  其他几个优势旨在使共识强制的[保管协议][topic vaults] 更容易理解和验证是否安全。在我们写完上面的内容之后，`OP_VAULT` 提案的作者 James O'Beirne 对 Sanders 的想法做出了积极的回应。O'Beirne 还对我们将在未来的周报中描述的其他更改有想法。
 
-- **New Optech 播客：** Twitter Spaces 上每周一次的 Optech Audio Recap 现已作为播客提供。每一集都将在所有流行的播客平台和 Optech 网站上作为文字记录提供。有关更多详细信息，包括为什么我们认为这是 Optech 改善比特币技术交流的使命的重要一步，请参阅我们的 [博客文章][podcast post]。{% include functions/podcast-callout.md url="pod241 podcast" %}
+- **New Optech 播客：** Twitter Spaces 上每周一次的 Optech Audio Recap 现已作为播客提供。每一集都将在所有流行的播客平台和 Optech 网站上作为文字记录提供。有关更多详细信息，包括为什么我们认为这是 Optech 改善比特币技术交流的使命的重要一步，请参阅我们的 [博客文章][podcast post]。
 
 ## Bitcoin Core PR 审核俱乐部
 
@@ -37,8 +37,7 @@ lang: zh
 
 [Bitcoin-inquisition: Activation logic for testing consensus changes][review club bi-16]是 Anthony Towns 的 PR，它在 [Bitcoin Inquisition][] 项目中添加了一种激活和停用软分叉的新方法，旨在在 [signet][topic signet]上运行并用于测试。该项目在 [周报 #219][newsletter #219 bi]中有介绍。
 
-具体来说，这个 PR 替换了 [BIP9][] 的区块版本位语义，取而代之的称为 [Heretical Deployments][]。与主网上的共识和中继更改相比——激活起来既困难又耗时，需要仔细建立（人类）共识和精心设计的 [soft fork activation][topic soft fork activation] 机制 -- 在测试网络上激活这些更改可以简化。PR 还实现了一种方法来停用被证明是有问题或不受欢迎的更改，这是与主网的主要不同。{% include
-functions/podcast-callout.md url="pod241 pr review" %}
+具体来说，这个 PR 替换了 [BIP9][] 的区块版本位语义，取而代之的称为 [Heretical Deployments][]。与主网上的共识和中继更改相比——激活起来既困难又耗时，需要仔细建立（人类）共识和精心设计的 [soft fork activation][topic soft fork activation] 机制 -- 在测试网络上激活这些更改可以简化。PR 还实现了一种方法来停用被证明是有问题或不受欢迎的更改，这是与主网的主要不同。
 
 {% include functions/details-list.md
   q0="为什么我们要部署未合并到 Bitcoin Core 的共识更改？将代码合并到 Bitcoin Core 中，然后在 signet 上测试它有什么问题（如果有的话）？"
@@ -66,14 +65,14 @@ functions/podcast-callout.md url="pod241 pr review" %}
 
 *热门的比特币基础设施项目的新版本与候选版本。请考虑升级到新版本或帮助测试候选版本。*
 
-- [Core Lightning 23.02][] 是这个流行的 LN 实现的新版本。它包括对备份数据的对等存储的实验性支持 (详见 [周报 #238][news238 peer storage]) 并更新对 [双重出资][topic dual funding] 和 [BOLT12 发票][topic offers] 的实验性支持。还包括其他一些改进和错误修复。{% include functions/podcast-callout.md url="pod241 cln" %}
+- [Core Lightning 23.02][] 是这个流行的 LN 实现的新版本。它包括对备份数据的对等存储的实验性支持 (详见 [周报 #238][news238 peer storage]) 并更新对 [双重出资][topic dual funding] 和 [BOLT12 发票][topic offers] 的实验性支持。还包括其他一些改进和错误修复。
 
 - [LDK v0.0.114][] 是该库的新版本，用于构建支持 LN 的钱包和应用程序。它修复了几个与安全相关的错误，并包括解析 [BOLT12 发票][topic
-  offers]的能力。{% include functions/podcast-callout.md url="pod241 ldk" %}
+  offers]的能力。
 
-- [BTCPay 1.8.2][] 是这款流行的比特币自托管支付处理软件的最新版本。1.8.0 版的发行说明说，“这个版本带来了自定义结账表、商店品牌选项、重新设计的 PoS 键盘视图、新的通知图标和地址标签。” {% include functions/podcast-callout.md url="pod241 btcpay" %}
+- [BTCPay 1.8.2][] 是这款流行的比特币自托管支付处理软件的最新版本。1.8.0 版的发行说明说，“这个版本带来了自定义结账表、商店品牌选项、重新设计的 PoS 键盘视图、新的通知图标和地址标签。”
 
-- [LND v0.16.0-beta.rc2][] 是这个流行的 LN 实现的新主要版本的候选版本。{% include functions/podcast-callout.md url="pod241 lnd" %}
+- [LND v0.16.0-beta.rc2][] 是这个流行的 LN 实现的新主要版本的候选版本。
 
 ## 重大的文档和代码变更
 
@@ -84,7 +83,7 @@ Interface (HWI)][hwi repo]、[Rust Bitcoin][rust bitcoin repo]、[BTCPay
 Server][btcpay server repo]、[BDK][bdk repo]、[Bitcoin Improvement
 Proposals (BIPs)][bips repo] 和 [Lightning BOLTs][bolts repo]。*
 
-- [LND #7462][] 允许创建具有远程签名和使用无状态初始化功能的观察钱包。{% include functions/podcast-callout.md url="pod241 lnd7462" %}
+- [LND #7462][] 允许创建具有远程签名和使用无状态初始化功能的观察钱包。
 
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="7462" %}
@@ -102,11 +101,3 @@ Proposals (BIPs)][bips repo] 和 [Lightning BOLTs][bolts repo]。*
 [bitcoin inquisition]: https://github.com/bitcoin-inquisition/bitcoin
 [heretical deployments]: https://github.com/bitcoin-inquisition/bitcoin/wiki/Heretical-Deployments
 [bip9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
-[pod241 op_vault]: /en/podcast/2023/03/09/#alternative-design-for-op-vault
-[pod241 podcast]: /en/podcast/2023/03/09/#new-optech-podcast
-[pod241 pr review]: /en/podcast/2023/03/09/#bitcoin-inquisition-activation-logic-for-testing-consensus-changes
-[pod241 cln]: /en/podcast/2023/03/09/#core-lightning-23-02
-[pod241 ldk]: /en/podcast/2023/03/09/#ldk-v0-0-114
-[pod241 btcpay]: /en/podcast/2023/03/09/#btcpay-1-8-2
-[pod241 lnd]: /en/podcast/2023/03/09/#lnd-v0-16-0-beta-rc2
-[pod241 lnd7462]: /en/podcast/2023/03/09/#lnd-7462


### PR DESCRIPTION
This PR removes the need for boilerplate logic when adding newsletter references. The new logic requires just the podcast timestamps to be added in the related newsletter sections.

**Current logic**:
- In the podcast, recreate the newsletter structure:
  - add title and anchor for each discussed item
  - add timestamp
  - add anchors for each segment in the transcript 
- In the referenced newsletter, for each item, add a link to the podcast page

**New logic**:
- In the podcast:
  - point to the newsletter it references using the `reference` variable in the frontmatter
- In the referenced newsletter:
  - add timestamp (podcast reference mark) for each discussed item

For each podcast, the `recap_references_generator` will parse the `reference` newsletter (declared in frontmatter) looking for podcast reference marks (timestamps) in order to create the newsletter references used by `{% include newsletter-references.md %}` in the podcast page.