### PR TITLE
Topics: rename two fields to be compatible with Hugo

### DIFF
--- a/_contrib/new-topic
+++ b/_contrib/new-topic
@@ -30,12 +30,12 @@ title: ${topic}
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - TODO
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_data/schemas/topics.yaml
+++ b/_data/schemas/topics.yaml
@@ -4,7 +4,7 @@ description: The topic object
 type: object
 required:
   - title
-  - categories
+  - topic-categories
   - excerpt
   - optech_mentions
 additionalProperties: false
@@ -17,7 +17,7 @@ properties:
     description: Short alternative name to use for creating Markdown reference links
     type: string
 
-  categories:
+  topic-categories:
     description: Which categories should list this topic?
     type: array
     additionalItems: false
@@ -45,7 +45,7 @@ properties:
         - Transaction Relay Policy
         - Wallet Collaboration Tools
 
-  aliases:
+  title-aliases:
     description: Other names for the topic?
     type: array
     items:

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -22,10 +22,10 @@ layout: post
 
   <!-- Build natural sentence-style list of aliases for this page's topic -->
   {% if page.aliases != nil %}
-    {% assign num_aliases = page.aliases | size %}
+    {% assign num_aliases = page.title-aliases | size %}
     {% capture aliases %}{:.center}{{newline}}*Also covering&nbsp;{% endcapture %}
     {% if num_aliases > 2 %}
-      {% for alias in page.aliases %}
+      {% for alias in page.title-aliases %}
         {% if forloop.last %}
           {% capture aliases %}{{aliases}}, and {{alias}}{% endcapture %}
         {% elsif forloop.first %}
@@ -35,7 +35,7 @@ layout: post
         {% endif %}
       {% endfor %}
     {% else %}
-      {% capture aliases %}{{aliases}}{{page.aliases | join: ' and '}}{% endcapture %}
+      {% capture aliases %}{{aliases}}{{page.title-aliases | join: ' and '}}{% endcapture %}
     {% endif %}
     {% assign aliases = aliases | append: '*' %}
   {% endif %}

--- a/_topics/en/acc.md
+++ b/_topics/en/acc.md
@@ -6,13 +6,13 @@ title: Accountable Computing Contracts
 shortname: ACC
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BitVM
   - Zero-Knowledge Contingent Payments (ZKCP)
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/accidental-confiscation.md
+++ b/_topics/en/accidental-confiscation.md
@@ -6,12 +6,12 @@ title: Accidental confiscation
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Transaction Relay Policy
 

--- a/_topics/en/adaptor-signatures.md
+++ b/_topics/en/adaptor-signatures.md
@@ -6,13 +6,13 @@ title: Adaptor signatures
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Signature adaptors
   - Scriptless scripts
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Privacy Enhancements
   - Scripts and Addresses

--- a/_topics/en/addr-v2.md
+++ b/_topics/en/addr-v2.md
@@ -2,12 +2,12 @@
 title: Addr v2
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/anchor-outputs.md
+++ b/_topics/en/anchor-outputs.md
@@ -2,12 +2,12 @@
 title: Anchor outputs
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Simplified commitments
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/annex.md
+++ b/_topics/en/annex.md
@@ -6,12 +6,12 @@ title: Annex
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/anonymity-networks.md
+++ b/_topics/en/anonymity-networks.md
@@ -6,13 +6,13 @@ title: Anonymity networks
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Tor
   - I2P
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/ark.md
+++ b/_topics/en/ark.md
@@ -6,12 +6,12 @@ title: Ark
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/asicboost.md
+++ b/_topics/en/asicboost.md
@@ -6,13 +6,13 @@ title: ASICBoost
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Overt ASICBoost
   - Covert ASICBoost
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Mining
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/assumeutxo.md
+++ b/_topics/en/assumeutxo.md
@@ -3,7 +3,7 @@ title: AssumeUTXO
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Consensus Enforcement
   - P2P Network Protocol
 

--- a/_topics/en/async-payments.md
+++ b/_topics/en/async-payments.md
@@ -6,12 +6,12 @@ title: Async payments
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/atomic-multipath.md
+++ b/_topics/en/atomic-multipath.md
@@ -6,13 +6,13 @@ title: Atomic multipath payments (AMPs)
 shortname: amp
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - AMP
   # Although common, I prefer not to put "OG AMP" in the alias list -harding
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Privacy Enhancements
 

