### PR TITLE
Remove links to dashboard

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,7 +25,6 @@
             <a class="page-link" href="/en/topics/">Topics</a>
             <a class="page-link" href="/en/workshops/">Workshops</a>
             <a class="page-link" href="/en/compatibility/">Compatibility</a>
-            <a class="page-link" href="https://dashboard.bitcoinops.org/">Dashboard</a>
         </div>
       </nav>
     {%- endif -%}

--- a/_includes/specials/bech32/02-stats.md
+++ b/_includes/specials/bech32/02-stats.md
@@ -6,8 +6,7 @@ track various segwit adoption statistics so that you can decide whether
 it's popular enough that your wallet or service might become an outlier
 by failing to support it soon.
 
-Optech tracks statistics about segwit use on our [dashboard][optech
-dashboard]; another site tracking related statistics is [P2SH.info][].
+A site tracking related statistics is [P2SH.info][].
 We see an average of about 200 outputs per block are sent to native
 segwit addresses (bech32).  Those outputs are then spent in about 10% of all
 Bitcoin transactions.  That makes payments involving native segwit addresses
@@ -47,7 +46,6 @@ bech32 sending support so that all wallets that want to take advantage
 of native segwit can do so in the next few months.
 
 [bech32 easy]: /en/newsletters/2019/03/19/#bech32-sending-support
