### PR TITLE
Topics: update primary references and see also sections

### DIFF
--- a/_data/schemas/topics.yaml
+++ b/_data/schemas/topics.yaml
@@ -32,6 +32,7 @@ properties:
         - Fee Management
         - Lightning Network
         - Lightweight Client Support
+        - Liquidity Management
         - Mining
         - P2P Network Protocol
         - Privacy Enhancements

--- a/_includes/snippets/msig-terms.md
+++ b/_includes/snippets/msig-terms.md
@@ -1,5 +1,5 @@
 | Term | Private keys | Messages<br>(e.g. tx inputs) | Published pubkeys | Signatures | Signers required | Notes |
 |-|-|-|-|-|
-| Multisig | `m` | `1` | `m` | `k` where `k<=m` | `k` | Uses Bitcoin Script multisig opcodes |
-| [Multisignature][topic multisignature] | `m` | `1` | `1` | `1` | `m` | Indistinguishable onchain from single-sig |
+| Scripted multisig | `m` | `1` | `m` | `k` where `k<=m` | `k` | Uses Bitcoin Script multisig opcodes |
+| [Scriptless multisignatures][topic multisignature] | `m` | `1` | `1` | `1` | `m` | Indistinguishable onchain from single-sig |
 | [Threshold signature][topic threshold signature] | `m` | `1` | `1` | `1` | `k` where `k<=m` | Indistinguishable onchain from single-sig |

--- a/_topics/en/adaptor-signatures.md
+++ b/_topics/en/adaptor-signatures.md
@@ -38,6 +38,9 @@ primary_sources:
     - title: One-time verifiably encrypted signatures (PDF)
       link: https://github.com/LLFourn/one-time-VES/blob/master/main.pdf
 
+    - title: Documentation for scriptless script protocols
+      link: https://github.com/BlockstreamResearch/scriptless-scripts
+
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
 optech_mentions:

--- a/_topics/en/addr-v2.md
+++ b/_topics/en/addr-v2.md
@@ -71,6 +71,9 @@ optech_mentions:
 see_also:
   - title: P2P protocol `addr` message
     link: https://btcinformation.org/en/developer-reference#addr
+
+  - title: Anonymity networks
+    link: topic anonymity networks
 ---
 The original `addr` message allows relaying 128-bit IPv6 addresses
 with backwards compatibility for IPv4 and [onioncat-encoded][] version

--- a/_topics/en/anchor-outputs.md
+++ b/_topics/en/anchor-outputs.md
@@ -162,6 +162,9 @@ see_also:
 
   - title: Package relay
     link: topic package relay
+
+  - title: Ephemeral anchors
+    link: topic ephemeral anchors
 ---
 Each time the balance changes in an LN channel, a *commitment
 transaction* is created and signed by the participating parties.  The

--- a/_topics/en/anonymity-networks.md
+++ b/_topics/en/anonymity-networks.md
@@ -111,6 +111,9 @@ see_also:
   - title: Dandelion
     link: topic dandelion
 
+  - title: Addr v2
+    link: topic addr v2
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/asicboost.md
+++ b/_topics/en/asicboost.md
@@ -34,9 +34,9 @@ optech_mentions:
     url: /en/newsletters/2021/04/28/#why-does-the-mined-block-differ-so-much-from-the-block-template
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: "BIP320: nVersion bits for general purpose use"
+    link: BIP320
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters

--- a/_topics/en/assumeutxo.md
+++ b/_topics/en/assumeutxo.md
@@ -19,6 +19,9 @@ primary_sources:
     - title: AssumeUTXO proposal
       link: https://github.com/jamesob/assumeutxo-docs/tree/2019-04-proposal/proposal
 
+    - title: AssumeUTXO project tracker
+      link: https://github.com/bitcoin/bitcoin/pull/27596
+
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
 optech_mentions:
@@ -53,6 +56,7 @@ optech_mentions:
 see_also:
   - title: "Bitcoin Core issue #15605: AssumeUTXO discussion"
     link: https://github.com/bitcoin/bitcoin/issues/15605
+
   - title: "[bitcoin-dev] assumeutxo and UTXO snapshots"
     link: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-April/016825.html
 ---

--- a/_topics/en/async-payments.md
+++ b/_topics/en/async-payments.md
@@ -56,6 +56,12 @@ see_also:
   - title: PTLCs
     link: topic ptlc
 