--- a/_topics/en/bech32.md
+++ b/_topics/en/bech32.md
@@ -1,7 +1,7 @@
 ---
 title: Bech32(m)
 shortname: bech32
-aliases:
+title-aliases:
   - Bech32
   - Bech32m
   - BIP173
@@ -9,7 +9,7 @@ aliases:
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/bip70-payment-protocol.md
+++ b/_topics/en/bip70-payment-protocol.md
@@ -2,12 +2,12 @@
 title: BIP70 payment protocol
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Wallet Collaboration Tools
   - Invoicing
 

--- a/_topics/en/block-explorers.md
+++ b/_topics/en/block-explorers.md
@@ -2,12 +2,12 @@
 title: Block explorers
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Problems
   - Developer Tools
 

--- a/_topics/en/bls-signatures.md
+++ b/_topics/en/bls-signatures.md
@@ -6,12 +6,12 @@ title: BLS signatures
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/channel-announcements.md
+++ b/_topics/en/channel-announcements.md
@@ -6,12 +6,12 @@ title: Channel announcements
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/channel-commitment-upgrades.md
+++ b/_topics/en/channel-commitment-upgrades.md
@@ -6,12 +6,12 @@ title: Channel commitment upgrades
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/channel-factories.md
+++ b/_topics/en/channel-factories.md
@@ -3,12 +3,12 @@ title: Channel factories
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Contract Protocols
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/channel-jamming-attacks.md
+++ b/_topics/en/channel-jamming-attacks.md
@@ -6,12 +6,12 @@ title: Channel jamming attacks
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/client-side-validation.md
+++ b/_topics/en/client-side-validation.md
@@ -6,14 +6,14 @@ title: Client-side validation
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - RGB
   - Taro
   - Taproot Assets
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/cltv-expiry-delta.md
+++ b/_topics/en/cltv-expiry-delta.md
@@ -6,12 +6,12 @@ title: CLTV expiry delta
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/cluster-mempool.md
+++ b/_topics/en/cluster-mempool.md
@@ -6,12 +6,12 @@ title: Cluster mempool
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Transaction Relay Policy
   - Mining
 

--- a/_topics/en/codex32.md
+++ b/_topics/en/codex32.md
@@ -6,12 +6,12 @@ title: Codex32
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP93
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Backup and Recovery
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/coin-selection.md
+++ b/_topics/en/coin-selection.md
@@ -2,12 +2,12 @@
 title: Coin selection
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Privacy Enhancements
 

--- a/_topics/en/coinjoin.md
+++ b/_topics/en/coinjoin.md
@@ -3,7 +3,7 @@ title: Coinjoin
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/coinswap.md
+++ b/_topics/en/coinswap.md
@@ -6,12 +6,12 @@ title: Coinswap
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Contract Protocols
 

--- a/_topics/en/compact-block-filters.md
+++ b/_topics/en/compact-block-filters.md
@@ -2,14 +2,14 @@
 title: Compact block filters
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP157
   - BIP158
   - Neutrino protocol
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Lightweight Client Support
   - P2P Network Protocol

--- a/_topics/en/compact-block-relay.md
+++ b/_topics/en/compact-block-relay.md
@@ -6,12 +6,12 @@ title: Compact block relay
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP152
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Bandwidth Reduction
   - Mining
   - P2P Network Protocol

--- a/_topics/en/consensus-cleanup-soft-fork.md
+++ b/_topics/en/consensus-cleanup-soft-fork.md
@@ -4,7 +4,7 @@ shortname: consensus cleanup
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
   - Mining

--- a/_topics/en/countersign.md
+++ b/_topics/en/countersign.md
@@ -3,7 +3,7 @@ title: Countersign
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Security Enhancements
   - Privacy Enhancements

--- a/_topics/en/covenants.md
+++ b/_topics/en/covenants.md
@@ -3,7 +3,7 @@ title: Covenants
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
 

--- a/_topics/en/cpfp-carve-out.md
+++ b/_topics/en/cpfp-carve-out.md
@@ -2,12 +2,12 @@
 title: CPFP carve out
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Contract Protocols
   - Transaction Relay Policy

