### PR TITLE
Topics: CVEs: add Milksad CVE number

### DIFF
--- a/_topics/en/cve.md
+++ b/_topics/en/cve.md
@@ -17,6 +17,7 @@ aliases:
   - CVE-2020-26895
   - CVE-2020-26896
   - CVE-2021-31876
+  - CVE-2023-39910
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
@@ -80,6 +81,9 @@ optech_mentions:
   - title: "CVE-2017-12842: Bitcoin Core PR Review Club discussion about lowering min relayable tx size"
     url: /en/newsletters/2022/11/09/#bitcoin-core-pr-review-club
 
+  - title: "Milk Sad team disclosed CVE-2023-39910 insecure entropy in Libbitcoin `bx` command"
+    url: /en/newsletters/2023/08/09/#libbitcoin-bitcoin-explorer-security-disclosure
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: Responsible disclosures
@@ -95,6 +99,13 @@ excerpt: >
 
 extra:
   cves:
+    CVE-2023-39910:
+      link: /en/newsletters/2023/08/09/#libbitcoin-bitcoin-explorer-security-disclosure
+      summary: >
+        Vulnerability in Libbitcoin `bx` command produces insecure
+        entropy when used with the `seed` parameter, having led to the
+        theft of the full balance of multiple wallets.
+
     CVE-2020-26896:
       link: /en/newsletters/2020/10/28/#cve-2020-26896-improper-preimage-revelation
       summary: >

--- a/_topics/en/responsible-disclosures.md
+++ b/_topics/en/responsible-disclosures.md
@@ -63,7 +63,7 @@ optech_mentions:
   - title: "René Pickhardt disclosed fee ransom attack affecting multiple LN implementations"
     url: /en/newsletters/2020/06/24/#ln-fee-ransom-attack
 
-  - title: "MilkSad team disclosed CVE-2023-39910 insecure entropy in Libbitcoin `bx` command"
+  - title: "Milk Sad team disclosed CVE-2023-39910 insecure entropy in Libbitcoin `bx` command"
     url: /en/newsletters/2023/08/09/#libbitcoin-bitcoin-explorer-security-disclosure
 
   - title: "Matt Morehouse disclosed fake channels vulnerability against four major LN node implementations"
@@ -73,9 +73,9 @@ optech_mentions:
     url: /en/newsletters/2023/10/25/#replacement-cycling-vulnerability-against-htlcs
 
 ## Optional.  Same format as "primary_sources" above
-# see_also:
-#   - title:
-#     link:
+see_also:
+  - title: "Common Vulnerabilities and Exposures (CVEs)"
+    link: topic cves
 
 ## Optional.  Force the display (true) or non-display (false) of stub
 ## topic notice.  Default is to display if the page.content is below a


### PR DESCRIPTION
Also add a link from Responsible Disclosures to CVEs

Note: I also wanted to add one of the CVE numbers for the replacement cycling attack, but those are still only reserved, e.g. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40231

(Also, I think I probably messed up with the CVE page.  The goal was to have a page that described all major security disclosures that have been discussed by Optech, but some things we've discussed this year (e.g. Matt Moorehouse's fake channels DoS disclosure) don't have CVEs.  I think in a future topic update we should look at creating a new page that includes everything have have the CVEs page redirect to it.)