### PR TITLE
Change keysend to keyspend in 2023-05-24-newsletter.md

### DIFF
--- a/_posts/en/newsletters/2023-05-24-newsletter.md
+++ b/_posts/en/newsletters/2023-05-24-newsletter.md
@@ -153,7 +153,7 @@ wallets and services.*
   Coinkite [announced][coinkite blog] experimental firmware for the Coldcard
   hardware signer that is designed for wallet developers and power users to
   experiment with newer features. The initial 6.0.0X release includes taproot
-  keysend payments, [tapscript][topic tapscript] multisig payments, and
+  keyspend payments, [tapscript][topic tapscript] multisig payments, and
   [BIP129][] support.
 
 ## Releases and release candidates

--- a/_posts/en/newsletters/2023-05-24-newsletter.md
+++ b/_posts/en/newsletters/2023-05-24-newsletter.md
@@ -153,7 +153,7 @@ wallets and services.*
   Coinkite [announced][coinkite blog] experimental firmware for the Coldcard
   hardware signer that is designed for wallet developers and power users to
   experiment with newer features. The initial 6.0.0X release includes taproot
-  keyspend payments, [tapscript][topic tapscript] multisig payments, and
+  keypath spends, [tapscript][topic tapscript] multisig payments, and
   [BIP129][] support.
 
 ## Releases and release candidates


### PR DESCRIPTION
Looks like a typo. Would we want to be consistent with the [Taproot topic](https://bitcoinops.org/en/topics/taproot/) and call it "keypath spend" instead?