+  - title: Signature adaptors
+    link: topic adaptor signatures
+
+  - title: Proof of payment
+    link: topic proof of payment
+
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a
 ## threshold word count

--- a/_topics/en/bech32.md
+++ b/_topics/en/bech32.md
@@ -1,6 +1,8 @@
 ---
-title: Bech32
+title: Bech32(m)
+shortname: bech32
 aliases:
+  - Bech32
   - Bech32m
   - BIP173
   - Native segwit address
@@ -12,15 +14,19 @@ categories:
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
-  **Bech32** is an address format used to pay native segwit outputs.
+  **Bech32** and **Bech32m** are address formats used to pay native segwit outputs.
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
-    - title: BIP173
-    - title: Bech32 reference code
+    - title: "BIP173: bech32"
+      link: BIP173
+
+    - title: "BIP350: bech32m"
+      link: BIP350
+
+    - title: "Bech32(m) reference code"
       link: https://github.com/sipa/bech32
-    - title: BIP350
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry

--- a/_topics/en/channel-commitment-upgrades.md
+++ b/_topics/en/channel-commitment-upgrades.md
@@ -36,9 +36,15 @@ optech_mentions:
     url: /en/newsletters/2022/04/06/#updating-ln-commitments
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Anchor outputs
+    link: topic anchor outputs
+
+  - title: "LN-Symmetry (Eltoo)"
+    link: topic eltoo
+
+  - title: PTLCs
+    link: topic ptlc
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/channel-factories.md
+++ b/_topics/en/channel-factories.md
@@ -22,6 +22,12 @@ primary_sources:
     - title: Scalable Funding of Bitcoin Micropayment Networks
       link: "https://tik-old.ee.ethz.ch/file//a20a865ce40d40c8f942cf206a7cba96/Scalable_Funding_Of_Blockchain_Micropayment_Networks%20(1).pdf"
 
+    - title: Inherited identifiers proposal
+      link: https://github.com/JohnLaw2/btc-iids
+
+    - title: Factory optimized Lightning channels
+      link: https://github.com/JohnLaw2/ln-factory-optimized
+
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
 optech_mentions:
@@ -44,9 +50,9 @@ optech_mentions:
     url: /en/newsletters/2023/03/29/#preventing-stranded-capital-with-multiparty-channels-and-channel-factories
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: "LN-Symmetry (Eltoo)"
+    link: topic eltoo
 ---
 For example, three users create a channel factory by each of them
 depositing some funds to an onchain 3-of-3 multisig address.  Using

--- a/_topics/en/channel-jamming-attacks.md
+++ b/_topics/en/channel-jamming-attacks.md
@@ -31,6 +31,12 @@ primary_sources:
   - title: LN spam prevention
     link: https://github.com/t-bast/lightning-docs/blob/master/spam-prevention.md
 
+  - title: "Unjamming Lightning: A Systematic Approach"
+    link: https://raw.githubusercontent.com/s-tikhomirov/ln-jamming-simulator/master/unjamming-lightning.pdf
+
+  - title: "Circuit Breaker: software to protect nodes from being flooded with htlcs"
+    link: https://github.com/lightningequipment/circuitbreaker
+
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
 optech_mentions:
@@ -104,9 +110,9 @@ optech_mentions:
     url: /en/newsletters/2023/06/28/#lnd-7710
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: HTLCs
+    link: topic htlc
 
 ---
 An LN node can route a payment to itself across a path of 20 or more

--- a/_topics/en/coinswap.md
+++ b/_topics/en/coinswap.md
@@ -77,6 +77,9 @@ see_also:
 
   - title: PTLCs
     link: topic ptlc
+
+  - title: Submarine swaps
+    link: topic submarine swaps
 ---
 Coinswaps are often compared to [coinjoins][topic coinjoin].  The most
 obvious difference is that a coinjoin uses a single transaction but a

--- a/_topics/en/consensus-cleanup-soft-fork.md
+++ b/_topics/en/consensus-cleanup-soft-fork.md
@@ -42,7 +42,10 @@ optech_mentions:
     url: /en/newsletters/2020/05/27/#minimum-transaction-size-discussion
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#  - title:
-#    link:
+see_also:
+ - title: Soft fork activation
+   link: topic soft fork activation
+
+ - title: "CVE-2017-12842: fake SPV proofs using 64-byte transactions"
+   link: "https://bitcoinops.org/en/topics/cve/#CVE-2017-12842"
 ---

