### PR TITLE
Podcasts: fix automatic reference generation for special sections

### DIFF
--- a/_includes/functions/podcast-note.md
+++ b/_includes/functions/podcast-note.md
@@ -1,0 +1,9 @@
+(<a title="Play this segment of the podcast" onClick="seek('{{reference.timestamp}}')" class="seek">{{reference.timestamp}}</a><noscript>{{reference.timestamp}}</noscript>)
+<a href="{{page.reference}}{{reference.slug}}">
+    <i class="fa fa-link" title="Link to related content"></i>
+</a>
+{% if reference.has_transcript_section %}
+    <a href="{{reference.slug}}-transcript">
+        <i class="fa fa-file-text-o" title="Read this segment of the transcription"></i>
+    </a>
+{% endif %}

--- a/_includes/newsletter-references.md
+++ b/_includes/newsletter-references.md
@@ -4,19 +4,29 @@
 ## News
 *No significant news this week was found on the Bitcoin-Dev or Lightning-Dev mailing lists.*
 {% endunless %}
-
+<div>
 {% for section in newsletter_sections %}
-## {{ section.name }}
-<ul>
-  {% for reference in section.items %}
-  {% assign podcast_slug = reference.podcast_slug | default: reference.slug %}
-  <li id="{{ podcast_slug | slice: 1, podcast_slug.size }}" class="anchor-list">
-    <p>
-      <a href="{{ podcast_slug }}" class="anchor-list-link">●</a>
-      {{ reference.title }}
-      {% include functions/podcast-note.md %}
-    </p>
-  </li>
-  {% endfor %}
-</ul>
+  <h2 id="{{ section.name | slugify: 'latin'}}"> {{ section.name }}
+    {% if page.special_sections contains section.name %}
+      <!-- Special sections are section that do not have list items, therefore
+        we display the timestamp and transcript links in the header -->
+      {% assign reference = section.items | first %}
+      <span style="font-size:0.5em">{% include functions/podcast-note.md %}</span>
+    {% endif %}
+  </h2>
+  {% unless page.special_sections contains section.name %}
+    <ul>
+      {% for reference in section.items %}
+      {% assign podcast_slug = reference.podcast_slug | default: reference.slug %}
+      <li id="{{ podcast_slug | slice: 1, podcast_slug.size }}" class="anchor-list">
+        <p>
+          <a href="{{ podcast_slug }}" class="anchor-list-link">●</a>
+          {{ reference.title }}
+          {% include functions/podcast-note.md %}
+        </p>
+      </li>
+      {% endfor %}
+    </ul>
+  {% endunless %}
 {% endfor %}
+</div>

--- a/_includes/newsletter-references.md
+++ b/_includes/newsletter-references.md
@@ -14,17 +14,7 @@
     <p>
       <a href="{{ podcast_slug }}" class="anchor-list-link">●</a>
       {{ reference.title }}
-      (<a title="Play this segment of the podcast" onClick="seek('{{reference.timestamp}}')" class="seek">{{reference.timestamp}}</a><noscript>{{reference.timestamp}}</noscript>)
-      <a href="{{page.reference}}{{reference.slug}}">
-        <i class="fa fa-link" title="Link to related content"></i>
-      </a>
-      <!--<a onClick="seek('{{include.timestamp}}')" class="seek"><i class="fa
-  fa-headphones" title="Play this segment of the podcast"></i></a>-->
-      {% if reference.has_transcript_section %}
-      <a href="{{reference.slug}}-transcript">
-        <i class="fa fa-file-text-o" title="Read this segment of the transcription"></i>
-      </a>
-      {% endif %}
+      {% include functions/podcast-note.md %}
     </p>
   </li>
   {% endfor %}


### PR DESCRIPTION
The current logic in `recap_references_generator.rb` doesn't work when a section does not have nested list items, which is the case with the recent special sections in newsletters [250](https://bitcoinops.org/en/newsletters/2023/05/10/#celebrating-optech-newsletter-250) and [251](https://bitcoinops.org/en/newsletters/2023/05/17/#waiting-for-confirmation-1-why-do-we-have-a-mempool). This first became visible with #1122 and that's why this PR is on top of that one, in order to be able to see the change in action. @bitschmidty feel free to either cherry-pick my commits in your PR, or you can merge this one, whatever you prefer.

This is how those special sections will be rendered in the recap podcast page:
![preview](https://github.com/bitcoinops/bitcoinops.github.io/assets/18506343/f25ba6d3-401f-4c6c-b89d-3609e8b81d79)


 