### PR TITLE
Fix typos in Lightning

### DIFF
--- a/_posts/en/newsletters/2019-04-30-newsletter.md
+++ b/_posts/en/newsletters/2019-04-30-newsletter.md
@@ -75,7 +75,7 @@ endcomment %}
   times the minimum cost to create and spend a P2PKH output. A reference
   is made to a [2013 discussion][dust convo].
 
-- [History of transactions in Lighting Network.]({{bse}}85901) A LN
+- [History of transactions in Lightning Network.]({{bse}}85901) A LN
   beginner asks how the history of transactions conducted on LN for a
   user can be saved and how a payer receives a proof of payment. Mark H
   responds saying the LN wallet would need to save transaction history

--- a/_posts/en/newsletters/2019-12-11-newsletter.md
+++ b/_posts/en/newsletters/2019-12-11-newsletter.md
@@ -64,7 +64,7 @@ projects.
 (BIPs)][bips repo], and [Lightning BOLTs][bolts repo].*
 
 - [C-Lightning #3260][] adds new `createonion` and `sendonion` RPC
-  methods that allow external tools or C-Lighting plugins to create and
+  methods that allow external tools or C-Lightning plugins to create and
   send encrypted LN messages that the node itself doesn't necessarily
   understand.  Some use cases for this mechanism described in the PR
   include: cross-chain atomic swaps, rendez-vous routing (see [Newsletter

--- a/_posts/en/newsletters/2023-08-30-newsletter.md
+++ b/_posts/en/newsletters/2023-08-30-newsletter.md
@@ -18,7 +18,7 @@ infrastructure software.
 ## News
 
 - **Disclosure of past LN vulnerability related to fake funding:** Matt
-  Morehouse [posted][morehouse dos] to the Lighting-Dev mailing list
+  Morehouse [posted][morehouse dos] to the Lightning-Dev mailing list
   the summary of a vulnerability he had previously [responsibly
   disclosed][topic responsible disclosures] and which is now addressed
   in the latest versions of all popular LN implementations.  To

--- a/_posts/en/podcast/2023-02-16-newsletter-recap.md
+++ b/_posts/en/podcast/2023-02-16-newsletter-recap.md
@@ -976,7 +976,7 @@ something?
 **Alex Myers**: Yeah, there is ongoing discussion, I believe.  I think the spec
 needs to be cleaned up a bit, but I know in the mailing list, this has been
 discussed in the past, the next step.  So, this is just a completely
-experimental feature for Core Lighting in this release; it's an optional feature
+experimental feature for Core Lightning in this release; it's an optional feature
 bit, so it's definitely not anything that other nodes will expect you to have.
 But yeah, if it all looks good, this will definitely inform the spec going
 forward and hopefully can be integrated into the BOLTs.

--- a/_posts/en/podcast/2023-03-16-newsletter-recap.md
+++ b/_posts/en/podcast/2023-03-16-newsletter-recap.md
@@ -575,7 +575,7 @@ say an ABI is an API in some sense.
 _LND v0.16.0-beta.rc3_
 
 The last release candidate that we had is LND v0.16.0-beta.rc3, and a few weeks
-ago we had some folks on from the Core Lighting team to explain the upcoming
+ago we had some folks on from the Core Lightning team to explain the upcoming
 release, and I thought that was useful, as opposed to us trying to jump into
 each of these release candidates and explain for ourselves.  I think, Murch, if
 you agree, maybe this is something that we should bring in some LND folks next

--- a/_posts/en/podcast/2023-06-22-newsletter-recap.md
+++ b/_posts/en/podcast/2023-06-22-newsletter-recap.md
@@ -231,7 +231,7 @@ I think my questions are answered.
 **Thomas Voegtlin**: Yeah, okay.  My feeling is that I'm not sure whether, okay,
 I don't want to sound pessimistic, but I'm not sure whether my proposal is
 really understood well by everybody.  But I do see that both these companies who
-are designing the protocol, Lighting Labs and Async, they have this business
+are designing the protocol, Lightning Labs and Async, they have this business
 model either with the submarine swap service or with the JIT channels, and they
 do not open source their service.  So, I'm wondering whether there is a conflict
 of interest here, because the fact that they don't open source it means that

--- a/_posts/en/podcast/2023-09-14-newsletter-recap.md
+++ b/_posts/en/podcast/2023-09-14-newsletter-recap.md
@@ -932,7 +932,7 @@ paid.  And so there's all these kinds of things you can layer on top that PTLCs
 are quite nice for.
 
 It also, if I remember right, it can also help reduce the amount of state that
-Lighting nodes have to store with some tricks.  So that's kind of the what and
+Lightning nodes have to store with some tricks.  So that's kind of the what and
 why.  But I guess why now?  Basically, Taproot channel spec is getting close
 from what I understand from the LND folks, roastbeef et al, and the LDK folks
 have fairly advanced implementations and there's a spec being worked on.  So,

--- a/_posts/en/podcast/2023-10-26-newsletter-recap.md
+++ b/_posts/en/podcast/2023-10-26-newsletter-recap.md
@@ -32,7 +32,7 @@ open-source Bitcoin developers, joined by my co-host, Murch.
 
 **Mike Schmidt**: And t-bast.
 
-**Bastien Teinturier**: Hi, I'm t-Bast, I work on Eclair and the lighting
+**Bastien Teinturier**: Hi, I'm t-Bast, I work on Eclair and the Lightning
 specification at ACINQ.
 
 **Mike Schmidt**: Fabien?


### PR DESCRIPTION
Fixes several instances of "Lighting" instead of "Lightning".