--- a/_topics/en/covenants.md
+++ b/_topics/en/covenants.md
@@ -19,9 +19,6 @@ primary_sources:
   - title: Enhancing Bitcoin transactions with covenants
     link: https://fc17.ifca.ai/bitcoin/papers/bitcoin17-final28.pdf
 
-  - title: BIP119 OP_CHECKTEMPLATEVERIFY proposal
-    link: https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki
-
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
 optech_mentions:
@@ -107,6 +104,9 @@ see_also:
 
   - title: OP_CHECKTEMPLATEVERIFY
     link: topic op_checktemplateverify
+
+  - title: SIGHASH_ANYPREVOUT
+    link: topic sighash_anyprevout
 
   - title: Vaults
     link: topic vaults

--- a/_topics/en/cpfp-carve-out.md
+++ b/_topics/en/cpfp-carve-out.md
@@ -60,6 +60,12 @@ see_also:
   - title: Transaction pinning
     link: topic transaction pinning
 
+  - title: Anchor outputs
+    link: topic anchor outputs
+
+  - title: Version 3 transaction relay
+    link: topic v3 transaction relay
+
   - title: "Bitcoin Core #16421 allowing RBF replacement of carve outs"
     link: https://github.com/bitcoin/bitcoin/pull/16421
 ---

--- a/_topics/en/cpfp.md
+++ b/_topics/en/cpfp.md
@@ -84,6 +84,9 @@ optech_mentions:
 see_also:
   - title: CPFP carve-out
     link: topic cpfp carve out
+
+  - title: Package relay
+    link: topic package relay
 ---
 Bitcoin consensus rules require that the transaction which creates an
 output must appear earlier in the block chain than the transaction

--- a/_topics/en/cve.md
+++ b/_topics/en/cve.md
@@ -81,7 +81,9 @@ optech_mentions:
     url: /en/newsletters/2022/11/09/#bitcoin-core-pr-review-club
 
 ## Optional.  Same format as "primary_sources" above
-#see_also:
+see_also:
+  - title: Responsible disclosures
+    link: topic responsible disclosures
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters

--- a/_topics/en/dandelion.md
+++ b/_topics/en/dandelion.md
@@ -40,9 +40,15 @@ optech_mentions:
     url: /en/newsletters/2018/12/28/#dandelion
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#  - title:
-#    link:
+see_also:
+ - title: Transaction origin privacy
+   link: topic transaction origin privacy
+
+ - title: Anonymity networks
+   link: topic anonymity networks
+
+ - title: Version 2 encrypted P2P transport
+   link: topic v2 p2p transport
 ---
 This propagation behavior would help hide which node originated the
 transaction, especially if some of the nodes involved in the initial

--- a/_topics/en/default-minimum-transaction-relay-feerates.md
+++ b/_topics/en/default-minimum-transaction-relay-feerates.md
@@ -46,6 +46,9 @@ see_also:
   - title: Package relay
     link: topic package relay
 
+  - title: Ephemeral anchors
+    link: topic ephemeral anchors
+
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a
 ## threshold word count

--- a/_topics/en/discreet-log-contracts.md
+++ b/_topics/en/discreet-log-contracts.md
@@ -75,9 +75,9 @@ optech_mentions:
     url: /en/newsletters/2023/01/18/#proposal-for-new-vault-specific-opcodes
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Signature adaptors
+    link: topic adaptor signatures
 ---
 The transactions creating and settling the contract can be made
 indistinguishable from many other Bitcoin transactions or they can be

--- a/_topics/en/dual-funding.md
+++ b/_topics/en/dual-funding.md
@@ -13,6 +13,7 @@ aliases:
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
@@ -115,8 +116,17 @@ optech_mentions:
 
 ## Optional.  Same format as "primary_sources" above
 see_also:
+  - title: Liquidity advertisements
+    link: topic liquidity advertisements
+
   - title: PSBT (dependency of dual funding)
     link: topic psbt
+
+  - title: Submarine swaps
+    link: topic submarine swaps
+
+  - title: Splicing
+    link: topic splicing
 ---
 [Early analysis][dryja single-funded] of LN determined that it would be
 significantly easier to build software where the user requesting to

