### PR TITLE
Prefer blockchain over block chain

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -93,7 +93,7 @@ beginning of a sentence).
 | Use | Don't use | Notes |
 |-|-|-|
 | anti fee sniping | anti-fee sniping, anti-fee-sniping | |
-| block chain | blockchain | |
+| blockchain | block chain | "block chain" is acceptable in unmodified older documents |
 | chain split | chainsplit | |
 | CPFP or Child Pays For Parent | Child-Pays-For-Parent | |
 | coinjoin | Coinjoin, coinJoin or coin-join | |


### PR DESCRIPTION
The term blockchain has become accepted since the style guide was written in 2019. There are already significantly more instances of "blockchain" than "block chain" in this repository.