--- a/_topics/en/cpfp.md
+++ b/_topics/en/cpfp.md
@@ -3,12 +3,12 @@ title: "Child pays for parent (CPFP)"
 shortname: cpfp
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Ancestor feerate mining
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Mining
 

--- a/_topics/en/cross-input-signature-aggregation.md
+++ b/_topics/en/cross-input-signature-aggregation.md
@@ -6,12 +6,12 @@ title: Cross-input signature aggregation (CISA)
 shortname: cisa
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Half aggregation
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
 

--- a/_topics/en/cve-2018-17144.md
+++ b/_topics/en/cve-2018-17144.md
@@ -2,12 +2,12 @@
 title: CVE-2018-17144
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Duplicate inputs vulnerability
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/cve.md
+++ b/_topics/en/cve.md
@@ -8,7 +8,7 @@ shortname: cves
 ## Optional.  An entry will be added to the topics index for each alias
 #
 ## PUT IN NUMERICAL ORDER
-aliases:
+title-aliases:
   - CVE-2012-2459
   - CVE-2013-2292
   - CVE-2017-12842
@@ -21,7 +21,7 @@ aliases:
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
@@ -188,7 +188,7 @@ extra:
 {% endfor %}
 
 ### Other CVEs
-{% for alias in page.aliases %}
+{% for alias in page.title-aliases %}
   * {:#{{alias}}} **[{{alias}}]({{page.extra.cves[alias].link | default: "#CVE-LINK-NOT-PROVIDED"}}):** {{page.extra.cves[alias].summary}}
 
   {%- for mention in page.optech_mentions -%}

--- a/_topics/en/dandelion.md
+++ b/_topics/en/dandelion.md
@@ -1,9 +1,9 @@
 ---
 title: Dandelion
-aliases:
+title-aliases:
   - BIP156
 
-categories:
+topic-categories:
   - P2P Network Protocol
   - Privacy Enhancements
 

--- a/_topics/en/default-minimum-transaction-relay-feerates.md
+++ b/_topics/en/default-minimum-transaction-relay-feerates.md
@@ -6,12 +6,12 @@ title: Default minimum transaction relay feerates
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Transaction Relay Policy
   - Fee Management
   - Mining

--- a/_topics/en/discreet-log-contracts.md
+++ b/_topics/en/discreet-log-contracts.md
@@ -11,7 +11,7 @@ shortname: dlc
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Privacy Enhancements
 

--- a/_topics/en/dual-funding.md
+++ b/_topics/en/dual-funding.md
@@ -6,12 +6,12 @@ title: Dual funding
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Interactive funding protocol
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/duplicate-transactions.md
+++ b/_topics/en/duplicate-transactions.md
@@ -6,12 +6,12 @@ title: Duplicate transactions
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Block 1,983,702 problem
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
   - Soft Forks
 

--- a/_topics/en/ecash.md
+++ b/_topics/en/ecash.md
@@ -6,12 +6,12 @@ title: Ecash
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/eclipse-attacks.md
+++ b/_topics/en/eclipse-attacks.md
@@ -2,12 +2,12 @@
 title: Eclipse attacks
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Security Problems
 

--- a/_topics/en/eltoo.md
+++ b/_topics/en/eltoo.md
@@ -1,12 +1,12 @@
 ---
 title: Eltoo
 
-aliases:
+title-aliases:
   - LN-Symmetry
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Contract Protocols
 

--- a/_topics/en/ephemeral-anchors.md
+++ b/_topics/en/ephemeral-anchors.md
@@ -6,12 +6,12 @@ title: Ephemeral anchors
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Fee Management
   - P2P Network Protocol

--- a/_topics/en/erlay.md
+++ b/_topics/en/erlay.md
@@ -3,7 +3,7 @@ title: Erlay
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Bandwidth Reduction
 

--- a/_topics/en/exfiltration-resistant-signing.md
+++ b/_topics/en/exfiltration-resistant-signing.md
@@ -6,12 +6,12 @@ title: Exfiltration resistant signing
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Enhancements
   - Wallet Collaboration Tools
 

--- a/_topics/en/expiration-floods.md
+++ b/_topics/en/expiration-floods.md
@@ -6,13 +6,13 @@ title: Expiration floods
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Forced expiration spam
   - Flood and loot
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Lightning Network
   - Security Problems

--- a/_topics/en/fee-estimation.md
+++ b/_topics/en/fee-estimation.md
@@ -6,12 +6,12 @@ title: Fee estimation
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/fee-sniping.md
+++ b/_topics/en/fee-sniping.md
@@ -6,12 +6,12 @@ title: Fee sniping
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Anti fee sniping
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Mining
   - Security Problems
   - Security Enhancements

--- a/_topics/en/fee-sourcing.md
+++ b/_topics/en/fee-sourcing.md
@@ -6,13 +6,13 @@ title: Fee sourcing
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Exogenous fees
   - Endogenous fees
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Fee Management
 

--- a/_topics/en/fee-sponsorship.md
+++ b/_topics/en/fee-sponsorship.md
@@ -6,12 +6,12 @@ title: Fee sponsorship
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/free-relay.md
+++ b/_topics/en/free-relay.md
@@ -6,12 +6,12 @@ title: Free relay
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Transaction Relay Policy
 

--- a/_topics/en/gap-limits.md
+++ b/_topics/en/gap-limits.md
@@ -6,12 +6,12 @@ title: Gap limits
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Backup and Recovery
   - Wallet Collaboration Tools
 

--- a/_topics/en/generic-signmessage.md
+++ b/_topics/en/generic-signmessage.md
@@ -2,13 +2,13 @@
 title: Generic signmessage
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Signmessage
   - BIP322
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Wallet Collaboration Tools
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/hd-key-generation.md
+++ b/_topics/en/hd-key-generation.md
@@ -6,13 +6,13 @@ title: HD key generation
 shortname: bip32
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
  - BIP32
  - HD wallets
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Wallet Collaboration Tools
 

--- a/_topics/en/hold-invoices.md
+++ b/_topics/en/hold-invoices.md
@@ -2,12 +2,12 @@
 title: Hold invoices
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/htlc-endorsement.md
+++ b/_topics/en/htlc-endorsement.md
@@ -6,12 +6,12 @@ title: HTLC endorsement
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/htlc.md
+++ b/_topics/en/htlc.md
@@ -6,12 +6,12 @@ title: Hash Time Locked Contract (HTLC)
 shortname: htlc
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Lightning Network
 

--- a/_topics/en/hwi.md
+++ b/_topics/en/hwi.md
@@ -4,7 +4,7 @@ shortname: hwi
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Wallet Collaboration Tools
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/jit-channels.md
+++ b/_topics/en/jit-channels.md
@@ -6,12 +6,12 @@ title: Just-In-Time (JIT) channels
 shortname: jit channels
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/jit-routing.md
+++ b/_topics/en/jit-routing.md
@@ -4,7 +4,7 @@ shortname: jit routing
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/joinpools.md
+++ b/_topics/en/joinpools.md
@@ -6,13 +6,13 @@ title: Joinpools
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Payment pools
   - Coinpools
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Fee Management
   - Privacy Enhancements

--- a/_topics/en/kindred-replace-by-fee.md
+++ b/_topics/en/kindred-replace-by-fee.md
@@ -6,12 +6,12 @@ title: Kindred replace by fee
 shortname: kindred rbf
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Sibling eviction
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Transaction Relay Policy
 

--- a/_topics/en/large-channels.md
+++ b/_topics/en/large-channels.md
@@ -2,12 +2,12 @@
 title: Large channels
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Wumbo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/liquidity-advertisements.md
+++ b/_topics/en/liquidity-advertisements.md
@@ -6,12 +6,12 @@ title: Liquidity advertisements
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/lnurl.md
+++ b/_topics/en/lnurl.md
@@ -6,12 +6,12 @@ title: LNURL
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Lightning Addresses
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Invoicing
 

--- a/_topics/en/low-r-grinding.md
+++ b/_topics/en/low-r-grinding.md
@@ -6,12 +6,12 @@ title: Low-r grinding
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Signature grinding
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Bandwidth Reduction
   - Fee Management
 

--- a/_topics/en/mast.md
+++ b/_topics/en/mast.md
@@ -2,12 +2,12 @@
 title: MAST
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
   - Privacy Enhancements

--- a/_topics/en/matt.md
+++ b/_topics/en/matt.md
@@ -6,12 +6,12 @@ title: MATT
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - OP_CHECKCONTRACTVERIFY
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/miniscript.md
+++ b/_topics/en/miniscript.md
@@ -3,7 +3,7 @@ title: Miniscript
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Wallet Collaboration Tools
   - Developer Tools

--- a/_topics/en/minisketch.md
+++ b/_topics/en/minisketch.md
@@ -1,12 +1,12 @@
 ---
 title: Minisketch
 
-aliases:
+title-aliases:
   - Libminisketch
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Developer Tools
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/multipath-payments.md
+++ b/_topics/en/multipath-payments.md
@@ -10,14 +10,14 @@ title: Multipath payments
 ## LND source code calls these multi-path payments, Eclair source code
 ## calls them multi-part payments, no C-Lightning sources yet but Rusty and
 ## Zmn call them multipath payments
-aliases:
+title-aliases:
   - Multipart payments
   - Simplified multipath payments
   - Base AMP
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/multisignature.md
+++ b/_topics/en/multisignature.md
@@ -6,13 +6,13 @@ title: Scriptless multisignatures
 shortname: multisignature
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - 2pECDSA
   - Two-Party ECDSA (2pECDSA)
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Fee Management
 

--- a/_topics/en/musig.md
+++ b/_topics/en/musig.md
@@ -2,12 +2,12 @@
 title: MuSig
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/offers.md
+++ b/_topics/en/offers.md
@@ -6,12 +6,12 @@ title: Offers
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BOLT12
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Invoicing
   - Wallet Collaboration Tools

--- a/_topics/en/onion-messages.md
+++ b/_topics/en/onion-messages.md
@@ -6,12 +6,12 @@ title: Onion messages
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/op_cat.md
+++ b/_topics/en/op_cat.md
@@ -6,12 +6,12 @@ title: OP_CAT
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
 

--- a/_topics/en/op_checksigfromstack.md
+++ b/_topics/en/op_checksigfromstack.md
@@ -2,12 +2,12 @@
 title: OP_CHECKSIGFROMSTACK
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
 

--- a/_topics/en/op_checktemplateverify.md
+++ b/_topics/en/op_checktemplateverify.md
@@ -2,11 +2,11 @@
 title: OP_CHECKTEMPLATEVERIFY
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
   - Fee Management

--- a/_topics/en/op_codeseparator.md
+++ b/_topics/en/op_codeseparator.md
@@ -2,12 +2,12 @@
 title: OP_CODESEPARATOR
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/out-of-band-fees.md
+++ b/_topics/en/out-of-band-fees.md
@@ -6,12 +6,12 @@ title: Out-of-band fees
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Security Problems
 

--- a/_topics/en/output-linking.md
+++ b/_topics/en/output-linking.md
@@ -2,14 +2,14 @@
 title: Output linking
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Address reuse
   - Dust attacks
   - Reuse avoidance
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Privacy Problems
   - Security Problems

--- a/_topics/en/output-script-descriptors.md
+++ b/_topics/en/output-script-descriptors.md
@@ -2,12 +2,12 @@
 title: Output script descriptors
 shortname: descriptors
 
-aliases:
+title-aliases:
   - Descriptors
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Wallet Collaboration Tools
 

--- a/_topics/en/package-relay.md
+++ b/_topics/en/package-relay.md
@@ -2,12 +2,12 @@
 title: Package relay
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP331
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Transaction Relay Policy
 

--- a/_topics/en/pay-to-contract-outputs.md
+++ b/_topics/en/pay-to-contract-outputs.md
@@ -6,12 +6,12 @@ title: Pay-to-Contract (P2C) protocols
 shortname: p2c
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Scripts and Addresses
 

--- a/_topics/en/payjoin.md
+++ b/_topics/en/payjoin.md
@@ -1,14 +1,14 @@
 ---
 title: Payjoin
 
-aliases:
+title-aliases:
   - Pay-to-EndPoint
   - Bustapay
   - BIP79
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/payment-batching.md
+++ b/_topics/en/payment-batching.md
@@ -6,12 +6,12 @@ title: Payment batching
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
  - Batching
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/payment-probes.md
+++ b/_topics/en/payment-probes.md
@@ -6,12 +6,12 @@ title: Payment probes
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Probing
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Privacy Problems
 

--- a/_topics/en/payment-secrets.md
+++ b/_topics/en/payment-secrets.md
@@ -6,12 +6,12 @@ title: Payment secrets
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Privacy Enhancements
 

--- a/_topics/en/peer-storage.md
+++ b/_topics/en/peer-storage.md
@@ -6,12 +6,12 @@ title: Peer storage
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Backup and Recovery
   - Lightning Network
 

--- a/_topics/en/proof-of-payment.md
+++ b/_topics/en/proof-of-payment.md
@@ -6,12 +6,12 @@ title: Proof of payment
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Lightning Network
 

--- a/_topics/en/proof-of-reserves.md
+++ b/_topics/en/proof-of-reserves.md
@@ -6,12 +6,12 @@ title: Proof of reserves
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Enhancements
   - Wallet Collaboration Tools
 

--- a/_topics/en/psbt.md
+++ b/_topics/en/psbt.md
@@ -2,13 +2,13 @@
 title: Partially signed bitcoin transactions
 shortname: psbt
 
-aliases:
+title-aliases:
   - BIP174
   - PSBT
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Wallet Collaboration Tools
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/ptlc.md
+++ b/_topics/en/ptlc.md
@@ -6,12 +6,12 @@ title: Point Time Locked Contracts (PTLCs)
 shortname: ptlc
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Lightning Network
   - Privacy Enhancements

--- a/_topics/en/quantum-resistance.md
+++ b/_topics/en/quantum-resistance.md
@@ -6,12 +6,12 @@ title: Quantum resistance
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Post-quantum cryptography
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Enhancements
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/redundant-overpayments.md
+++ b/_topics/en/redundant-overpayments.md
@@ -6,13 +6,13 @@ title: Redundant overpayments
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Stuckless payments
   - Boomerang payments
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/rendez-vous-routing.md
+++ b/_topics/en/rendez-vous-routing.md
@@ -6,14 +6,14 @@ title: Rendez-vous routing
 shortname: rv routing
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Hidden destinations
   - Blinded paths
   - Route blinding
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Privacy Enhancements
 

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -2,14 +2,14 @@
 title: Replace-by-fee (RBF)
 shortname: rbf
 
-aliases:
+title-aliases:
   - BIP125
   - Opt-in Replace-by-Fee
   - Full-RBF
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Fee Management
   - Transaction Relay Policy
   - Mining

--- a/_topics/en/reproducible-builds.md
+++ b/_topics/en/reproducible-builds.md
@@ -2,13 +2,13 @@
 title: Reproducible builds
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Gitian
   - Guix
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Enhancements
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/responsible-disclosures.md
+++ b/_topics/en/responsible-disclosures.md
@@ -6,12 +6,12 @@ title: Responsible disclosures
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -3,7 +3,7 @@ title: Schnorr signatures
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
 

--- a/_topics/en/segregated-witness.md
+++ b/_topics/en/segregated-witness.md
@@ -6,12 +6,12 @@ title: Segregated witness
 shortname: segwit
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/side-channels.md
+++ b/_topics/en/side-channels.md
@@ -6,12 +6,12 @@ title: Side channels
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
   - Security Enhancements
 

--- a/_topics/en/sidechains.md
+++ b/_topics/en/sidechains.md
@@ -3,7 +3,7 @@ title: Sidechains
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/sighash_anyprevout.md
+++ b/_topics/en/sighash_anyprevout.md
@@ -3,11 +3,11 @@ title: SIGHASH_ANYPREVOUT
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
 
-aliases:
+title-aliases:
   - SIGHASH_NOINPUT
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/signer-delegation.md
+++ b/_topics/en/signer-delegation.md
@@ -6,12 +6,12 @@ title: Signer delegation
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Delegation
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Scripts and Addresses
 

--- a/_topics/en/signet.md
+++ b/_topics/en/signet.md
@@ -2,12 +2,12 @@
 title: Signet
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Developer Tools
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/silent-payments.md
+++ b/_topics/en/silent-payments.md
@@ -6,12 +6,12 @@ title: Silent payments
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/simple-taproot-channels.md
+++ b/_topics/en/simple-taproot-channels.md
@@ -6,12 +6,12 @@ title: Simple taproot channels
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/simplicity.md
+++ b/_topics/en/simplicity.md
@@ -3,7 +3,7 @@ title: Simplicity
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Soft Forks
 

--- a/_topics/en/soft-fork-activation.md
+++ b/_topics/en/soft-fork-activation.md
@@ -6,13 +6,13 @@ title: Soft fork activation
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP8
   - BIP9
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Consensus Enforcement
   - Soft Forks
 

--- a/_topics/en/splicing.md
+++ b/_topics/en/splicing.md
@@ -2,11 +2,11 @@
 title: Splicing
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/spontaneous-payments.md
+++ b/_topics/en/spontaneous-payments.md
@@ -2,12 +2,12 @@
 title: Spontaneous payments
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Keysend
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/statechains.md
+++ b/_topics/en/statechains.md
@@ -6,12 +6,12 @@ title: Statechains
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/stateless-invoices.md
+++ b/_topics/en/stateless-invoices.md
@@ -6,12 +6,12 @@ title: Stateless invoices
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/static-channel-backups.md
+++ b/_topics/en/static-channel-backups.md
@@ -6,12 +6,12 @@ title: Static channel backups
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Backup and Recovery
 

--- a/_topics/en/submarine-swaps.md
+++ b/_topics/en/submarine-swaps.md
@@ -6,12 +6,12 @@ title: Submarine swaps
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Liquidity Management
 

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -3,7 +3,7 @@ title: Taproot
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
   - Privacy Enhancements

--- a/_topics/en/tapscript.md
+++ b/_topics/en/tapscript.md
@@ -3,7 +3,7 @@ title: Tapscript
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Soft Forks
   - Scripts and Addresses
 

--- a/_topics/en/threshold-signature.md
+++ b/_topics/en/threshold-signature.md
@@ -6,12 +6,12 @@ title: Threshold signature
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Privacy Enhancements
   - Fee Management
 

--- a/_topics/en/time-warp.md
+++ b/_topics/en/time-warp.md
@@ -6,12 +6,12 @@ title: Time warp
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/timelocks.md
+++ b/_topics/en/timelocks.md
@@ -6,12 +6,12 @@ title: Timelocks
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Contract Protocols
   - Transaction Relay Policy

--- a/_topics/en/trampoline-payments.md
+++ b/_topics/en/trampoline-payments.md
@@ -2,12 +2,12 @@
 title: Trampoline payments
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/transaction-bloom-filtering.md
+++ b/_topics/en/transaction-bloom-filtering.md
@@ -2,13 +2,13 @@
 title: Transaction bloom filtering
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - BIP37
   - Bloom filters
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightweight Client Support
   - Privacy Problems
   - P2P Network Protocol

--- a/_topics/en/transaction-origin-privacy.md
+++ b/_topics/en/transaction-origin-privacy.md
@@ -6,12 +6,12 @@ title: Transaction origin privacy
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Transaction Relay Policy
   - Privacy Enhancements
   - Privacy Problems

--- a/_topics/en/transaction-pinning.md
+++ b/_topics/en/transaction-pinning.md
@@ -2,12 +2,12 @@
 title: Transaction pinning
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Security Problems
   - Fee Management
   - Contract Protocols

--- a/_topics/en/trimmed-htlc.md
+++ b/_topics/en/trimmed-htlc.md
@@ -6,12 +6,12 @@ title: Trimmed HTLC
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/unannounced-channels.md
+++ b/_topics/en/unannounced-channels.md
@@ -2,12 +2,12 @@
 title: Unannounced channels
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Private channels
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.

--- a/_topics/en/uneconomical-outputs.md
+++ b/_topics/en/uneconomical-outputs.md
@@ -6,12 +6,12 @@ title: Uneconomical outputs
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - Dust
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Transaction Relay Policy
   - Privacy Problems
 

--- a/_topics/en/utreexo.md
+++ b/_topics/en/utreexo.md
@@ -3,7 +3,7 @@ title: Utreexo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Consensus Enforcement
 

--- a/_topics/en/v2-p2p-transport.md
+++ b/_topics/en/v2-p2p-transport.md
@@ -4,11 +4,11 @@ shortname: v2 p2p transport
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - P2P Network Protocol
   - Privacy Enhancements
 
-aliases:
+title-aliases:
   - BIP151
   - BIP324
 

--- a/_topics/en/vaults.md
+++ b/_topics/en/vaults.md
@@ -2,12 +2,12 @@
 title: Vaults
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
   - Security Enhancements
 

--- a/_topics/en/version-3-transaction-relay.md
+++ b/_topics/en/version-3-transaction-relay.md
@@ -6,12 +6,12 @@ title: Version 3 transaction relay
 shortname: v3 transaction relay
 
 ## Optional.  An entry will be added to the topics index for each alias
-aliases:
+title-aliases:
   - "Topologically Restricted Until Confirmation (TRUC)"
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Contract Protocols
   - Transaction Relay Policy
 

--- a/_topics/en/wallet-labels.md
+++ b/_topics/en/wallet-labels.md
@@ -6,12 +6,12 @@ title: Wallet labels
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Backup and Recovery
   - Wallet Collaboration Tools
 

--- a/_topics/en/watchtowers.md
+++ b/_topics/en/watchtowers.md
@@ -3,7 +3,7 @@ title: Watchtowers
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
   - Security Enhancements
   - Backup and Recovery

--- a/_topics/en/x-only-public-keys.md
+++ b/_topics/en/x-only-public-keys.md
@@ -6,12 +6,12 @@ title: X-only public keys
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Scripts and Addresses
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/_topics/en/zero-conf-channels.md
+++ b/_topics/en/zero-conf-channels.md
@@ -6,12 +6,12 @@ title: Zero-conf channels
 # shortname: foo
 
 ## Optional.  An entry will be added to the topics index for each alias
-#aliases:
+#title-aliases:
 #  - Foo
 
 ## Required.  At least one category to which this topic belongs.  See
 ## schema for options
-categories:
+topic-categories:
   - Lightning Network
 
 ## Optional.  Produces a Markdown link with either "[title][]" or

--- a/en/topic-categories.md
+++ b/en/topic-categories.md
@@ -7,10 +7,10 @@ layout: page
 
 {% capture raw_categories %}
 {%- for topic in site.topics -%}
-  {%- if topic.categories == empty -%}
+  {%- if topic.topic-categories == empty -%}
     {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
   {%- endif -%}
-  {%- for category in topic.categories -%}
+  {%- for category in topic.topic-categories -%}
     {{category}}|
   {%- endfor -%}
 {%- endfor -%}
@@ -32,7 +32,7 @@ produce code blocks -->{% endcomment %}
   <h3 id="{{category | slugify}}">{{category}}</h3>
   <ul>
   {% for topic in site.topics %}
-    {% if topic.categories contains category %}
+    {% if topic.topic-categories contains category %}
       <li><a href="{{topic.url}}">{{topic.title}}</a></li>
     {% endif %}
   {% endfor %}

--- a/en/topics.md
+++ b/en/topics.md
@@ -13,7 +13,7 @@ rather than URL. -->{% endcomment %}
 {% capture raw_topics_list %}
 {%- for topic in site.topics -%}
   <!--{% include functions/sort-rename.md name=topic.title %}-->[{{topic.title}}]({{topic.url}})ENDTOPIC
-  {%- for alias in topic.aliases -%}
+  {%- for alias in topic.title-aliases -%}
     <!--{% include functions/sort-rename.md name=alias %}-->*[{{alias}}]({{topic.url}})*ENDTOPIC
   {%- endfor -%}
 {%- endfor -%}

--- a/topics.json
+++ b/topics.json
@@ -15,8 +15,8 @@
         "title": {{ topic.title | jsonify }},
         "slug": {{ topic_slug | jsonify }},
         "optech_url": "{{ site.url }}{{ topic.url }}",
-        "categories": {{ topic.categories | jsonify }},
-        "aliases":  {{ topic.aliases | jsonify }},
+        "categories": {{ topic.topic-categories | jsonify }},
+        "aliases":  {{ topic.title-aliases | jsonify }},
         "excerpt": {{ topic.excerpt | jsonify }}
       }{% unless forloop.last %},{% endunless %}
   {% endfor %}


### PR DESCRIPTION
Part of #1551 project to switch to the Hugo static site generator.

This changes the name of two fields in the topic files, `aliases` and `categories`.  Hugo uses both of those field names for special purposes, so this PR gives them alternative names.  This should not have any effect on the site output.

- "aliases" to "title-aliases".  In Hugo, "aliases" creates copies of the current page at the indicated alias urls.

- "categories" to "topic-categories".  In Hugo, "categories" results in the creation of category pages.

Both of those are cool and we'll probably use them in the future, but we want the initial switchover to produce two nearly identical sites.