--- a/_topics/en/eclipse-attacks.md
+++ b/_topics/en/eclipse-attacks.md
@@ -78,9 +78,9 @@ optech_mentions:
     url: /en/newsletters/2021/11/24/#lnd-0-14-0-beta
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Anonymity networks
+    link: topic anonymity networks
 ---
 Without any connections to honest peers, the eclipsed node won't
 receive the latest blocks on the most proof-of-work block chain.  This

--- a/_topics/en/erlay.md
+++ b/_topics/en/erlay.md
@@ -15,6 +15,8 @@ excerpt: >
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
+    - title: BIP330
+
     - title: Erlay
       link: https://arxiv.org/pdf/1905.10518.pdf
 

--- a/_topics/en/fee-sponsorship.md
+++ b/_topics/en/fee-sponsorship.md
@@ -49,6 +49,9 @@ see_also:
   - title: Transaction pinning
     link: topic transaction pinning
 
+  - title: Ephemeral anchors
+    link: topic ephemeral anchors
+
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a
 ## threshold word count

--- a/_topics/en/hd-key-generation.md
+++ b/_topics/en/hd-key-generation.md
@@ -85,9 +85,9 @@ optech_mentions:
     url: /en/newsletters/2023/05/24/#edge-firmware-for-coldcard-announced
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Output script descriptors
+    link: topic descriptors
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters

--- a/_topics/en/hold-invoices.md
+++ b/_topics/en/hold-invoices.md
@@ -45,9 +45,9 @@ optech_mentions:
     url: /en/newsletters/2020/11/04/#bi-directional-upfront-fees-for-ln
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Channel jamming attacks
+    link: topic channel jamming attacks
 ---
 For example, Alice could automatically generate hold invoices on her
 website but wait until a customer actually paid before searching her

--- a/_topics/en/hwi.md
+++ b/_topics/en/hwi.md
@@ -71,6 +71,15 @@ optech_mentions:
 see_also:
   - title: Partially-Signed Bitcoin Transactions (PSBTs)
     link: topic psbt
+
+  - title: Output script descriptors
+    link: topic descriptors
+
+  - title: Miniscript
+    link: topic miniscript
+
+  - title: Exfiltration resistant signing
+    link: topic exfiltration resistant signing
 ---
 Designed primarily by Bitcoin Core developers to allow that software to
 use hardware wallets as external signers, HWI is now being used by

--- a/_topics/en/jit-channels.md
+++ b/_topics/en/jit-channels.md
@@ -13,6 +13,7 @@ shortname: jit channels
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"

--- a/_topics/en/jit-routing.md
+++ b/_topics/en/jit-routing.md
@@ -6,6 +6,7 @@ shortname: jit routing
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >

--- a/_topics/en/joinpools.md
+++ b/_topics/en/joinpools.md
@@ -53,6 +53,9 @@ see_also:
   - title: Channel factories
     link: topic channel factories
 
+  - title: Covenants
+    link: topic covenants
+
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a
 ## threshold word count

--- a/_topics/en/liquidity-advertisements.md
+++ b/_topics/en/liquidity-advertisements.md
@@ -13,6 +13,7 @@ title: Liquidity advertisements
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"

--- a/_topics/en/multisignature.md
+++ b/_topics/en/multisignature.md
@@ -1,9 +1,9 @@
 ---
-title: Multisignature
+title: Scriptless multisignatures
 
 ## Optional.  Shorter name to use for reference style links e.g., "foo"
 ## will allow using the link [topic foo][].  Not case sensitive
-# shortname: foo
+shortname: multisignature
 
 ## Optional.  An entry will be added to the topics index for each alias
 aliases:
@@ -19,7 +19,7 @@ categories:
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >
-  **Multisignatures** are digital signatures created using two or more
+  **Scriptless multisignatures** are digital signatures created using two or more
   private keys which can be verified using only a single public key
   and a single signature.
 
@@ -99,7 +99,7 @@ see_also:
   - title: Threshold signature
     link: topic threshold signature
 ---
-Multisignatures can be compared with *multisig*, the use of public
+Scriptless multisignatures can be compared with *scripted multisig*, the use of public
 keys and signatures with Bitcoin's `OP_CHECKMULTISIG` and
 `OP_CHECKMULTISIGVERIFY` opcodes (and the `OP_CHECKSIGADD` opcode
 proposed for [tapscript][topic tapscript]).  Multisignatures have the

