### PR TITLE
Replace hyphens with en dashes

### DIFF
--- a/_posts/en/newsletters/2018-10-09-newsletter.md
+++ b/_posts/en/newsletters/2018-10-09-newsletter.md
@@ -103,7 +103,7 @@ appeared in the forward blocks.
 
 This talk describes an alternative to the Schnorr
 signature scheme described in the [MuSig paper][] that makes use of [pairing-based cryptography][],
-specifically an adaptation of the [Boneh-Lynn-Shacham (BLS) signature
+specifically an adaptation of the [Boneh--Lynn--Shacham (BLS) signature
 scheme][bls sigs].  Although pairing-based schemes require an additional
 fundamental security assumption beyond those made by both Bitcoin's
 current ECDSA scheme and proposed Schnorr scheme, the authors present

--- a/_posts/en/newsletters/2019-04-23-newsletter.md
+++ b/_posts/en/newsletters/2019-04-23-newsletter.md
@@ -142,7 +142,7 @@ backported to its pending release.*
   values seem high, recall this is for a simulation network more than 25
   times the size of the current mainnet network and 1,000 times the size
   of the network a bit over a year ago.)  A notable part of this change
-  is C-Lightning switching from its rather unique [Bellman-Ford-Gibson
+  is C-Lightning switching from its rather unique [Bellman--Ford--Gibson
   (BFG)][bfg post] routing algorithm to a [slightly-customized][e197956]
   version of [Dijkstra][].
 
@@ -180,7 +180,7 @@ backported to its pending release.*
     (what developers call previous outputs (prevouts)).   Each of the
     scriptPubKeys is hashed to give each item the same size and then
     these items are sorted into a list that has duplicated elements
-    removed.  This list is then encoded using the [Golomb-Rice Coded
+    removed.  This list is then encoded using the [Golomb--Rice Coded
     Sets][gcs] (GCS) algorithm also described in BIP158, losslessly
     reducing the size of the list.  This specific basic filter provides
     enough information for anyone who knows a Bitcoin address to find

--- a/_posts/en/newsletters/2019-06-19-newsletter.md
+++ b/_posts/en/newsletters/2019-06-19-newsletter.md
@@ -42,7 +42,7 @@ Bitcoin infrastructure projects.
   Snigirev's idea eliminates the need to route the encrypted pre-image.
   He notes that the routing of a payment from Alice to Bob already
   requires them to have a common shared secret (derived using Elliptic
-  Curve Diffie-Hellman ([ECDH][]).  This secret can be hashed once to
+  Curve Diffie--Hellman ([ECDH][]).  This secret can be hashed once to
   produce a unique pre-image known to both of them, and that pre-image
   can be hashed again to be the payment hash.  To use this system,
   whenever Bob receives a payment to a hash that he didn't create an

--- a/_posts/en/newsletters/2019-09-04-newsletter.md
+++ b/_posts/en/newsletters/2019-09-04-newsletter.md
@@ -53,7 +53,7 @@ notes a few changes in popular Bitcoin infrastructure projects.
   addresses for her two outputs.  However, Bob has no way in this
   non-interactive protocol to tell Alice what addresses to use for his
   output.  Instead, Alice can use Bob's public key and [Elliptic Curve
-  Diffie-Hellman][ECDH] (ECDH) to derive a shared secret that Bob will
+  Diffie--Hellman][ECDH] (ECDH) to derive a shared secret that Bob will
   also be able to derive from Alice's public key.  With the shared
   secret and Bob's public key, Alice is able to create a new public key
   that only Bob can sign for.  That new public key is used to create the
@@ -124,6 +124,6 @@ notes a few changes in popular Bitcoin infrastructure projects.
 [bolts608]: /en/newsletters/2019/08/28/#bolts-608
 [bolts]: https://github.com/lightningnetwork/lightning-rfc/
 [snicker]: https://gist.github.com/AdamISZ/2c13fb5819bd469ca318156e2cf25d79
-[ecdh]: https://en.wikipedia.org/wiki/Elliptic_curve_Diffie-Hellman
+[ecdh]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie–Hellman
 [snicker email]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-September/017283.html
 [snicker blog]: https://joinmarket.me/blog/blog/snicker/

--- a/_posts/en/newsletters/2020-03-04-newsletter.md
+++ b/_posts/en/newsletters/2020-03-04-newsletter.md
@@ -175,7 +175,7 @@ candidates.*
 [sign to contract]: https://www.wpsoftware.net/andrew/secrets/slides.pdf
 [secp s2c]: https://github.com/bitcoin-core/secp256k1/pull/589
 [secp nonce]: https://github.com/bitcoin-core/secp256k1/pull/590
-[ecdh]: https://en.wikipedia.org/wiki/Elliptic_curve_Diffie-Hellman
+[ecdh]: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie–Hellman
 [ecies]: https://en.wikipedia.org/wiki/Integrated_Encryption_Scheme
 [bip340 update]: #updates-to-bip340-schnorr-keys-and-signatures
 [news83 eclair determ]: /en/newsletters/2020/02/05/#eclair-1295

--- a/_posts/en/newsletters/2021-04-28-newsletter.md
+++ b/_posts/en/newsletters/2021-04-28-newsletter.md
@@ -80,7 +80,7 @@ Bitcoin infrastructure software.
     signature object for the adaptors, so it uses `OP_CHECKMULTISIG` and
     is not quite as scriptless as before.  The separated construction also requires a [security
     warning][ecdh warning] related to reusing some of the involved keys
-    with Elliptic Curve Diffie Hellman (ECDH) key exchange and ElGamal
+    with Elliptic Curve Diffie--Hellman (ECDH) key exchange and ElGamal
     encryption.  Beyond that, this technique makes signature adaptors entirely
     usable on Bitcoin today, and it's what various [DLC][topic dlc]
     projects have been using.

--- a/_posts/en/newsletters/2022-08-17-newsletter.md
+++ b/_posts/en/newsletters/2022-08-17-newsletter.md
@@ -27,7 +27,7 @@ infrastructure software.
 
     This week, Lloyd Fournier [posted][fournier dlc-dev] to the DLC-Dev
     mailing list about the benefits of having an oracle make their
-    attestation using Boneh-Lynn-Shacham ([BLS][]) signatures.  Bitcoin
+    attestation using Boneh--Lynn--Shacham ([BLS][]) signatures.  Bitcoin
     does not support BLS signatures and a soft fork would be required to
     add them, but Fournier links to a [paper][fournier et al] he
     co-authored that describes how information can be securely extracted

--- a/_posts/en/newsletters/2022-12-21-newsletter.md
+++ b/_posts/en/newsletters/2022-12-21-newsletter.md
@@ -424,7 +424,7 @@ any changes to the LN protocol.
 
 {:#dlc-bls}
 Lloyd Fournier [wrote][news213 bls] about the benefits of having
-[DLC][topic dlc] oracles make their attestations using Boneh-Lynn-Shacham
+[DLC][topic dlc] oracles make their attestations using Boneh--Lynn--Shacham
 ([BLS][]) signatures.  Bitcoin does not support BLS signatures and a
 soft fork would be required to add them, but Fournier links to a paper
 he co-authored that describes how information can be securely extracted

--- a/_posts/en/newsletters/2023-06-28-newsletter.md
+++ b/_posts/en/newsletters/2023-06-28-newsletter.md
@@ -209,7 +209,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
   indistinguishable from random data. The `ellswift` module provides functions
   for encoding and decoding public keys in the new format as well as
   convenience functions to generate new uniformly-random keys and perform
-  an Elliptic Curve Diffie-Hellman key exchange (ECDH) on ellswift-encoded
+  an Elliptic Curve Diffie--Hellman key exchange (ECDH) on ellswift-encoded
   keys. The ellswift-based ECDH is to be used in establishing connections
   for the [version 2 P2P encrypted transport][topic v2 p2p transport] protocol ([BIP324][]). {% assign timestamp="1:40:37" %}
 

--- a/_posts/en/newsletters/2023-08-02-newsletter.md
+++ b/_posts/en/newsletters/2023-08-02-newsletter.md
@@ -38,7 +38,7 @@ Bitcoin infrastructure software.
     related to the specific problem and of [even more generalized blind
     schnorr signing][generalized blind schnorr].  Also mentioned was a
     year-old [gist][somsen gist] by Ruben Somsen about a 1996 protocol
-    for blind [Diffie-Hellman (DH) key exchange][dhke], which can be used for
+    for blind [Diffie--Hellman (DH) key exchange][dhke], which can be used for
     blinded ecash.  [Lucre][] and [Minicash][] are previous
     implementations of this scheme unrelated to Bitcoin, and [Cashu][]
     is an implementation related to Minicash that also integrates

--- a/_posts/en/newsletters/2023-10-04-newsletter.md
+++ b/_posts/en/newsletters/2023-10-04-newsletter.md
@@ -117,7 +117,7 @@ infrastructure software.
     LN-Symmetry would require a consensus change, which seems unlikely
     to happen in the near future, so a [follow-up post][zmnscpxj
     sidepools2] by ZmnSCPxj appears to be focusing on duplex payment
-    channels (which ZmnSCPxj calls "Decker-Wattenhofer" after the
+    channels (which ZmnSCPxj calls "Decker--Wattenhofer" after the
     researchers who first proposed them).  A downside of duplex payment
     channels is that they can't be kept open indefinitely, although
     ZmnSCPxj's analysis indicates they can probably be kept open for

--- a/_posts/en/newsletters/2023-11-29-newsletter.md
+++ b/_posts/en/newsletters/2023-11-29-newsletter.md
@@ -54,7 +54,7 @@ answers posted since our last update.*
   Pieter Wuille describes the differences between multisignatures, signature
   aggregation, key aggregation, and Bitcoin multisig and notes several related
   schemes including [BIP340][] [schnorr signatures][topic schnorr signatures],
-  [MuSig2][topic musig], FROST, and Bellare-Neven 2006.  {% assign timestamp="38:49" %}
+  [MuSig2][topic musig], FROST, and Bellare--Neven 2006.  {% assign timestamp="38:49" %}
 
 - [Is it advisable to operate a release candidate full node on mainnet?]({{bse}}120375)
   Vojtěch Strnad and Murch point out that running Bitcoin Core release

--- a/_posts/en/podcast/2022-08-18-newsletter-recap.md
+++ b/_posts/en/podcast/2022-08-18-newsletter-recap.md
@@ -125,7 +125,7 @@ taproot world.
 So yeah, we can now perhaps move on to what our most recent research is, is that
 we managed to make practical, I would say this is the major outcome, although I
 think there are some really interesting things inside this, but the major
-outcome for DLCs is that we can have the oracle attest using Boneh-Lynn-Shacham
+outcome for DLCs is that we can have the oracle attest using Boneh--Lynn--Shacham
 (BLS) signatures, which are signatures on a different curve, different
 properties to the elliptic curve that Bitcoin uses for its cryptography.  And
 the interesting thing about BLS signatures is that they are deterministic, and

--- a/_posts/en/podcast/2022-08-25-newsletter-recap.md
+++ b/_posts/en/podcast/2022-08-25-newsletter-recap.md
@@ -87,7 +87,7 @@ you reuse addresses, that's very bad for privacy, because any reuse of the same
 scriptPubKey will make it immediately obvious that the same entity is involved
 in a transaction.  However, if you publish a pubkey, somebody can use their
 private key to generate a shared secret.  And essentially, some of you might
-have heard of the Diffie-Hellman handshake, which is the observation that a
+have heard of the Diffie--Hellman handshake, which is the observation that a
 public key multiplied by a private key of the other party gets the same result
 as a private key multiplied by the public key of the other party.  So, public
 key and private key versus private key and public key of the corresponding

--- a/_posts/en/podcast/2022-12-01-newsletter-recap.md
+++ b/_posts/en/podcast/2022-12-01-newsletter-recap.md
@@ -696,7 +696,7 @@ experimental modules are now included by default when you build the libsecp, and
 those modules are extra keys for working with x-only pubkeys, ECDH, and schnorr
 signatures.
 
-**Mark Erhardt**: Elliptic Curve Diffie-Hellman.  It's a way to generate a
+**Mark Erhardt**: Elliptic Curve Diffie--Hellman.  It's a way to generate a
 shared secret between two parties.
 
 **Mike Schmidt**: And so, these additional modules, which were behind and

--- a/_posts/en/podcast/2023-01-26-newsletter-recap.md
+++ b/_posts/en/podcast/2023-01-26-newsletter-recap.md
@@ -681,7 +681,7 @@ the answer from sipa that's on the Stack Exchange for the details there; unless,
 Murch, do you want to take a crack at the BLS cryptographic assumptions, or
 shall we point them to the Stack Exchange?
 
-**Mark Erhardt**: I can talk a little bit about that.  So, Boneh-Lynn-Shacham
+**Mark Erhardt**: I can talk a little bit about that.  So, Boneh--Lynn--Shacham
 signatures or BLS signatures, are a fairly new construction, I think, and
 they're very attractive in that they're small and they can be non-interactively
 aggregated.  So, I think in the context of Schnorr signatures, some people might

--- a/_posts/en/podcast/2023-02-02-newsletter-recap.md
+++ b/_posts/en/podcast/2023-02-02-newsletter-recap.md
@@ -233,7 +233,7 @@ verification on it.  And you can just pull one of these protocols off the shelf.
 In the serverless payjoin case, that's NNpsk0, meaning neither the sender nor
 the receiver have a long-term key and they pre-share a key in the first message.
 But I think we could even get rid of the noise NNpsk0 if you just did a
-Diffie-Hellman key exchange between the sender and the receiver.  So, you'd have
+Diffie--Hellman key exchange between the sender and the receiver.  So, you'd have
 to wait until the key exchange was established and then the receiver could sign
 the payload they send back to the sender, which is the payjoin PSBT, with the
 key related to their initial address, to do authentication.  I'm a little off of

--- a/_posts/en/podcast/2023-08-10-newsletter-recap.md
+++ b/_posts/en/podcast/2023-08-10-newsletter-recap.md
@@ -915,10 +915,10 @@ So, that first PR for Core isn't really talking about how we do it in the
 wallet, how we parse the address, and it's more just, how do we make sure the
 right primitives are in Core so that we can implement this protocol?  So, for
 example, with silent payments, we use the private keys of the UTXOs that you
-want to spend to do the Diffie-Hellman step.  So, we needed to add some
+want to spend to do the Diffie--Hellman step.  So, we needed to add some
 functions in Bitcoin Core so that we could add private keys together.  For the
 receiver, they look at a transaction and they look at the public keys and then
-they want to add those public keys together to do the Diffie-Hellman step.  So,
+they want to add those public keys together to do the Diffie--Hellman step.  So,
 we needed to add some functions to Bitcoin Core for adding public keys.
 
 Then, we added some functions that do the silent payments protocol.  And then,

--- a/_posts/en/podcast/2023-08-17-newsletter-recap.md
+++ b/_posts/en/podcast/2023-08-17-newsletter-recap.md
@@ -170,7 +170,7 @@ significant is, scanning for multiple silent payment addresses essentially
 doubles the cost.  Sure, the information that you need about every transaction
 in order to check whether it is a silent payment to you, that remains the same
 for checking on multiple, but the calculations and ECDSA operations, the
-Diffie-Hellman and so forth, you would have to repeat for every separate silent
+Diffie--Hellman and so forth, you would have to repeat for every separate silent
 payment address that you make.  So having a number of silent payment addresses
 that you have posted, which would be the case if you have an expiration date on
 any of them, would mean that you significantly increase the cost for scanning

--- a/_posts/en/podcast/2023-09-07-newsletter-recap.md
+++ b/_posts/en/podcast/2023-09-07-newsletter-recap.md
@@ -532,7 +532,7 @@ one is to the libsecp repository.  It is the 0.4.0 release, and there's a couple
 of things that I think are worth highlighting here.  First is that this release
 adds a new module to libsecp, called ellswift, which implements ElligatorSwift,
 and that's in libsecp.  This will be used for encoding public keys and x-only
-Diffie-Hellman key exchange for them.  And ElligatorSwift allows representing
+Diffie--Hellman key exchange for them.  And ElligatorSwift allows representing
 libsecp256k1 pubkeys as 64-byte arrays, which cannot be distinguished from
 uniformly random data.  And this technology is part of what BIP324 is using, as
 part of the P2P encrypted transport protocol project that's currently in

--- a/_posts/en/podcast/2023-11-30-newsletter-recap.md
+++ b/_posts/en/podcast/2023-11-30-newsletter-recap.md
@@ -595,7 +595,7 @@ signature aggregation, what is multisignature, and what is this thing in Bitcoin
 that we call multisig.  And then he also, based on the definitions of those
 terms, jumped into a bunch of related schemes that are applicable in Bitcoin,
 including schnorr signatures as defined in BIP340, MuSig2, Frost, and I don't
-think this one is actually applicable to Bitcoin, but the Bellare-Neven 2006
+think this one is actually applicable to Bitcoin, but the Bellare--Neven 2006
 scheme.  I don't know, Murch, how much you want to dig into any of those, or if
 that's an exercise for the listener.  What do you think?
 


### PR DESCRIPTION
Fixes multiple instances where hyphens are used instead of en dashes in names created by joining the names of authors, such as Diffie–Hellman or Boneh–Lynn–Shacham.