### PR TITLE
Fix typo in compatibility matrix

### DIFF
--- a/_includes/templates/compatibility/rbf.md
+++ b/_includes/templates/compatibility/rbf.md
@@ -115,7 +115,7 @@ block chain space used, this is the most efficient form of fee bumping.
   - **Signals BIP125 replaceability when sending transactions**<br>
     Allows sending of BIP125 opt-in-RBF transactions in the interface.
   {% when "false" %}{:.feature-no}
-  - **Does not signal BIP125 repleacability when sending transactions**<br>
+  - **Does not signal BIP125 replaceability when sending transactions**<br>
     Does not allow sending of BIP125 opt-in-RBF transactions in the interface.
   {% when "na" %}{:.feature-neutral}
   - **Does not send transactions**<br>

--- a/_topics/en/responsible-disclosures.md
+++ b/_topics/en/responsible-disclosures.md
@@ -79,7 +79,7 @@ optech_mentions:
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 ## Should be less than 500 characters
 excerpt: >
-  **Responsible disclosures** were occassions when someone discovered a
+  **Responsible disclosures** were occasions when someone discovered a
   vulnerability in Bitcoin-related software and reported it to
   developers, affected users, and the public in a way that helped
   minimize harm.


### PR DESCRIPTION
Fixes a typo introduced with a recent pull request