### PR TITLE
Newsletters: add 277 (2023-11-15)

### DIFF
--- a/_includes/articles/wizardsardine-miniscript.md
+++ b/_includes/articles/wizardsardine-miniscript.md
@@ -1,0 +1,112 @@
+{:.post-meta}
+*by [Antoine Poinsot][] from [Wizardsardine][]*
+
+Our (practical) interest for miniscript started back in early 2020 when we were
+designing [Revault][], a multiparty [vault][topic vaults] architecture only
+using then available scripting primitives.
+
+We initially showcased Revault using a fixed set of participants. We quickly ran
+into issues as we tried to generalize it to more participants in a production
+setting.
+
+- Actually are we _sure_ the script we used in the demo is secure? Is it
+possible to spend it in all the ways it's advertized to be? Is there no other
+way of spending it than how it's advertized?
+- Even if it is, how can we generalize it to various number of participants and
+keep it secure? How can we apply some optimizations and make sure the resulting
+script has the same semantics?
+- In addition, Revault is using pre-signed transactions (to enforce spending
+policies). How can we know in advance the budget to allocate for fee-bumping
+given the configuration of the script? How can we make sure _any_ transaction
+spending those scripts will pass the most common standardness checks?
+- Finally, even assuming our scripts correspond to the intended semantics and
+are always spendable, how can we _concretely_ spend them? As in how can we
+produce a satisfying witness for ("sign for") each and every possible
+configuration? How can we make hardware signing devices compatible with our
+scripts?
+
+These questions would have been a show stopper if it was not for miniscript. Two
+guys in a garage are not going to write a software that [creates some script on
+the fly, hope for the best][rekt lost funds] and on top of that call it a
+security enhancing Bitcoin wallet. We wanted to start a company around the
+development of Revault, but we wouldn't get funding without providing some
+reasonable assurance to an investor we could bring a safe product to market. And
+we wouldn't be able to solve all these engineering problems without funding.
+
+[Enters miniscript][sipa miniscript], "a language for writing (a subset of)
+Bitcoin Scripts in a structured way, enabling analysis, composition, generic
+signing and more. [...] It has a structure that allows composition. It is very
+easy to statically analyze for various properties (spending conditions,
+correctness, security properties, malleability, ...)." This is exactly what we
+needed. Armed with this powerful tool, we could give better guarantees [0] to
+our investors, raise funds, and start the development of Revault.
+
+At the time, miniscript was still far from being a turnkey solution for any
+Bitcoin application developer to use. (If you are a new Bitcoin dev reading this
+after the year 2023, yes, there was a time where we used to write Bitcoin
+scripts BY HAND.) We had to integrate miniscript in Bitcoin Core (see PRs
+[#24147][Bitcoin Core #24147], [#24148][Bitcoin Core #24148] and
+[#24149][Bitcoin Core #24149]), which we used as the backend of the Revault
+wallet, and convince signing devices manufacturers to implement it in their
+firmware. The latter part would turn out to be the most difficult.
+
+It was a chicken-and-egg problem: incentives were low for manufacturers to
+implement miniscript with no demand from users. And we couldn't release Revault
+without signing device support. Fortunately this cycle was eventually broken by
+[Stepan Snigirev][] in March 2021 by [bringing][github embit descriptors]
+[support][github specter descriptors] for miniscript descriptors to the [Specter
+DIY][]. The Specter DIY was however for a long time disclaimed as being merely a
+"functional prototype", and [Salvatore Ingala][] brought [miniscript to a
+production-ready signing device][ledger miniscript blog] for the first time in 2022 with the [new
+Bitcoin app][ledger bitcoin app] for the Ledger Nano S(+). The app was released
+in January 2023, allowing us to publish the [Liana wallet][] with support for
+the most popular signing device.
+
+One last development is left to wrap up our miniscript journey. [Liana][github
+liana] is a Bitcoin wallet focused on recovery options. It lets one specify some
+timelocked recovery conditions (for instance a third-party [recovery key that
+cannot normally spend the funds][blog liana 0.2 recovery], or a
+[decaying/expanding multisig][blog liana 0.2 decaying]). Miniscript was
+initially only available for P2WSH scripts. Almost 2 years after [taproot][topic
+taproot] activated, it's unfortunate that you would have to publish your
+recovery spending paths onchain every time you spend. To this end, we have been
+working to port miniscript to tapscript (see [here][github minitapscript] and
+[here][Bitcoin Core #27255]).
+
+The future is bright. With most signing devices either having implemented or in
+the process of implementing miniscript support (for instance recently
+[Bitbox][github bitbox v9.15.0] and [Coldcard][github coldcard 227]), along with
+[taproot and miniscript native frameworks][github bdk] being polished,
+contracting on Bitcoin with safe primitives is more accessible than ever.
+
+It's interesting to note how the funding of Open Source tools and frameworks
+lower the barrier to entry for innovative companies to compete and, more
+generally, projects to be implemented. This trend accelerating in the past years
+can make us hopeful about the future of the space.
+
+[0] There was still risk, of course. But at least we were confident we could get
+past the onchain part. The offchain one would prove to be (as expected) more
+challenging.
+
+{% include references.md %}
+{% include linkers/issues.md v=2 issues="24147,24148,24149,27255" %}
+[Antoine Poinsot]: https://twitter.com/darosior
+[Wizardsardine]: https://wizardsardine.com/
+[Revault]: https://wizardsardine.com/revault
+[rekt lost funds]: https://rekt.news/leaderboard/
+[sipa miniscript]: https://bitcoin.sipa.be/miniscript
+[Stepan Snigirev]: https://github.com/stepansnigirev
+[github embit descriptors]: https://github.com/diybitcoinhardware/embit/pull/4
+[github specter descriptors]: https://github.com/cryptoadvance/specter-diy/pull/133
+[Specter DIY]: https://github.com/cryptoadvance/specter-diy
+[Salvatore Ingala]: https://github.com/bigspider
+[ledger miniscript blog]: https://www.ledger.com/blog/miniscript-is-coming
+[ledger bitcoin app]: https://github.com/LedgerHQ/app-bitcoin-new
+[Liana wallet]: https://wizardsardine.com/liana/
+[github liana]: https://github.com/wizardsardine/liana
+[blog liana 0.2 recovery]: https://wizardsardine.com/blog/liana-0.2-release/#trust-distributed-safety-net
+[blog liana 0.2 decaying]: https://wizardsardine.com/blog/liana-0.2-release/#decaying-multisig
+[github minitapscript]: https://github.com/sipa/miniscript/pull/134
+[github bitbox v9.15.0]: https://github.com/digitalbitbox/bitbox02-firmware/releases/tag/firmware%2Fv9.15.0
+[github coldcard 227]: https://github.com/Coldcard/firmware/pull/227
+[github bdk]: https://github.com/bitcoindevkit/bdk

--- a/_includes/snippets/recap-ad.md
+++ b/_includes/snippets/recap-ad.md
@@ -1,0 +1,73 @@
+{% capture /dev/null %}
+<!--
+recap-ad.md: creates an advertisement for the next recap
+-->
+
+  Input:
+    - when: UTC time of next recap in any format supported by the `date`
+      filter, e.g. YYYY-MM-DD HH:MM
+
+  Output:
+    A div with a paragraph announcing the next recap and how to
+    participate in it.
+
+  Example:
+    Input:
+      % include linkers/issues.md issues="123,456" %
+    Output
+      ... at HOUR on DAY ...
+-->
+{% assign current_epoch_time = site.time | date: "%s" %}
+{% assign when_epoch_time = include.when | date: "%s" %}
+{% assign recap_formatted_date_utc = include.when | date: "%B %-d" %}
+{% assign recap_formatted_time_utc = include.when | date: "%H:%M" %}
+{% endcapture %}{% capture recap_ad_text %}
+<div markdown="1" class="callout">
+{% case page.lang %}
+{% when "cs" %}
+
+## Chcete víc?
+
+Další diskuze o tématech zmíněných v tomto zpravodaji proběhnou v týdenním
+Bitcoin Optech Recap na [Twitter Spaces][@bitcoinoptech] ve čtvrtek (den po
+vydání zpravodaje) v {{recap_formatted_time_utc}} UTC. Diskuze jsou nahrávány a zpřístupněny
+na stránce našeho [podcastu][podcast].
+{% when "fr" %}
+
+## Vous en voulez plus?
+
+Pour plus de discussions sur les sujets mentionnés dans ce bulletin,
+rejoignez-nous pour le récapitulatif hebdomadaire Bitcoin Optech sur [Twitter
+Spaces][@bitcoinoptech] à {{recap_formatted_time_utc}} UTC le jeudi (le jour suivant la publication de
+la newsletter). La discussion est également enregistrée et sera disponible sur
+notre page de [podcasts][podcast].
+{% when "ja" %}
+
+## もっと知りたいですか？
+
+このニュースレターで言及されたトピックについてもっと議論したい方は、
+（ニュースレターが公開された翌日の）木曜日の{{recap_formatted_time_utc}} UTCから[Twitter
+Spaces][@bitcoinoptech]で毎週開催されているBitcoin Optech Recapにご参加ください。
+この議論は録画もされ、[ポッドキャスト][podcast]ページからご覧いただけます。
+
+{% when "zh" %}
+
+## 想了解更多？
+
+想了解更多本周报中提到的内容，请加入我们每周的比特币 Optech 回顾的 [Twitter
+Space][@bitcoinoptech]，时间为每周四 {{recap_formatted_time_utc}} UTC（即周报发布后的一天）。讨论内容会
+被录制下来，也将在我们的[播客][podcast]页面上提供。
+
+{% else %}
+## Want more?
+
+For more discussion about the topics mentioned in this newsletter, join
+us for the weekly Bitcoin Optech Recap on [Twitter
+Spaces][@bitcoinoptech] at {{recap_formatted_time_utc}} UTC on
+{{recap_formatted_date_utc}}.  The discussion is also recorded and will
+be available from our [podcasts][podcast] page.
+{% endcase %}
+
+</div>
+{% endcapture %}
+{% if when_epoch_time > current_epoch_time %}{{recap_ad_text}}{% endif %}

--- a/_posts/cs/newsletters/2023-11-01-newsletter.md
+++ b/_posts/cs/newsletters/2023-11-01-newsletter.md
@@ -135,16 +135,6 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo] a
   což může zlepšit obranu proti určitým útokům, jako je replacement cycling
   popsaný v [minulém čísle][news274 cycling]).
 
-<div markdown="1" class="callout">
-## Chcete víc?
-
-Další diskuze o tématech zmíněných v tomto zpravodaji proběhnou v týdenním
-Bitcoin Optech Recap na [Twitter Spaces][@bitcoinoptech] ve čtvrtek (den po
-vydání zpravodaje) v 16:00 SEČ. Diskuze jsou nahrávány a zpřístupněny
-na stránce našeho [podcastu][podcast].
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="28685,28651,28565,7828,2660,1086,27511" %}
 [news164 pong]: /en/newsletters/2021/09/01/#lnd-5621

--- a/_posts/en/2023-11-15-wizardsardine-miniscript.md
+++ b/_posts/en/2023-11-15-wizardsardine-miniscript.md
@@ -1,0 +1,14 @@
+---
+title: 'Field Report: A Miniscript Journey'
+permalink: /en/wizardsardine-miniscript/
+name: 2023-11-15-wizardsardine-miniscript
+slug: 2023-11-15-wizardsardine-miniscript
+type: posts
+layout: post
+lang: en
+version: 1
+excerpt: >
+   This field report outlines miniscript's ecosystem adoption from the perspective of Wizardsardine.
+
+---
+{% include articles/wizardsardine-miniscript.md %}

--- a/_posts/en/newsletters/2023-11-01-newsletter.md
+++ b/_posts/en/newsletters/2023-11-01-newsletter.md
@@ -150,17 +150,6 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   attacks, such as the replacement cycling attack described in [last
   week's newsletter][news274 cycling]). {% assign timestamp="35:02" %}
 
-<div markdown="1" class="callout">
-## Want more?
-
-For more discussion about the topics mentioned in this newsletter, join
-us for the weekly Bitcoin Optech Recap on [Twitter
-Spaces][@bitcoinoptech] at 15:00 UTC on Thursday (the day after the
-newsletter is published).  The discussion is also recorded and will be
-available from our [podcasts][podcast] page.
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="28685,28651,28565,7828,2660,1086,27511" %}
 [news164 pong]: /en/newsletters/2021/09/01/#lnd-5621

--- a/_posts/en/newsletters/2023-11-08-newsletter.md
+++ b/_posts/en/newsletters/2023-11-08-newsletter.md
@@ -213,17 +213,6 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   funding].  See [Newsletter #253][news253 stuck] for another mitigation
   by Eclair for a stuck funds problem. {% assign timestamp="41:02" %}
 
-<div markdown="1" class="callout">
-## Want more?
-
-For more discussion about the topics mentioned in this newsletter, join
-us for the weekly Bitcoin Optech Recap on [Twitter
-Spaces][@bitcoinoptech] at 15:00 UTC on Thursday (the day after the
-newsletter is published).  The discussion is also recorded and will be
-available from our [podcasts][podcast] page.
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="6824,6783,6780,6773,6734,2761,851" %}
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/

--- a/_posts/en/newsletters/2023-11-15-newsletter.md
+++ b/_posts/en/newsletters/2023-11-15-newsletter.md
@@ -1,0 +1,117 @@
+---
+title: 'Bitcoin Optech Newsletter #277'
+permalink: /en/newsletters/2023/11/15/
+name: 2023-11-15-newsletter
+slug: 2023-11-15-newsletter
+type: newsletter
+layout: newsletter
+lang: en
+---
+This week's newsletter describes an update to the proposal for ephemeral
+anchors and provides a contributed field report about miniscript from a
+developer working at Wizardsardine.  Also included are our regular sections
+announcing new software releases and release candidates and summarizing
+notable changes to popular Bitcoin infrastructure projects.
+
+## News
+
+- **Eliminating malleability from ephemeral anchor spends:** Gregory
+  Sanders [posted][sanders mal] to the Delving Bitcoin forum about a
+  tweak to the [ephemeral anchors][topic ephemeral anchors] proposal.
+  That proposal would allow transactions to include a zero-value output
+  with an anyone-can-spend output script.  Because anyone can spend the
+  output, anyone can [CPFP][topic cpfp] fee bump the transaction that
+  created the output.  This is convenient for multiparty contract
+  protocols such as LN where transactions often get signed before it's
+  possible to accurately predict what feerate they should pay.
+  Ephemeral anchors allows any
+  party to the contract to add as much fee as they think is necessary.
+  If any other party---or any other user for any reason---wants to add a
+  higher fee, they can [replace][topic rbf] the CPFP fee bump with their
+  own higher-feerate CPFP fee bump.
+
+    The type of anyone-can-spend script proposed for use is an output
+    script consisting of the equivalent of `OP_TRUE`, which can be spent by an input
+    with an empty input script.  As Sanders posted this week, using a
+    legacy output script means that the child transaction spending it
+    has a malleable txid, e.g. any miner can add data to the input
+    script to change the child transaction's txid.  That can make it
+    unwise to use the child transaction for anything besides fee bumping
+    as, even if it gets confirmed, it might get confirmed with a
+    different txid that invalidates any grandchild transactions.
+
+    Sanders suggests instead using one of the output scripts that had
+    been reserved for future segwit upgrades.  This uses slightly more
+    block space---four bytes for segwit versus one byte for bare
+    `OP_TRUE`---but eliminates any concerns about transaction
+    malleability.  After some discussion on the thread, Sanders later
+    proposed offering both: an `OP_TRUE` version for anyone who doesn't
+    care about malleability and wants to minimize transaction size, plus a
+    segwit version that is slightly larger but does not allow the child
+    transaction to be mutated.  Additional discussion in the thread
+    focused on choosing the extra bytes for the segwit approach to
+    create a memorable [bech32m address][topic bech32].
+
+## Releases and release candidates
+
+*New releases and release candidates for popular Bitcoin infrastructure
+projects.  Please consider upgrading to new releases or helping to test
+release candidates.*
+
+- [LND 0.17.1-beta][] is a maintenance release for this LN node
+  implementation that includes several bug fixes and minor improvements.
+
+- [Bitcoin Core 26.0rc2][] is a release candidate for the next major
+  version of the predominant full node implementation. There's a [testing
+  guide][26.0 testing] and a scheduled
+  meeting of the [Bitcoin Core PR Review Club][] dedicated to testing on
+  15 November 2023.
+
+- [Core Lightning 23.11rc1][] is a release candidate for the next
+  major version of this LN node implementation.
+
+## Notable code and documentation changes
+
+*Notable recent changes in [Bitcoin Core][bitcoin core repo], [Core
+Lightning][core lightning repo], [Eclair][eclair repo], [LDK][ldk repo],
+[LND][lnd repo], [libsecp256k1][libsecp256k1 repo], [Hardware Wallet
+Interface (HWI)][hwi repo], [Rust Bitcoin][rust bitcoin repo], [BTCPay
+Server][btcpay server repo], [BDK][bdk repo], [Bitcoin Improvement
+Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
+[Bitcoin Inquisition][bitcoin inquisition repo].*
+
+- [Bitcoin Core #28207][] updates the way the mempool is stored on disk
+  (which normally happens during node shutdown, but can also be
+  triggered by the `savemempool` RPC).  Previously, it was stored in a
+  simple serialization of the underlying data.  Now, that serialized
+  structure is XOR'd by a random value generated independently by each
+  node, obfuscating the data.  It's XOR'd by the same value during
+  loading to remove the obfuscation.  The obfuscation prevents someone
+  from being able to put certain data in a transaction to get a
+  particular sequence of bytes to appear in the saved mempool data, which
+  might cause programs like virus scanners to flag the saved mempool
+  data as dangerous.  The same method was previously applied to storing
+  the UTXO set in [PR #6650][bitcoin core #6650].  Any software that
+  needs to read mempool data from disk should be able to trivially apply
+  the XOR operation itself, or use the configuration setting
+  `-persistmempoolv1` to request saving in the unobfuscated format.
+  Note, the backward-compatibility configuration setting is planned to
+  be removed in a future release.
+
+- [LDK #2715][] allows a node to optionally accept a smaller value
+  [HTLC][topic htlc] than is supposed to be delivered.  This is useful
+  when the upstream peer is paying the node through a new [JIT
+  channel][topic jit channels], which costs the upstream peer an onchain
+  transaction fee that they want to deduct from the amount of the HTLC
+  being paid to the node.  See [Newsletter #257][news257 jitfee] for
+  LDK's previous implementation of the upstream portion of this feature.
+
+{% include snippets/recap-ad.md when="2023-11-16 15:00" %}
+{% include references.md %}
+{% include linkers/issues.md v=2 issues="28207,6650,2715" %}
+[bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
+[26.0 testing]: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/26.0-Release-Candidate-Testing-Guide
+[core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
+[lnd 0.17.1-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta
+[sanders mal]: https://delvingbitcoin.org/t/segwit-ephemeral-anchors/160
+[news257 jitfee]: /en/newsletters/2023/06/28/#ldk-2319

--- a/_posts/en/newsletters/2023-11-15-newsletter.md
+++ b/_posts/en/newsletters/2023-11-15-newsletter.md
@@ -52,6 +52,10 @@ notable changes to popular Bitcoin infrastructure projects.
     focused on choosing the extra bytes for the segwit approach to
     create a memorable [bech32m address][topic bech32].
 
+## Field Report: A Miniscript Journey
+
+{% include articles/wizardsardine-miniscript.md extrah="#" %}
+
 ## Releases and release candidates
 
 *New releases and release candidates for popular Bitcoin infrastructure

--- a/_posts/fr/newsletters/2023-11-01-newsletter.md
+++ b/_posts/fr/newsletters/2023-11-01-newsletter.md
@@ -110,15 +110,6 @@ travaillent sur une solution pour un deuxième candidat à la version.
   telles que l'attaque de remplacement cyclique décrite dans [le bulletin de la semaine dernière][news274 cycling]).
   {% assign timestamp="35:02" %}
 
-<div markdown="1" class="callout">
-## Vous en voulez plus ?
-
-Pour plus de discussions sur les sujets mentionnés dans cebulletin, rejoignez-nous pour le récapitulatif hebdomadaire de Bitcoin Optech
-sur [Twitter Spaces][@bitcoinoptech] à 15h00 UTC le jeudi (le jour suivant la publication de la newsletter). La discussion est également
-enregistrée et sera disponible sur notre page de [podcasts][podcast].
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="28685,28651,28565,7828,2660,1086,27511" %}
 [news164 pong]: /en/newsletters/2021/09/01/#lnd-5621

--- a/_posts/fr/newsletters/2023-11-08-newsletter.md
+++ b/_posts/fr/newsletters/2023-11-08-newsletter.md
@@ -174,15 +174,6 @@ versions ou d'aider à tester les versions candidates.*
   ou [un financement double][topic dual funding]. Voir le [Bulletin #253][news253 stuck] pour une autre atténuation par Eclair pour un
   problème de fonds bloqués. {% assign timestamp="41:02" %}
 
-<div markdown="1" class="callout">
-## Vous en voulez plus?
-
-Pour plus de discussions sur les sujets mentionnés dans ce bulletin, rejoignez-nous pour le récapitulatif hebdomadaire Bitcoin Optech
-sur [Twitter Spaces][@bitcoinoptech] à 15h00 UTC le jeudi (le jour suivant la publication de la newsletter). La discussion est également
-enregistrée et sera disponible sur notre page de [podcasts][podcast].
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="6824,6783,6780,6773,6734,2761,851" %}
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/

--- a/_posts/ja/newsletters/2023-11-01-newsletter.md
+++ b/_posts/ja/newsletters/2023-11-01-newsletter.md
@@ -113,16 +113,6 @@ Proposals（BIP）][bips repo]、[Lightning BOLTs][bolts repo]および
   または、より高い最大HTLC delta設定の場合は同じホップ数で、
   [先週のニュースレター][news274 cycling]で説明した置換サイクル攻撃などの特定の攻撃に対する耐性を向上させることができます）。
 
-<div markdown="1" class="callout">
-## もっと知りたいですか？
-
-このニュースレターで言及されたトピックについてもっと議論したい方は、
-（ニュースレターが公開された翌日の）木曜日の15:00 UTCから[Twitter
-Spaces][@bitcoinoptech]で毎週開催されているBitcoin Optech Recapにご参加ください。
-この議論は録画もされ、[ポッドキャスト][podcast]ページからご覧いただけます。
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="28685,28651,28565,7828,2660,1086,27511" %}
 [news164 pong]: /ja/newsletters/2021/09/01/#lnd-5621

--- a/_posts/ja/newsletters/2023-11-08-newsletter.md
+++ b/_posts/ja/newsletters/2023-11-08-newsletter.md
@@ -170,16 +170,6 @@ Proposals（BIP）][bips repo]、[Lightning BOLTs][bolts repo]および
   _資金のスタック問題_ を解決するのに役立ちます。資金のスタック問題に対するEclairの別の緩和策については、
   [ニュースレター #253][news253 stuck]をご覧ください。
 
-<div markdown="1" class="callout">
-## もっと知りたいですか？
-
-このニュースレターで言及されたトピックについてもっと議論したい方は、
-（ニュースレターが公開された翌日の）木曜日の15:00 UTCから[Twitter
-Spaces][@bitcoinoptech]で毎週開催されているBitcoin Optech Recapにご参加ください。
-この議論は録画もされ、[ポッドキャスト][podcast]ページからご覧いただけます。
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="6824,6783,6780,6773,6734,2761,851" %}
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/

--- a/_posts/zh/newsletters/2023-11-01-newsletter.md
+++ b/_posts/zh/newsletters/2023-11-01-newsletter.md
@@ -55,13 +55,6 @@ _注意：_ 在我们上一期的周报中提到的 Bitcoin Core 26.0rc1 已经�
 
 - [BOLTs #1086][] 规定：如果创建一个转发 [HTLC][topic htlc] 请求的指令需要本地节点等待超过 2,016 个区块才能申请退款，应该拒绝（退款） HTLC 并返回一个 `expiry_too_far` 错误。降低此设置的数值可以减少节点在任何形式的[通道钉死攻击][topic channel jamming attacks]或长时间的[暂缓兑付发票][topic hold invoices]的最坏情况下而损失的资金。提高设置数值，可实现付款在相同的最大 HTLC 过期时间差设定（HTLC delta setting）下在更多通道上进行转发（或者在相同数量的跳数时允许更高的最大 HTLC 过期时间差设定），可以提高对一些特定攻击的抗性，例如[上周的周报][news274 cycling]中描述的替换循环攻击。 {% assign timestamp="35:02" %}
 
-<div markdown="1" class="callout">
-## 想了解更多？
-
-想了解更多本周报中提到的内容，请加入我们每周的比特币 Optech 回顾的 [Twitter Space][@bitcoinoptech]，时间为每周四 15:00 UTC（即周报发布后的一天）。讨论内容会被录制下来，也将在我们的[播客][podcast]页面上提供。
-
-</div>
-
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="28685,28651,28565,7828,2660,1086,27511" %}
 [news164 pong]: /en/newsletters/2021/09/01/#lnd-5621

--- a/_topics/en/cpfp.md
+++ b/_topics/en/cpfp.md
@@ -80,6 +80,9 @@ optech_mentions:
   - title: "Suggested best practices for CPFP or RBF fee-bumping a previous CPFP fee bump"
     url: /en/newsletters/2023/04/26/#best-practices-with-multiple-cpfps-cpfp-rbf
 
+  - title: "Making anyone-can-spend outputs for CPFP with non-malleable txids"
+    url: /en/newsletters/2023/11/15/#eliminating-malleability-from-ephemeral-anchor-spends
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: CPFP carve-out

--- a/_topics/en/ephemeral-anchors.md
+++ b/_topics/en/ephemeral-anchors.md
@@ -44,6 +44,9 @@ optech_mentions:
   - title: "LN developer discussion about multiple relay policy topics, including ephemeral anchors"
     url: /en/newsletters/2023/07/26/#reliable-transaction-confirmation
 
+  - title: "Making ephemeral anchor spends with non-malleable txids"
+    url: /en/newsletters/2023/11/15/#eliminating-malleability-from-ephemeral-anchor-spends
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: V3 Transaction Relay

--- a/_topics/en/jit-channels.md
+++ b/_topics/en/jit-channels.md
@@ -36,6 +36,9 @@ optech_mentions:
   - title: "LDK #2319 allows underfunding HTLCs in support of JIT channel creation"
     url: /en/newsletters/2023/06/28/#ldk-2319
 
+  - title: "LDK #2715 allows accepting underfunded HTLCs in support of JIT channel creation"
+    url: /en/newsletters/2023/11/15/#ldk-2715
+
 ## Optional.  Same format as "primary_sources" above
 # see_also:
 #   - title:

--- a/_topics/en/miniscript.md
+++ b/_topics/en/miniscript.md
@@ -82,6 +82,10 @@ optech_mentions:
   - title: "Bitcoin Core #27255 ports miniscript to tapscript, providing tapscript descriptors"
     url: /en/newsletters/2023/10/18/#bitcoin-core-27255
 
+  - title: "Field Report: A Miniscript Journey"
+    url: /en/wizardsardine-miniscript/
+    date: 2023-11-15
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: "Miniscript: streamlined Bitcoin scripting"


### PR DESCRIPTION
- [x] Lede, releases/RCs, topic entries @harding 
- [x] Wizardsardine field report

Note: this  PR parameterizes the advertisement for the spaces that we began including two newsletters ago.  The new version uses basically the same text but should automatically stop displaying the ad on a particular newsletter the first time the site is built after the spaces is scheduled to begin.  Let me know if anyone disagrees with that behavior.  In accordance with that behavior, this PR also manually deletes the add from the previous two newsletters.