### PR TITLE
Build: remove Travis CI bundler update directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,5 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-# xenial builds fail if you don't update bundler
 before_install:
-  - yes | gem update --system
   - sudo apt install optipng


### PR DESCRIPTION
One does not simply remove the command that is required in order to not break the builds but which is also currently breaking the builds

![image](https://github.com/bitcoinops/bitcoinops.github.io/assets/1615772/276a822f-9358-444c-8916-3dca786012a7)

But it works(?)