### PR TITLE
Revert "Fix use of now-removed github-log.md"

### DIFF
--- a/_posts/zh/newsletters/2018-08-07-newsletter.md
+++ b/_posts/zh/newsletters/2018-08-07-newsletter.md
@@ -36,7 +36,27 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中值得注意的提交。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中值得注意的提交。*
+
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="ef4fac0ea5b4891f4529e4b59dfd1f7aeb3009b5"
+  end="2b67354aa584c4aabae049a67767ac7b70e2d01a"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="92b0b10dc75de87be3a9f895c8dfc5a84a2aec7a"
+  end="f0f5e11b826e020c11c37343bcbaf9725627378b"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="0b597f671aa31c1c56d32a554fcdf089646fc7c1"
+  end="80a8e57ede82292818032eeb3510da067fddfd5e"
+%}
 
 - [Bitcoin Core #13697][]：Pieter Wuille 在 [Newsletter #5][] 中提到的这个 PR 已被合并，它为即将发布的 0.17 RPC `scantxoutset` 添加了[输出脚本描述符][output script descriptors]支持。这些描述符为软件提供了一种全面的方式来描述你想要找到的输出脚本，预计将随时间适应 Bitcoin Core API 的其他部分，如 [importprivkey][rpc importprivkey]、[importaddress][rpc importaddress]、[importpubkey][rpc importpubkey]、[importmulti][rpc importmulti] 和 [importwallet][rpc importwallet]。
 

--- a/_posts/zh/newsletters/2018-08-14-newsletter.md
+++ b/_posts/zh/newsletters/2018-08-14-newsletter.md
@@ -59,7 +59,26 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的显著提交。不包括上文描述的 Bitcoin Core #13907 或 #13666。注意：本周所有三个项目的大部分更改似乎是对其自动化测试代码的改进；我们没有在这份简报中描述这些改进，但我们确信用户和开发者非常欣赏这项工作。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的显著提交。不包括上文描述的 Bitcoin Core #13907 或 #13666。注意：本周所有三个项目的大部分更改似乎是对其自动化测试代码的改进；我们没有在这份简报中描述这些改进，但我们确信用户和开发者非常欣赏这项工作。*
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="2b67354aa584c4aabae049a67767ac7b70e2d01a"
+  end="1b04b55f2d22078ca79cd38fc1078e15fa9cbe94"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="f0f5e11b826e020c11c37343bcbaf9725627378b"
+  end="6989316b11c51922b4c6ae3507ac06680ec530b9"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="80a8e57ede82292818032eeb3510da067fddfd5e"
+  end="a97955845ff43d4780b33a7301695db33823c57c"
+%}
 
 - [Bitcoin Core #13925][]：增加 Bitcoin Core 内部数据库可以使用的文件描述符的最大数量，这可以允许更多的文件描述符被用于网络连接。如果你修改了 Bitcoin Core 以接受超过 117 个进来的连接，在升级过了这个合并之后，你可能会看到连接数量的进一步增加。（注意：我们不建议增加默认值，除非你有特殊需求。）
 

--- a/_posts/zh/newsletters/2018-08-21-newsletter.md
+++ b/_posts/zh/newsletters/2018-08-21-newsletter.md
@@ -36,9 +36,28 @@ Bitcoin Core 和大多数自由和开源软件项目一样，是自下而上组�
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。*
 
 {% comment %}<!-- 依我看来，c-lightning 本周只有 6 次提交，主要是小的文档更新，因此没有新闻报道。我仍然会在上面提及它们，以便下周易于复制/粘贴。-harding -->{% endcomment %}
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="1b04b55f2d22078ca79cd38fc1078e15fa9cbe94"
+  end="df660aa7717a6f4784e90535a13a95d82244565a"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="6989316b11c51922b4c6ae3507ac06680ec530b9"
+  end="3f5ec993300e38369110706ac83301b8875500d6"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="a97955845ff43d4780b33a7301695db33823c57c"
+  end="80a875a9a54e26c2ea4c90aee8fe606ddcc27c55"
+%}
 
 - Bitcoin Core 0.17 分支：这允许开发者专注于确保稳定性、翻译完整性和其他发布特性，而新特性的开发继续在主分支上进行。本值得注意的提交部分仅关注每个项目的主开发分支，因此从此时起提及的提交不太可能包含在 Bitcoin Core 0.17 版本中，且不应期待在 0.18 版本之前出现。
 

