### PR TITLE
Fix: add missing code delimiters for timestamp in News239

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ test-after-build: build
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	! find _site/ -name '*.html' | xargs grep '\[^' | grep .
 	! find _site/ -name '*.html' | xargs grep '\[\]' | grep -v skip-test | grep .
+	! find _site/ -name '*.html' | xargs grep 'timestamp=' | grep -v skip-test | grep .
 
 	## Check for duplicate anchors
 	! find _site/ -name '*.html' | while read file ; do \

--- a/_posts/en/newsletters/2023-02-22-newsletter.md
+++ b/_posts/en/newsletters/2023-02-22-newsletter.md
@@ -214,7 +214,7 @@ Proposals (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
   wallet cannot yet estimate the input weight for some descriptors
   before signing and cannot yet sign [PSBTs][topic PSBT] in some
   edge-cases. Miniscript support for P2TR outputs is also still
-  pending. assign timestamp="53:57"
+  pending. {% assign timestamp="53:57" %}
 
 - [Bitcoin Core #25344][] updates the `bumpfee` and `psbtbumpfee` RPCs
   for creating [Replace By Fee][topic rbf] (RBF) fee bumps.  The update


### PR DESCRIPTION
Also adds a test to catch future incidents.