-[optech dashboard]: https://dashboard.bitcoinops.org/
 [p2sh.info]: https://p2sh.info/
 [bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
 [when segwit]: https://whensegwit.com/

--- a/_includes/specials/bech32/zh/02-stats.md
+++ b/_includes/specials/bech32/zh/02-stats.md
@@ -1,6 +1,6 @@
 正如[上周所述][bech32 easy]，实现 segwit 仅花费应当是容易的。然而我们怀疑一些管理者可能会想知道是否有足够多人使用 segwit 来证明他们的团队值得在此方面花费开发精力。本周，我们查看了追踪各种 segwit 采用统计数据的网站，以便你可以决定它是否足够流行，以至于你的钱包或服务如果不支持它会成为异类。
 
-Optech 在我们的[仪表盘][optech dashboard]上追踪 segwit 使用的统计数据；另一个追踪相关统计数据的网站是 [P2SH.info][]。我们看到平均每个区块大约有 200 个输出被发送到原生 segwit 地址 (bech32)。这些输出随后在大约 10% 的比特币交易中被花费。使得涉及原生 segwit 地址的支付比几乎所有的山寨币都更受欢迎。
+Optech 在我们的仪表盘上追踪 segwit 使用的统计数据；另一个追踪相关统计数据的网站是 [P2SH.info][]。我们看到平均每个区块大约有 200 个输出被发送到原生 segwit 地址 (bech32)。这些输出随后在大约 10% 的比特币交易中被花费。使得涉及原生 segwit 地址的支付比几乎所有的山寨币都更受欢迎。
 
 ![Optech 仪表盘 segwit 使用统计数据的截图](/img/posts/2019-03-segwit-usage.png)
 
@@ -13,7 +13,6 @@ Optech 在我们的[仪表盘][optech dashboard]上追踪 segwit 使用的统计
 统计数据和兼容性数据显示 segwit 已经得到了良好的支持并且经常使用，但仍有一些值得注意的迟缓者尚未提供支持。我们希望我们的活动和其他社区努力将帮助说服这些迟缓者赶上 bech32 发送支持，以便所有希望利用原生 segwit 的钱包可以在接下来的几个月中做到这一点。
 
 [bech32 easy]: /zh/newsletters/2019/03/19/#bech32-发送支持
-[optech dashboard]: https://dashboard.bitcoinops.org/
 [p2sh.info]: https://p2sh.info/
 [bech32 adoption]: https://en.bitcoin.it/wiki/Bech32_adoption
 [when segwit]: https://whensegwit.com/

--- a/_posts/en/2018-09-04-dashboard-announcement.md
+++ b/_posts/en/2018-09-04-dashboard-announcement.md
@@ -16,6 +16,9 @@ excerpt: >
 {:.post-meta}
 *by [Marcin Jachymiak](https://github.com/marcinja)<br>Intern at Bitcoin Optech*
 
+**Note: As of February 2025, the Bitcoin Optech Dashboard has been retired and
+is no longer accessible.**
+
 This summer I was an intern for [Bitcoin Optech](/), working on a Bitcoin metrics dashboard. In this post I'll be describing the purpose of the dashboard and how it was implemented.
 
 The goal of the Optech dashboard is to show a variety of metrics of how effectively blockspace is being used. Important metrics are those that show activity like:
@@ -23,9 +26,6 @@ The goal of the Optech dashboard is to show a variety of metrics of how effectiv
  - [consolidations](https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation): combining many UTXOs in a single UTXO during low fee period, to avoid paying a higher fee in the future
  - dust creation: creation of UTXOs that cost more to spend than they have value, at different fee-rates
  - SegWit adoption: creation of and spending from SegWit outputs
-
-
-The dashboard is live and is showing these stats and more at [dashboard.bitcoinops.org](https://dashboard.bitcoinops.org).
 
 The dataset used for the dashboard is also saved as a directory of JSON files, updated nightly. You can download the zipped dataset from our [S3 bucket](http://dashboard.dataset.s3.us-east-2.amazonaws.com/backups/bitcoinops-dataset.tar.gz). If you just want the JSON file for a specific block, you can get it at: `http://dashboard.dataset.s3.us-east-2.amazonaws.com/blocks/BLOCK_NUMBER.json` If you'd rather recreate the data using your own full node (it might take a few days), you can use the code with instructions at [github.com/bitcoinops/btc-dashboard](https://github.com/bitcoinops/btc-dashboard).
 
@@ -119,4 +119,4 @@ err := worker.pgClient.Insert(&data.DashboardDataRow)
 At this point I spent more time writing code to get information *out* of InfluxDB then on inserting it into Postgres. Once the switch to Postgres was done, the dashboard graphs came up much faster in Grafana.
 
 ## Results
-You can use the Bitcoin Optech dashboard to see these stats as historical trends from the entire history of Bitcoin, and also from new blocks as they get confirmed. All of this is available live on our dashboard at [dashboard.bitcoinops.org](https://dashboard.bitcoinops.org)!
+You can use the Bitcoin Optech dashboard to see these stats as historical trends from the entire history of Bitcoin, and also from new blocks as they get confirmed. All of this is available live on our dashboard!

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -30,7 +30,7 @@ level of conversation around scaling Bitcoin][announcement]. This year, we’ve:
   book pages, they'd be over 100 pages long (36,000 words at 350 words per
   page). Over 1,800 Bitcoin engineers and enthusiasts have subscribed to the
   newsletter.
-- Built a [dashboard][] to track the state of the Bitcoin network and the
+- Built a dashboard to track the state of the Bitcoin network and the
   adoption rate of scaling technologies. Marcin wrote about [building the
   dashboard in an Optech blog post][dashboard blog post].
 - Started writing the first chapter of our [Scaling Book][scaling book].
@@ -82,7 +82,6 @@ scale.
 [announcement]: /en/announcing-bitcoin-optech/
 [workshops]: /en/workshops/
 [newsletters]: /en/newsletters/
-[dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /en/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md

--- a/_posts/en/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/en/2019-02-11-rbf-in-the-wild.md
@@ -405,7 +405,6 @@ reach out to [mike@bitcoinops.org](mailto:mike@bitcoinops.org).
 [announcement]: /en/announcing-bitcoin-optech/
 [workshops]: /en/workshops/
 [newsletters]: /en/newsletters/
-[dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /en/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md

--- a/_posts/en/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/en/2019-02-11-rbf-in-the-wild.md
@@ -72,8 +72,7 @@ incentive issues mentioned above by requiring higher transaction fees for
 replacement transactions.
 
 ![rbf-transactions-in-2018](/img/posts/rbf-in-the-wild/rbf-transactions-in-2018.png)
-*~6% of transactions signaled opt-in RBF in 2018. Source: [Bitcoin Optech
-Dashboard](https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1&from=1514835702976&to=1546285302976)*
+*~6% of transactions signaled opt-in RBF in 2018.*
 
 ## What was evaluated?
 

--- a/_posts/en/2021-02-19-pausing-memberships.md
+++ b/_posts/en/2021-02-19-pausing-memberships.md
@@ -33,7 +33,7 @@ members. We've undertaken projects in two broad areas:
 1. High-quality online documentation and material for Bitcoin engineers, freely
    available to everyone and released under permissive open source licenses.
    Those materials include our [weekly newsletter][], [blog posts and field
-   reports][], [dashboard][], [compatibility matrix][], [topic index][] and
+   reports][], [compatibility matrix][], [topic index][] and
    [taproot workbooks][].
 
 2. In-person [workshops][] and informal dinners and social events, open to

--- a/_posts/en/2021-02-19-pausing-memberships.md
+++ b/_posts/en/2021-02-19-pausing-memberships.md
@@ -70,10 +70,8 @@ future we'll be able to get back to running workshops and social events.
 [Optech launch]: /en/announcing-bitcoin-optech/
 [weekly newsletter]: /en/newsletters/
 [blog posts and field reports]: /en/blog/
-[dashboard]: https://dashboard.bitcoinops.org/
 [compatibility matrix]: /en/compatibility/
 [topic index]: /en/topics/
 [taproot workbooks]: /en/schnorr-taproot-workshop/
 [workshops]: /en/workshops/
 [Haegwan Kim]: https://twitter.com/haegwankim
-

--- a/_posts/en/newsletters/2018-08-07-newsletter.md
+++ b/_posts/en/newsletters/2018-08-07-newsletter.md
@@ -30,13 +30,13 @@ Bitcoin Core, LND, and C-Lightning projects.
   It’s a good time to [consolidate UTXOs][consolidate info].
 
 - Adoption of opt-in RBF remains fairly low, but has materially grown the past
-  year, increasing from [1.5% to 5.7% of transactions][rbf data]. This data was
+  year, increasing from 1.5% to 5.7% of transactions. This data was
   sourced from Optech's beta dashboard, which we encourage people to try out and
   provide us feedback!
 
   ![{{img1_label}}](/img/posts/rbf.png)
   *{{img1_label}},
-  source: [Optech dashboard][rbf data]*
+  source: Optech dashboard*
 
 ## News
 
@@ -148,6 +148,5 @@ repo], and [C-lightning][core lightning repo].*
 [contract thread]: https://gnusha.org/url/https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-August/001383.html
 [fee metrics]: https://statoshi.info/dashboard/db/fee-estimates
 [consolidate info]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation
-[rbf data]: https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1&from=now-1y&to=now
 [newsletter #5]: /en/newsletters/2018/07/24/#first-use-of-output-script-descriptors
 [output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-08-14-newsletter.md
+++ b/_posts/en/newsletters/2018-08-14-newsletter.md
@@ -46,11 +46,11 @@ It’s a good time to [consolidate UTXOs][consolidate info].
 
 - The number of transactions in each block. This metric is vaguely periodic in that it has peaks at around 13:00 to 17:00 UTC each
 day. The graph below shows a 25-block moving average of the number of transactions. It was sourced from the
-[Optech beta dashboard][periodic txn data] that we encourage people to try out and provide us feedback about.
+Optech beta dashboard that we encourage people to try out and provide us feedback about.
 
 ![{{img1_label}}](/img/posts/transactions-spikes.png)
 *{{img1_label}},
-source: [Optech dashboard][periodic txn data]*
+source: Optech dashboard*
 
 ## News
 
@@ -218,4 +218,3 @@ users and developers highly appreciate that work.*
 [fee metrics]: https://statoshi.info/dashboard/db/fee-estimates
 [consolidate info]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation
 [btc hash rate]: https://fork.lol/pow/hashrate
-[periodic txn data]: https://dashboard.bitcoinops.org/d/K7C9p0vmz/btc-number-of-txns-total-fee-per-block-volume?panelId=4&fullscreen&orgId=1

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -359,8 +359,7 @@ developing the protocol has proceeded.
 
 After starting [Optech][] in May, we've signed up 15 companies as
 members, held two [workshops][optech workshops], produced 28 weekly
-[newsletters][optech newsletters], built a [dashboard][optech
-dashboard], and made a solid start on a book about
+[newsletters][optech newsletters], built a dashboard, and made a solid start on a book about
 individually-deployable scaling techniques.  To learn more about what we
 accomplished in 2018 and what we have planned for 2019, please see our
 short [annual report][optech annual report].
@@ -542,7 +541,7 @@ substantially lower costs than competitors that haven't optimized.
 within each block, smoothed using a simple moving average over 1,000
 blocks.  Empty blocks (those with only a generation transaction) were
 excluded from analysis.  Most of the above statistics may be obtained
-from the [Optech Dashboard][], which is updated after every block.
+from the Optech Dashboard, which is updated after every block.
 Note: After 1 January 2019, we will update the plots in this article to
 reflect all of 2018, at which point this sentence will be deleted.*
 </div>
@@ -658,7 +657,6 @@ newsletters] or follow our [RSS feed][].*
 [onchain pizza]: https://en.bitcoin.it/wiki/Laszlo_Hanyecz
 [optech]: /
 [optech annual report]: /en/2018-optech-annual-report/
-[optech dashboard]: https://dashboard.bitcoinops.org/
 [optech newsletters]: /en/newsletters/
 [optech workshops]: /en/workshops/
 [p2ep]: https://blockstream.com/2018/08/08/improving-privacy-using-pay-to-endpoint/

--- a/_posts/en/newsletters/2021-10-20-newsletter.md
+++ b/_posts/en/newsletters/2021-10-20-newsletter.md
@@ -166,7 +166,7 @@ seems worth publicizing the decision to use this value -->
 - [Bitcoin Core #22539][] considers replacement transactions seen by the
   local node when generating fee estimates.  Replacement transactions
   were [previously][bitcoin core #9519] not considered when they rarely
-  occurred, but currently about [20% of all transactions][optech rbf] send the
+  occurred, but currently about 20% of all transactions send the
   [BIP125][] signal for opting in to replacement and [several
   thousand][0xb10c stats] replacements occur in a typical day.
 
@@ -203,7 +203,6 @@ seems worth publicizing the decision to use this value -->
 [news170 ln cve]: /en/newsletters/2021/10/13/#ln-spend-to-fees-cve
 [BDK 0.12.0]: https://github.com/bitcoindevkit/bdk/releases/tag/v0.12.0
 [0xb10c stats]: https://github.com/bitcoin/bitcoin/pull/22539#issuecomment-885763670
-[optech rbf]: https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1
 [zeus v0.6.0-alpha3]: https://github.com/ZeusLN/zeus/releases/tag/v0.6.0-alpha3
 [news167 lightning addresses]: /en/newsletters/2021/09/22/#lightning-address-identifiers-announced
 [sparrow 1.5.0]: https://github.com/sparrowwallet/sparrow/releases/tag/1.5.0

--- a/_posts/zh/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/zh/2019-02-11-rbf-in-the-wild.md
@@ -245,7 +245,6 @@ BRD 在替换交易上显示“失败”标签。在测试中，“失败”交�
 [announcement]: /zh/announcing-bitcoin-optech/
 [workshops]: /en/workshops/
 [newsletters]: /zh/newsletters/
-[dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /zh/dashboard-announcement/
 [scaling book]: https://github.com/bitcoinops/scaling-book
 [scaling book feebumping]: https://github.com/bitcoinops/scaling-book/blob/master/1.fee_bumping/fee_bumping.md

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -211,9 +211,6 @@ see_also:
 
   - title: Opt-in RBF FAQ
     link: https://bitcoincore.org/en/faq/optin_rbf/
-
-  - title: "Optech Dashboard: BIP125 usage"
-    link: https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1
 ---
 Different node software can use different RBF rules, so there have
 been several variations.  The most widely-used form of RBF today is

--- a/en/about.md
+++ b/en/about.md
@@ -12,13 +12,12 @@ order to lower costs and improve customer experiences.
 An initial focus for the group is working with its member organizations to
 reduce transaction sizes and minimize the effect of subsequent transaction fee
 increases.  We provide [workshops][],
-[weekly newsletters][], [original research][dashboard], [case studies
+[weekly newsletters][], [case studies
 and announcements][blog], a [podcast][], and help facilitate improved relations between
 businesses and the open source community.
 
 [workshops]: /en/workshops
 [weekly newsletters]: /en/newsletters/
-[dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/
 [podcast]: /en/podcast/
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Bitcoin Optech helps Bitcoin users and businesses integrate scaling
 technologies.
 
 We provide [workshops][], [weekly
-newsletters][], [original research][dashboard], [case studies and
+newsletters][], [case studies and
 announcements][blog], [analysis of Bitcoin software and
 services][compatibility], a [podcast][], and help facilitate improved relations between
 businesses
@@ -22,7 +22,6 @@ and the open source community.
 
 [workshops]: /en/workshops
 [weekly newsletters]: /en/newsletters/
-[dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/
 [podcast]: /en/podcast/
 [about]: /en/about


### PR DESCRIPTION
It appears that the dashboard is defunct, so for now it probably makes sense to remove the links to it.