--- a/_topics/en/musig.md
+++ b/_topics/en/musig.md
@@ -116,7 +116,7 @@ optech_mentions:
 
 ## Optional.  Same format as "primary_sources" above
 see_also:
-  - title: Multisignatures
+  - title: Scriptless multisignatures
     link: topic multisignature
 
   - title: Schnorr signatures

--- a/_topics/en/offers.md
+++ b/_topics/en/offers.md
@@ -87,9 +87,9 @@ optech_mentions:
     url: /en/newsletters/2023/03/01/#ldk-1977
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Blinded paths
+    link: topic rv routing
 ---
 An example of a common use of this protocol would be that a merchant
 generates a QR code, the customer scans the QR code, the customer’s LN

--- a/_topics/en/onion-messages.md
+++ b/_topics/en/onion-messages.md
@@ -69,9 +69,9 @@ optech_mentions:
     url: /en/newsletters/2023/06/21/#ldk-2294
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Blinded paths
+    link: topic rv routing
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/op_checktemplateverify.md
+++ b/_topics/en/op_checktemplateverify.md
@@ -2,8 +2,7 @@
 title: OP_CHECKTEMPLATEVERIFY
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
-  - OP_CHECKOUTPUTSHASHVERIFY
+#aliases:
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options

--- a/_topics/en/pay-to-contract-outputs.md
+++ b/_topics/en/pay-to-contract-outputs.md
@@ -40,9 +40,12 @@ optech_mentions:
     url: /en/newsletters/2022/01/26/#psbt-extension-for-p2c-fields
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Proof of payment
+    link: topic proof of payment
+
+  - title: Taproot
+    link: topic taproot
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/payment-probes.md
+++ b/_topics/en/payment-probes.md
@@ -59,9 +59,12 @@ optech_mentions:
     url: /en/newsletters/2022/07/13/#ldk-1567
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: JIT routing
+    link: topic jit routing
+
+  - title: Channel jamming attacks
+    link: topic channel jamming attacks
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/quantum-resistance.md
+++ b/_topics/en/quantum-resistance.md
@@ -60,7 +60,6 @@ see_also:
   - title: Version 2 P2P transport
     link: topic v2 p2p transport
 
-
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/rendez-vous-routing.md
+++ b/_topics/en/rendez-vous-routing.md
@@ -67,6 +67,12 @@ see_also:
   - title: Unannounced channels
     link: topic unannounced channels
 
+  - title: Onion messages
+    link: topic onion messages
+
+  - title: Offers
+    link: topic offers
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -146,6 +146,12 @@ optech_mentions:
 
 ## Optional.  Same format as "primary_sources" above
 see_also:
+  - title: Transaction pinning
+    link: topic transaction pinning
+
+  - title: Version 3 transaction relay
+    link: topic v3 transaction relay
+
   - title: Opt-in RBF FAQ
     link: https://bitcoincore.org/en/faq/optin_rbf/
 

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -17,7 +17,7 @@ excerpt: >
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
-    - title: bip-schnorr
+    - title: BIP340
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry
@@ -125,6 +125,8 @@ see_also:
     link: https://bitcoin.stackexchange.com/questions/82952/will-a-schnorr-soft-fork-introduce-a-new-address-format-i-e-not-bech32
   - title: Taproot
     link: topic taproot
+  - title: Scriptless multisignatures
+    link: topic multisignature
 ---
 Schnorr is secure under the same cryptographic assumptions as
 [ECDSA][] and it is easier and faster to create secure multiparty

--- a/_topics/en/segregated-witness.md
+++ b/_topics/en/segregated-witness.md
@@ -64,6 +64,9 @@ see_also:
   - title: Taproot
     link: topic taproot
 
+  - title: Bech32 addresses
+    link: topic bech32
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/side-channels.md
+++ b/_topics/en/side-channels.md
@@ -44,9 +44,9 @@ optech_mentions:
     url: /en/newsletters/2023/04/12/#libsecp256k1-0-3-1
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Exfiltration resistant signing
+    link: topic exfiltration resistant signing
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters

--- a/_topics/en/sighash_anyprevout.md
+++ b/_topics/en/sighash_anyprevout.md
@@ -109,6 +109,9 @@ see_also:
   - title: Eltoo
     link: topic eltoo
 
+  - title: Covenants
+    link: topic covenants
+
 redirect_from:
   - /en/topics/sighash_noinput/
 