--- a/_posts/zh/newsletters/2018-08-28-newsletter.md
+++ b/_posts/zh/newsletters/2018-08-28-newsletter.md
@@ -41,9 +41,28 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。提醒：新的合并到 Bitcoin Core 的代码被提交到其主开发分支，并不太可能成为即将发布的 0.17 版本的一部分——你可能要等到大约六个月后的 0.18 版本。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。提醒：新的合并到 Bitcoin Core 的代码被提交到其主开发分支，并不太可能成为即将发布的 0.17 版本的一部分——你可能要等到大约六个月后的 0.18 版本。*
 
 {% comment %}<!-- I didn't notice anything interesting in LND this week -harding -->{% endcomment %}
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="df660aa7717a6f4784e90535a13a95d82244565a"
+  end="427253cf7e19ed9ef86b45457de41e345676c88e"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="3f5ec993300e38369110706ac83301b8875500d6"
+  end="26f68da5b2883885fcf6a8e79b3fc9bb12cc9eef"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="80a875a9a54e26c2ea4c90aee8fe606ddcc27c55"
+  end="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"
+%}
 
 - [Bitcoin Core #12254][] 添加了必要的功能，允许 Bitcoin Core 生成 [BIP158][] 致密区块过滤器。这段代码目前尚未被 Bitcoin Core 使用，但未来的工作预计将使用这些功能提供两个特性：
 

--- a/_posts/zh/newsletters/2018-09-04-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-04-newsletter.md
@@ -35,9 +35,28 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——你可能需要等到大约六个月后的 0.18 版本。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——你可能需要等到大约六个月后的 0.18 版本。*
 
 {% comment %}<!-- 本周 LND 只有三次合并，个人觉得都不太激动人心 -harding -->{% endcomment %}
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="427253cf7e19ed9ef86b45457de41e345676c88e"
+  end="68f3c7eb080e461cfeac37f8db7034fe507241d0"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="26f68da5b2883885fcf6a8e79b3fc9bb12cc9eef"
+  end="2b448be048daf85cef4cbb37ceed4413fdb051e6"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"
+  end="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"
+%}
 
 - [Bitcoin Core #12952][]：在经过几个主要版本的弃用并且在即将发布的 0.17 版本中默认禁用后，Bitcoin Core 的内置账户系统已从主开发分支中移除。账户系统于 2010 年末添加，以允许早期的比特币交易所在 Bitcoin Core 中管理其用户账户，但它缺少许多真正生产系统所需的特性（如原子数据库更新），并且经常让用户感到困惑，因此逐步移除它已经是几年来的一个目标。
 

--- a/_posts/zh/newsletters/2018-09-11-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-11-newsletter.md
@@ -31,7 +31,26 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="68f3c7eb080e461cfeac37f8db7034fe507241d0"
+  end="cb25cd6aa18c69918176d68e36e26f7e373aa48c"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="2b448be048daf85cef4cbb37ceed4413fdb051e6"
+  end="1941353fb28755a170793e43595601d75c8f3dda"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="77d3ca3ea3ba607e0b08c7921c41bfc0a9658ed2"
+  end="634f19a7b230edc686be56ab950b80784e56252c"
+%}
 
 - [Bitcoin Core #12775][] 为 Bitcoin Core 添加对 RapidCheck（一个 [QuickCheck][] 重新实现）的支持，提供一套基于属性的测试套件，它根据程序员告诉它的函数属性（例如，它接受什么作为输入并返回什么作为输出）自动生成自己的测试。
 

--- a/_posts/zh/newsletters/2018-09-18-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-18-newsletter.md
@@ -37,7 +37,26 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="cb25cd6aa18c69918176d68e36e26f7e373aa48c"
+  end="c53e083a49291b611d278a8db24ff235c1202e43"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="1941353fb28755a170793e43595601d75c8f3dda"
+  end="3b2c807288b1b7f40d609533c1e96a510ac5fa6d"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="634f19a7b230edc686be56ab950b80784e56252c"
+  end="36eab5de26e203311ceeb65c94ec5beb9c94ff5d"
+%}
 
 - [Bitcoin Core #14054][]：此 PR 阻止节点默认发送 [BIP61][] 点对点协议[拒绝消息][p2p reject]。这些消息的实现是为了让轻客户端开发者更容易获取关于连接和交易转发问题的反馈。然而，没有要求（或方法来要求）节点发送拒绝消息或准确的拒绝消息，因此这些消息可能只会浪费带宽。
 

--- a/_posts/zh/newsletters/2018-09-25-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-25-newsletter.md
@@ -55,7 +55,26 @@ lang: zh
 
 ## 值得注意的提交
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的提交。提醒：新合并到 Bitcoin Core 的代码是提交到其主开发分支的，不太可能成为即将发布的 0.17 版本的一部分——您可能需要等待大约六个月后的 0.18 版本。*
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="c53e083a49291b611d278a8db24ff235c1202e43"
+  end="920c090f63f4990bf0f3b3d1a6d3d8a8bcd14ba0"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="3b2c807288b1b7f40d609533c1e96a510ac5fa6d"
+  end="f4305097e1638f6f8958dfa9eec941d8bf80246e"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="36eab5de26e203311ceeb65c94ec5beb9c94ff5d"
+  end="3ce53ab9eddd397d57b6afc5faefe6703e56ac26"
+%}
 
 - [Bitcoin Core #13152][]: 当连接到点对点网络时，节点会共享它们听说过的其他节点的 IP 地址，这些地址被存储在一个数据库中，Bitcoin Core 会在想要打开新连接时查询这个数据库。这个 PR 添加了一个新的 RPC 命令 `getnodeaddresses`，它返回一个或多个这样的地址。这可以与工具如 [bitcoin-submittx][] 结合使用时非常有用。
 

--- a/_posts/zh/newsletters/2018-10-02-newsletter.md
+++ b/_posts/zh/newsletters/2018-10-02-newsletter.md
@@ -25,7 +25,26 @@ lang: zh
 
 ## 值得注意的代码变更
 
-*本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的值得注意的代码变更。*
+*本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的值得注意的代码变更。*
+
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="920c090f63f4990bf0f3b3d1a6d3d8a8bcd14ba0"
+  end="c9327306b580bb161d1732c0a0260b46c0df015c"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="f4305097e1638f6f8958dfa9eec941d8bf80246e"
+  end="79ed4e8b600e4834f058cbf3cb8b93f5aa5ab3d4"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="3ce53ab9eddd397d57b6afc5faefe6703e56ac26"
+  end="d6fcfe00c722f7e6f4b691cd47743ed593aeea0e"
+%}
 
 - [Bitcoin Core #14305][]：在发现几个基于 Python 的测试由于使用了错误命名的变量而错误地通过的情况后，使用 Python 3 的 `__slots__` 特性为类实现了一个变量名称白名单。
 

--- a/_posts/zh/newsletters/2018-10-16-newsletter.md
+++ b/_posts/zh/newsletters/2018-10-16-newsletter.md
@@ -39,8 +39,26 @@ CoreDev.tech 是一个仅限邀请的活动，面向比特币基础设施项目�
 
 ## 值得注意的代码变更
 
-本周在 [Bitcoin Core][bitcoin core repo]、[LND][lnd repo] 和 [C-lightning][core lightning repo] 中的显著代码变更。
+本周在 [Bitcoin Core][core commits]、[LND][lnd commits] 和 [C-lightning][cl commits] 中的显著代码变更。
 
+{% include linkers/github-log.md
+  refname="core commits"
+  repo="bitcoin/bitcoin"
+  start="c9327306b580bb161d1732c0a0260b46c0df015c"
+  end="be992701b018f256db6d64786624be4cb60d8975"
+%}
+{% include linkers/github-log.md
+  refname="lnd commits"
+  repo="lightningnetwork/lnd"
+  start="79ed4e8b600e4834f058cbf3cb8b93f5aa5ab3d4"
+  end="e5b84cfadab56037ae3957e704b3e570c9368297"
+%}
+{% include linkers/github-log.md
+  refname="cl commits"
+  repo="ElementsProject/lightning"
+  start="d6fcfe00c722f7e6f4b691cd47743ed593aeea0e"
+  end="a44491fff0ccd7bde20661eecf88bf136db5f6e6"
+%}
 {% comment %}<!-- last secp256k1 commit checked: 1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c -->{% endcomment %}
 
 - [LND #1970][]：AbandonChannel RPC 方法（仅在开发者调试模式中可用）现在在用户告诉其节点放弃一个支付通道时提供了额外的信息（如果不小心使用，此方法可能导致金钱损失）。额外的信息足以允许稍后重新启动一个开放的支付通道，或证明程序有足够的信息对现已关闭的支付通道做出更多的承诺。


### PR DESCRIPTION
Reverts bitcoinops/bitcoinops.github.io#1619

Hello,

When I synced the code from the Master branch, I encountered an error as shown below:
<img width="933" alt="Screenshot 2024-05-09 at 2 39 06 PM" src="https://github.com/bitcoinops/bitcoinops.github.io/assets/99865255/94c5075f-2621-4f63-bbea-83a02cd16d9f">



There's a lot of content like this:
```markdown
SyntaxError: invalid syntax
  File "_contrib/find-bad-indentation", line 26
    if re.match(rf'^\s{{{X}}}(?![-\*]|[0-9]*\.)\S', first_line):
                                                 ^
SyntaxError: invalid syntax
  File "_contrib/find-bad-indentation", line 26
    if re.match(rf'^\s{{{X}}}(?![-\*]|[0-9]*\.)\S', first line):
                                                 ^
SyntaxError: invalid syntax
  File "_contrib/find-bad-indentation", line 26
    if re.match(rf'^\s{{{X}}}(?![-\*]|[0-9]*\.)\S', first line):
```
I am unsure what is causing this error. How should I address it?

Best regards,