### PR TITLE
Posts: check YAML formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,11 @@ test-before-build: $(compatibility_validation) $(topic_validation)
 	@ ## - MD009: trailing spaces (can lead to extraneous <br> tags
 	bundle exec mdl -g -r MD009 .
 
-	## Check that posts declare a slug, see issue #155 and PR #156
+	## Check that posts declare certain fields, see issue #155 and PR #156
 	! git --no-pager grep -L "^slug: " _posts
+	! git --no-pager grep -L "^title: " _posts
+	! git --no-pager grep -L "^permalink: " _posts
+	! git --no-pager grep -L "^name: " _posts
 	## Check that all slugs are unique
 	! git --no-pager grep -h "^slug: " _posts | sort | uniq -d | grep .
 	## Check that all post titles are unique (per language)

--- a/_posts/fr/newsletters/2024-02-21-newsletter.md
+++ b/_posts/fr/newsletters/2024-02-21-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #290'
-permalink : /fr/newsletters/2024/02/21/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #290'
+permalink: /fr/newsletters/2024/02/21/
 name: 2024-02-21-newsletter-fr
 slug: 2024-02-21-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-03-06-newsletter.md
+++ b/_posts/fr/newsletters/2024-03-06-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #292'
-permalink : /fr/newsletters/2024/03/06/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #292'
+permalink: /fr/newsletters/2024/03/06/
 name: 2024-03-06-newsletter-fr
 slug: 2024-03-06-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-03-13-newsletter.md
+++ b/_posts/fr/newsletters/2024-03-13-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #293'
-permalink : /fr/newsletters/2024/03/13/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #293'
+permalink: /fr/newsletters/2024/03/13/
 name: 2024-03-13-newsletter-fr
 slug: 2024-03-13-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-03-27-newsletter.md
+++ b/_posts/fr/newsletters/2024-03-27-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #295'
-permalink : /fr/newsletters/2024/03/27/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #295'
+permalink: /fr/newsletters/2024/03/27/
 name: 2024-03-27-newsletter-fr
 slug: 2024-03-27-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-04-03-newsletter.md
+++ b/_posts/fr/newsletters/2024-04-03-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #296'
-permalink : /fr/newsletters/2024/04/03/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #296'
+permalink: /fr/newsletters/2024/04/03/
 name: 2024-04-03-newsletter-fr
 slug: 2024-04-03-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-04-10-newsletter.md
+++ b/_posts/fr/newsletters/2024-04-10-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #297'
-permalink : /fr/newsletters/2024/04/10/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #297'
+permalink: /fr/newsletters/2024/04/10/
 name: 2024-04-10-newsletter-fr
 slug: 2024-04-10-newsletter-fr
 type: newsletter

--- a/_posts/fr/newsletters/2024-04-17-newsletter.md
+++ b/_posts/fr/newsletters/2024-04-17-newsletter.md
@@ -1,6 +1,6 @@
 ---
-title : 'Bulletin Hebdomadaire Bitcoin Optech #298'
-permalink : /fr/newsletters/2024/04/17/
+title: 'Bulletin Hebdomadaire Bitcoin Optech #298'
+permalink: /fr/newsletters/2024/04/17/
 name: 2024-04-17-newsletter-fr
 slug: 2024-04-17-newsletter-fr
 type: newsletter


### PR DESCRIPTION
Part of #1551

Some of our posts contain an extra space in the YAML header between a key and value, e.g.:

    title : 'Bulletin Hebdomadaire Bitcoin Optech #290'

Jekyll strips the extra space, so the key becomes `title`.  Hugo preserves the extra space, so the field doesn't work as expected.

This PR eliminates the extra space in the source file and adds a test to help avoid future extra spaces.