--- a/_topics/en/signer-delegation.md
+++ b/_topics/en/signer-delegation.md
@@ -38,6 +38,9 @@ see_also:
   - title: Statechains
     link: topic statechains
 
+  - title: "OP_CHECKSIGFROMSTACK"
+    link: "topic op_checksigfromstack"
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/simplicity.md
+++ b/_topics/en/simplicity.md
@@ -49,6 +49,9 @@ optech_mentions:
 see_also:
   - title: "Simplicity: A New Language for Blockchains"
     link: https://blockstream.com/simplicity.pdf
+
+  - title: Covenants
+    link: topic covenants
 ---
 At its core, Simplicity consists of nine primitive operators called
 combinators whose semantics are formally specified. However,

--- a/_topics/en/splicing.md
+++ b/_topics/en/splicing.md
@@ -8,6 +8,7 @@ title: Splicing
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
@@ -19,6 +20,9 @@ excerpt: >
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
 primary_sources:
+    - title: "Splicing specification (draft)"
+      link: https://github.com/lightning/bolts/pull/863
+
     - title: Splice proposal (Rusty Russell)
       link: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-October/001434.html
 
@@ -59,9 +63,12 @@ optech_mentions:
     url: /en/newsletters/2023/04/19/#eclair-2584
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Interactive transaction construction protocol
+    link: topic dual funding
+
+  - title: Submarine swaps
+    link: topic submarine swaps
 ---
 Splicing comes in two varieties:
 
@@ -79,7 +86,7 @@ Splicing comes in two varieties:
   secured by the old channel's security until the new channel has
   fully confirmed.
 
