### PR TITLE
fix amounts in overflow bug description

### DIFF
--- a/_topics/en/soft-fork-activation.md
+++ b/_topics/en/soft-fork-activation.md
@@ -490,13 +490,13 @@ occasions included:
 
 - **Fix value overflow bug (August 2010):** someone
   created a transaction that spent 0.5 BTC to two outputs worth
-  92,233,720,368.54277039 BTC.  Bitcoin requires that the output
+  92,233,720,368.54275808 BTC.  Bitcoin requires that the output
   amount be less than or equal to the input amount, but this was
   checked by adding the output values into a single 64-bit
   integer which can only hold a maximum value of
-  9,223,372,036,854,776 sats (about 92 billion BTC) before rolling over to negative numbers,
-  starting with -9,223,372,036,854,776 sats.  This meant it looked like the
-  transaction spent a total of -0.1 BTC (negative 0.1 BTC).  This
+  9,223,372,036,854,775,807 sats (about 92 billion BTC) before rolling over to negative numbers,
+  starting with -9,223,372,036,854,775,808 sats.  This meant it looked like the
+  transaction spent a total of -0.01 BTC (negative 0.01 BTC).  This
   bypassed another rule that forbid individual negative outputs---but
   not negative aggregate amounts---since it assumed the sum of any set
   of positive values would also be positive.  This gave the person who

--- a/_topics/en/soft-fork-activation.md
+++ b/_topics/en/soft-fork-activation.md
@@ -496,7 +496,7 @@ occasions included:
   integer which can only hold a maximum value of
   9,223,372,036,854,775,807 sats (about 92 billion BTC) before rolling over to negative numbers,
   starting with -9,223,372,036,854,775,808 sats.  This meant it looked like the
-  transaction spent a total of -0.01 BTC (negative 0.01 BTC).  This
+  transaction outputs summed to a total of -0.01 BTC (negative 0.01 BTC) and left 0.51 BTC to be collected as a transaction fee.  This
   bypassed another rule that forbid individual negative outputs---but
   not negative aggregate amounts---since it assumed the sum of any set
   of positive values would also be positive.  This gave the person who


### PR DESCRIPTION
**easy changes:**
`INT64_MAX` is `9223372036854775807` (`2**63-1`)
`INT64_MIN` is `-9223372036854775808` (`-2**63`)

**other changes:**
For whatever reason, post # 1 in [bitcointalk topic 822](https://bitcointalk.org/index.php?topic=822.0) contains a different output amount than post # 3  
`post #1: 92233720368.54277039 (0x7ffffffffff863af)`  
`post #3: 92233720368.54275808 (0x7ffffffffff85ee0)`  
I'm assuming post # 3 ist right, because it's `2**63-500000`, and the sum of outputs is a round number: -0.01 BTC (minus 1 million sats). (calculation: `9223372036854275808*2 - 2**64 = -1000000`)