### PR TITLE
Topics: export as JSON

### DIFF
--- a/topics.json
+++ b/topics.json
@@ -1,0 +1,23 @@
+---
+---
+{% capture raw_categories %}
+{%- for topic in site.topics -%}
+  {%- for category in topic.categories -%}
+    {{category}}|
+  {%- endfor -%}
+{%- endfor -%}
+{% endcapture %}
+{% assign categories = raw_categories | split: "|" | sort_natural | uniq %}
+[
+  {% for topic in site.topics %}
+    {% assign topic_slug = topic.shortname | default: topic.title | slugify %}
+      {
+        "title": {{ topic.title | jsonify }},
+        "slug": {{ topic_slug | jsonify }},
+        "optech_url": "{{ site.url }}{{ topic.url }}",
+        "categories": {{ topic.categories | jsonify }},
+        "aliases":  {{ topic.aliases | jsonify }},
+        "excerpt": {{ topic.excerpt | jsonify }}
+      }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]


### PR DESCRIPTION
Exporting topics in a JSON format allows **seamless utilization of this well-thought-out resource by anyone**.

After this change, the topics (alongside their metadata) will be available at `https://bitcoinops.org/topics.json`
Example of exported JSON:
```
[
  {
    "title": "Accountable Computing Contracts",
    "slug": "acc",
    "optech_url": "https://bitcoinops.org/en/topics/acc/",
    "categories": [
      "Contract Protocols"
    ],
    "aliases": [
      "BitVM",
      "Zero-Knowledge Contingent Payments (ZKCP)"
    ],
    "excerpt": "**Accountable Computing Contracts (ACC)** are payments that the receiving party can spend if they verifiably run a specified function on a specified set of inputs.  If the receiving party doesn't run the function or doesn't run it correctly, the paying party can reclaim the payment after a period of time.\n"
  },
  ...
]
```

We are already using this functionality for https://btctranscripts.com/tags ([implementation details](https://github.com/bitcointranscripts/bitcointranscripts.github.io/pull/56))