-Splicing is different from *submarine swaps* (such as those
+Splicing is different from [submarine swaps][topic submarine swaps] (such as those
 implemented by [Lightning Loop][]) where funds are transferred
 between users in exchange for onchain transactions---in submarine
 swaps, the overall balance of the channel stays the same; in

--- a/_topics/en/statechains.md
+++ b/_topics/en/statechains.md
@@ -49,6 +49,12 @@ see_also:
   - title: Multisignatures
     link: topic multisignature
 
+  - title: Signer delegation
+    link: topic signer delegation
+
+  - title: Sidechains
+    link: topic sidechains
+
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >

--- a/_topics/en/stateless-invoices.md
+++ b/_topics/en/stateless-invoices.md
@@ -51,9 +51,9 @@ optech_mentions:
     url: /en/newsletters/2023/02/01/#ldk-1878
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Offers
+    link: topic offers
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/static-channel-backups.md
+++ b/_topics/en/static-channel-backups.md
@@ -13,6 +13,7 @@ title: Static channel backups
 ## schema for options
 categories:
   - Lightning Network
+  - Backup and Recovery
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"

--- a/_topics/en/submarine-swaps.md
+++ b/_topics/en/submarine-swaps.md
@@ -13,6 +13,7 @@ title: Submarine swaps
 ## schema for options
 categories:
   - Lightning Network
+  - Liquidity Management
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -16,11 +16,11 @@ excerpt: >
 
 ## Optional
 primary_sources:
+    - title: BIP341
     - title: Original description
       link: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-January/015614.html
-    - title: bip-taproot
-    - title: Draft implementation
-      link: https://github.com/sipa/bitcoin/commits/taproot
+    - title: Original implementation
+      link: https://github.com/bitcoin/bitcoin/pull/19953
 
 ## Optional
 optech_mentions:
@@ -237,6 +237,15 @@ optech_mentions:
 see_also:
   - title: MAST
     link: topic mast
+
+  - title: Tapscript
+    link: topic tapscript
+
+  - title: Schnorr signatures
+    link: topic schnorr signatures
+
+  - title: Pay-to-contract
+    link: topic p2c
 ---
 Coins protected by taproot may be spent either by satisfying one of
 the committed scripts or by simply providing a signature that verifies

--- a/_topics/en/threshold-signature.md
+++ b/_topics/en/threshold-signature.md
@@ -48,7 +48,7 @@ optech_mentions:
 
 ## Optional.  Same format as "primary_sources" above
 see_also:
-  - title: Multisignature
+  - title: Scriptless multisignature
     link: topic multisignature
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
@@ -63,7 +63,7 @@ excerpt: >
 ---
 Different algorithms exist for creating threshold signatures, but
 perhaps the simplest of these is a slight extension of a typical
-algorithm for creating a [multisignature][topic multisignature].  This
+algorithm for creating a [scriptless multisignature][topic multisignature].  This
 is easiest explained with an example: participants A, B, and C want to receive
 funds that can be spent by any three of them.  They cooperate to create
 an ordinary multisignature public key for receiving the funds, then they

--- a/_topics/en/transaction-pinning.md
+++ b/_topics/en/transaction-pinning.md
@@ -79,6 +79,9 @@ optech_mentions:
 see_also:
    - title: CPFP carve out
      link: topic cpfp carve out
+
+   - title: Ephemeral anchors
+     link: topic ephemeral anchors
 ---
 Nodes such as Bitcoin Core that allow transactions to be replaced
 (RBF) or packaged with higher-fee child transactions (CPFP) place

--- a/_topics/en/unannounced-channels.md
+++ b/_topics/en/unannounced-channels.md
@@ -57,9 +57,9 @@ optech_mentions:
     url: /en/newsletters/2021/07/21/#c-lightning-4611
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Blinded paths
+    link: topic rv routing
 ---
 Most unannounced channels are believed to belong to users that simply
 don't intend to route payments, such as users of mobile clients that

--- a/_topics/en/uneconomical-outputs.md
+++ b/_topics/en/uneconomical-outputs.md
@@ -68,6 +68,9 @@ see_also:
   - title: Dust attacks (output linking)
     link: topic output linking
 
+  - title: Ephemeral anchors
+    link: topic ephemeral anchors
+
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a
 ## threshold word count

--- a/_topics/en/utreexo.md
+++ b/_topics/en/utreexo.md
@@ -41,9 +41,9 @@ optech_mentions:
     url: /en/newsletters/2023/05/24/#state-compression-with-zero-knowledge-validity-proofs
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Uneconomical outputs
+    link: topic uneconomical outputs
 ---
 A merkle tree updated after every block accumulates references to
 every unspent transaction output, allowing nodes to skip storing the

--- a/_topics/en/v2-p2p-transport.md
+++ b/_topics/en/v2-p2p-transport.md
@@ -59,8 +59,8 @@ optech_mentions:
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: BIP151
-  - title: "Countersign: a secret authentication protocol"
-    link: https://gist.github.com/sipa/d7dcaae0419f10e5be0270fada84c20b
+  - title: Countersign
+    link: topic countersign
 ---
 Some other changes to the communication protocol are also suggested,
 such as allowing frequently-used protocol commands to be aliased to

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -54,8 +54,8 @@ see_also:
   - title: Transaction pinning
     link: topic transaction pinning
 
-  - title: Anchor outputs
-    link: topic anchor outputs
+  - title: Ephemeral anchors
+    link: topic ephemeral anchors
 ---
 V3 transaction relay is a superset of standard transaction policy.
 That is, v3 transactions follow all rules for standard transactions

--- a/_topics/en/wallet-labels.md
+++ b/_topics/en/wallet-labels.md
@@ -52,9 +52,12 @@ optech_mentions:
     url: /en/newsletters/2023/07/05/#bips-1452
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: Output script descriptors
+    link: topic descriptors
+
+  - title: Output linking
+    link: topic output linking
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a

--- a/_topics/en/watchtowers.md
+++ b/_topics/en/watchtowers.md
@@ -6,6 +6,7 @@ title: Watchtowers
 categories:
   - Lightning Network
   - Security Enhancements
+  - Backup and Recovery
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
@@ -89,6 +90,9 @@ optech_mentions:
 see_also:
   - title: LND watchtower tutorial
     link: https://github.com/wbobeirne/watchtower-example
+
+  - title: Static channel backups
+    link: topic static channel backups
 ---
 The service provided by watchtowers allows their clients to go offline
 for significant amounts of time without having to worry about their

--- a/_topics/en/zero-conf-channels.md
+++ b/_topics/en/zero-conf-channels.md
@@ -57,9 +57,9 @@ optech_mentions:
     url: /en/newsletters/2023/05/17/#challenges-with-zero-conf-channels-when-dual-funding
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: JIT channels
+    link: topic jit channels
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a


### PR DESCRIPTION
Also includes a few other small changes, plus a separate commit that starts the process of changing our usage of the terms "multisigature" and "multisig" to, respectively, "scriptless multisignature" and "scripted multisig(nature)", which came about as I was writing about them in a different context and had some discussions with a few Bitcoin wizards.  It's easy for me to drop that separate commit if that change is controversial.