### PR TITLE
Newsletters: add 303 (2024-05-17)

### DIFF
--- a/_posts/en/newsletters/2024-05-17-newsletter.md
+++ b/_posts/en/newsletters/2024-05-17-newsletter.md
@@ -132,27 +132,48 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo],
 [Bitcoin Inquisition][bitcoin inquisition repo], and [BINANAs][binana
 repo]._
 
-FIXME:Gustavojfe to add summaries.  Let harding know if you have any
-questions.  Add an HTML comment <!-- like this --> to any of your
-summaries that you have notes about, e.g. if you aren't sure why I
-thought something was noteworthy or if you aren't 100% sure your
-description is correct.  That way harding and the other reviewers will
-give it extra attention.
+- [Core Lightning #7190][] adds an additional offset (called `chainlag`)
+  into the [HTLC][topic htlc] timelock calculation.  This allows HTLCs
+  to target the current block height instead of the most recent block
+  that the LN node has processed (its sync height).  This makes it safe
+  for a node to send payments during the blockchain sync process.
 
-- [Core Lightning #7190][] Add the `chainlag` to the payment
+- [LDK #2973][] implements support for `OnionMessenger` to intercept [onion messages][topic onion messages] on
+  behalf of offline peers. It generates events on message interception and on
+  the peer's return to online status for forwarding. Users should maintain an
+  _allow list_ to only store messages for relevant peers. This is a
+  stepping stone to supporting [async payments][topic async payments]
+  through `held_htlc_available` [BOLTs #989][].  In that protocol, Alice
+  wants to pay Carol through Bob, but Alice doesn't know if Carol is
+  online.  Alice sends an onion message to Bob; Bob holds the message
+  until Carol comes online; Carol opens the message, which tells her to
+  request a payment from Alice (or Alice's Lightning service provider);
+  Carol requests the payment and Alice sends it in the normal way.
 
-- [LDK #2973][] Support generating events when an OM for an offline peer is received.
+- [LDK #2907][] extends `OnionMessage` handling to accept an optional
+  `Responder` input and return an object `ResponseInstructions` that indicates how
+  the response to the message should be handled. This change enables asynchronous
+  onion messaging responses and opens the door to more complex response
+  mechanisms, such as might be needed for [async payments][topic async
+  payments].
 
-- [LDK #2907][] Introduce ResponseInstructions for OnionMessage Handling
+- [BDK #1403][] updates the `bdk_electrum` crate to make use of new
+  sync/full-scan structures introduced in [BDK #1413][], queryable `CheckPoint`
+  linked list [BDK #1369][], and cheaply-clonable transactions in `Arc`
+  pointers [BDK #1373][]. This change improves the performance of
+  wallets scanning for transaction data using an Electrum-style server.
+  It is also now an option to fetch `TxOut`s to allow for
+  fee calculation on transactions received from an external wallet.
 
-- [BDK #1403][] Update `bdk_electrum` crate to use sync/full-scan structs
-
-- [BIPs #1458][] josibake/silent-payments-bip
+- [BIPs #1458][] adds [BIP352][] which proposes [silent payments][topic silent
+  payments], a protocol for reusable
+  payment addresses that generate a unique onchain address each time it is
+  used. The BIP draft was first discussed in [Newsletter #255][news255 bip352].
 
 {% assign day_after_posting = page.date | date: "%s" | plus: 86400 | date: "%Y-%m-%d 14:30" %}
 {% include snippets/recap-ad.md when="2024-05-21 14:30" %}
 {% include references.md %}
-{% include linkers/issues.md v=2 issues="7190,2973,2907,1403,1458" %}
+{% include linkers/issues.md v=2 issues="7190,2973,2907,1403,1458,989,1413,1369,1373" %}
 [lnd v0.18.0-beta.rc2]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.0-beta.rc2
 [gibson autct]: https://delvingbitcoin.org/t/anonymous-usage-tokens-from-curve-trees-or-autct/862/
 [news261 lngossip]: /en/newsletters/2023/07/26/#updated-channel-announcements
@@ -172,3 +193,4 @@ give it extra attention.
 [bitvmx website]: https://bitvmx.org/
 [erhardt bip2]: https://mailing-list.bitcoindevs.xyz/bitcoindev/0bc47189-f9a6-400b-823c-442974c848d5@murch.one/
 [news297 bip2]: /en/newsletters/2024/04/10/#updating-bip2
+[news255 bip352]: /en/newsletters/2023/06/14/#draft-bip-for-silent-payments

--- a/_posts/en/newsletters/2024-05-17-newsletter.md
+++ b/_posts/en/newsletters/2024-05-17-newsletter.md
@@ -1,0 +1,174 @@
+---
+title: 'Bitcoin Optech Newsletter #303'
+permalink: /en/newsletters/2024/05/17/
+name: 2024-05-17-newsletter
+slug: 2024-05-17-newsletter
+type: newsletter
+layout: newsletter
+lang: en
+---
+This week's newsletter summarizes a new scheme for anonymous usage
+tokens that could be used for LN channel announcements and multiple
+other sybil-resistant coordination protocols, links to discussion about
+a new BIP39 seed phrase splitting scheme, announces an alternative to
+BitVM for verifying successful execution of arbitrary programs in
+interactive contract protocols, and relays suggestions for updating the
+BIPs process.
+
+## News
+
+- **Anonymous usage tokens:** Adam Gibson [posted][gibson autct] to
+  Delving Bitcoin about a scheme he has developed to allow anyone who
+  can [keypath-spend][topic taproot] a UTXO to prove they could spend it
+  without revealing which UTXO it is.  This follows Gibson's previous
+  work developing anti-sybil mechanisms [PoDLE][news85 podle] (used in
+  the Joinmarket [coinjoin][topic coinjoin] implementation) and
+  [RIDDLE][news205 riddle].
+
+  One use he describes is announcing LN channels.  Each LN node
+  announces its channels to other LN nodes so that they can find paths
+  for routing funds across the network.  Much of that channel
+  information is stored in memory and the announcements are often
+  rebroadcast to ensure they reach as many nodes as possible.  If an
+  attacker could cheaply announce fake channels, they could waste an
+  excessive amount of honest nodes' memory and bandwidth in addition to
+  disrupting pathfinding.  LN nodes deal with this today by
+  only accepting announcements that are signed by a key that belongs to
+  a valid UTXO.  <!-- ignoring for this description that the current LN
+  protocol requires only P2WSH UTXOs --> That requires the channel
+  co-owners to identify the specific UTXO they co-own, which may associate
+  those funds with other past or future onchain transactions they create
+  (or lead to someone making an inaccurate association).
+
+  With Gibson's scheme, called anonymous usage tokens [with] curve trees
+  (autct), the channel co-owners could sign a message without revealing
+  their UTXO.  An attacker without a UTXO couldn't create a valid
+  signature.  An attacker who did have a UTXO could create a
+  valid signature---but they would have to keep as much money in that
+  UTXO as an LN node would need to keep in a channel, limiting
+  the worst case of any attack.  See [Newsletter #261][news261 lngossip]
+  for a previous discussion of disassociating [channel
+  announcements][topic channel announcements] from particular UTXOs.
+
+  Gibson also describes several other ways autct could be used.  A
+  basic mechanism for accomplishing this type of privacy---ring
+  signatures---has been known for a long time, but Gibson uses a new
+  cryptographic construction ([curve trees][]) to make the proofs more
+  compact and faster to verify.  He also has each proof privately commit
+  to the key used so a single UTXO can't be used to create an unlimited
+  number of valid signatures.
+
+  In addition to publishing [code][autct repo], Gibson also published a
+  proof-of-concept [forum][hodlboard] that requires providing an autct
+  proof to sign up, providing an environment where everyone is
+  known to be a holder of bitcoins but no one needs to provide any
+  identifying information about themselves or their bitcoins.
+
+- **BIP39 seed phrase splitting:** Rama Gan [posted][gan penlock] to the
+  Bitcoin-Dev mailing list a link to a [set of tools][penlock website]
+  they have developed for generating and splitting a [BIP39][] seed
+  phrase without using any electronic computing equipment (except to
+  print instructions and templates).  This is similar to [codex32][topic
+  codex32] but operates on BIP39 seed words that are compatible with
+  almost all current hardware signing devices and many software wallets.
+
+  Andrew Poelstra, co-author of codex32, [replied][poelstra penlock1]
+  with several comments and suggestions.  Without us trying both
+  schemes---which would take several hours each---the exact set of
+  tradeoffs between them isn't clear to us.  However, both seem to offer
+  the same fundamental capabilities: instructions for securely
+  generating a seed offline; the ability to split the seed into multiple
+  shares using [Shamir's secret sharing][sss]; the ability to
+  reconstitute the shares into the original seed; and the ability to
+  verify checksums on both the shares and the original seed, allowing
+  users to detect data corruption early when the original data might
+  still be recoverable.
+
+- **Alternative to BitVM:** Sergio Demian Lerner and several co-authors
+  [posted][lerner bitvmx] to the Bitcoin-Dev mailing list about a new
+  virtual CPU architecture based in part on the ideas behind
+  [BitVM][topic acc].  The goal of their project, BitVMX, is to be able
+  to efficiently prove the proper execution of any program that can be
+  compiled to run on an established CPU architecture, such as
+  [RISC-V][].  Like BitVM, BitVMX does not require any consensus changes,
+  but it does require one or more designated parties to act as a trusted
+  verifier.  That means multiple users interactively participating in a
+  contract protocol can prevent any one (or more) of the parties from
+  withdrawing money from the contract unless that party successfully
+  executes an arbitrary program specified by the contract.
+
+  Lerner links to a [paper][bitvmx paper] about BitVMX which compares it
+  to the original BitVM (see [Newsletter #273][news273 bitvm]) and to
+  the limited details available about follow-up projects from the
+  original BitVM developers.  An accompanying [website][bitvmx website]
+  provides additional information in a slightly less technical form.
+
+- **Continued discussion about updating BIP2:** Mark "Murch" Erhardt
+  [continued][erhardt bip2] the discussion on the Bitcoin-Dev mailing
+  list about updating [BIP2][], which is the document that currently
+  describes the Bitcoin improvement proposals (BIP) process.  His email
+  describes several problems, suggests solutions for many of them,
+  and solicits feedback on his suggestions as well as proposals for
+  solutions to the remaining problems.  For previous discussion about
+  updating BIP2, see [Newsletter #297][news297 bip2].
+
+## Releases and release candidates
+
+*New releases and release candidates for popular Bitcoin infrastructure
+projects.  Please consider upgrading to new releases or helping to test
+release candidates.*
+
+- [LND v0.18.0-beta.rc2][] is a release candidate for the next major
+  version of this popular LN node implementation.
+
+## Notable code and documentation changes
+
+_Notable recent changes in [Bitcoin Core][bitcoin core repo], [Core
+Lightning][core lightning repo], [Eclair][eclair repo], [LDK][ldk repo],
+[LND][lnd repo], [libsecp256k1][libsecp256k1 repo], [Hardware Wallet
+Interface (HWI)][hwi repo], [Rust Bitcoin][rust bitcoin repo], [BTCPay
+Server][btcpay server repo], [BDK][bdk repo], [Bitcoin Improvement
+Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo],
+[Bitcoin Inquisition][bitcoin inquisition repo], and [BINANAs][binana
+repo]._
+
+FIXME:Gustavojfe to add summaries.  Let harding know if you have any
+questions.  Add an HTML comment <!-- like this --> to any of your
+summaries that you have notes about, e.g. if you aren't sure why I
+thought something was noteworthy or if you aren't 100% sure your
+description is correct.  That way harding and the other reviewers will
+give it extra attention.
+
+- [Core Lightning #7190][] Add the `chainlag` to the payment
+
+- [LDK #2973][] Support generating events when an OM for an offline peer is received.
+
+- [LDK #2907][] Introduce ResponseInstructions for OnionMessage Handling
+
+- [BDK #1403][] Update `bdk_electrum` crate to use sync/full-scan structs
+
+- [BIPs #1458][] josibake/silent-payments-bip
+
+{% assign day_after_posting = page.date | date: "%s" | plus: 86400 | date: "%Y-%m-%d 14:30" %}
+{% include snippets/recap-ad.md when="2024-05-21 14:30" %}
+{% include references.md %}
+{% include linkers/issues.md v=2 issues="7190,2973,2907,1403,1458" %}
+[lnd v0.18.0-beta.rc2]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.0-beta.rc2
+[gibson autct]: https://delvingbitcoin.org/t/anonymous-usage-tokens-from-curve-trees-or-autct/862/
+[news261 lngossip]: /en/newsletters/2023/07/26/#updated-channel-announcements
+[news205 riddle]: /en/newsletters/2022/06/22/#new-riddle-anti-sybil-method
+[news85 podle]: /en/newsletters/2020/02/19/#using-podle-in-ln
+[curve trees]: https://eprint.iacr.org/2022/756
+[autct repo]: https://github.com/AdamISZ/aut-ct
+[hodlboard]: https://hodlboard.org/
+[gan penlock]: https://mailing-list.bitcoindevs.xyz/bitcoindev/9bt6npqSdpuYOcaDySZDvBOwXVq_v70FBnIseMT6AXNZ4V9HylyubEaGU0S8K5TMckXTcUqQIv-FN-QLIZjj8hJbzfB9ja9S8gxKTaQ2FfM=@proton.me/
+[penlock website]: https://beta.penlock.io/
+[poelstra penlock1]: https://mailing-list.bitcoindevs.xyz/bitcoindev/ZkIYXs7PgbjazVFk@camus/
+[sss]: https://en.m.wikipedia.org/wiki/Shamir%27s_secret_sharing
+[lerner bitvmx]: https://mailing-list.bitcoindevs.xyz/bitcoindev/5189939b-baaf-4366-92a7-3f3334a742fdn@googlegroups.com/
+[risc-v]: https://en.wikipedia.org/wiki/RISC-V
+[bitvmx paper]: https://bitvmx.org/files/bitvmx-whitepaper.pdf
+[news273 bitvm]: /en/newsletters/2023/10/18/#payments-contingent-on-arbitrary-computation
+[bitvmx website]: https://bitvmx.org/
+[erhardt bip2]: https://mailing-list.bitcoindevs.xyz/bitcoindev/0bc47189-f9a6-400b-823c-442974c848d5@murch.one/
+[news297 bip2]: /en/newsletters/2024/04/10/#updating-bip2

--- a/_topics/en/acc.md
+++ b/_topics/en/acc.md
@@ -46,6 +46,9 @@ optech_mentions:
   - title: "Development of domain-specific languages for smart contracting, including with BitVM"
     url: /en/newsletters/2024/04/10/#dsl-for-experimenting-with-contracts
 
+  - title: "BitVMX: an alternative to BitVM for verification of program execution"
+    url: /en/newsletters/2024/05/17/#alternative-to-bitvm
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: "Merklize All The Things (MATT)"

--- a/_topics/en/async-payments.md
+++ b/_topics/en/async-payments.md
@@ -48,6 +48,9 @@ optech_mentions:
   - title: Using adaptor signatures to prove an async payment was accepted
     url: /en/newsletters/2023/02/01/#ln-async-proof-of-payment
 
+  - title: "LDK #2973 adds support for intercepting onion messages to facilitate async payments"
+    url: /en/newsletters/2024/05/17/#ldk-2973
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: Trampoline payments

--- a/_topics/en/channel-announcements.md
+++ b/_topics/en/channel-announcements.md
@@ -38,6 +38,9 @@ optech_mentions:
   - title: LN developer discussion about updated channel announcements
     url: /en/newsletters/2023/07/26/#updated-channel-announcements
 
+  - title: New anonymous usage tokens proposed that could be used to improve channel announcement privacy
+    url: /en/newsletters/2024/05/17/#anonymous-usage-tokens
+
 ## Optional.  Same format as "primary_sources" above
 # see_also:
 #   - title:

--- a/_topics/en/codex32.md
+++ b/_topics/en/codex32.md
@@ -38,6 +38,9 @@ optech_mentions:
   - title: "Core Lightning #6466 and #6473 add support for backing up and restoring codex32-encoded seeds"
     url: /en/newsletters/2023/08/09/#core-lightning-6466
 
+  - title: "Penlock proposed as an alternative to codex32 that provides BIP39 seed phrase splitting"
+    url: /en/newsletters/2024/05/17/#bip39-seed-phrase-splitting
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: BIP32 hierarchical derivation from seeds

--- a/_topics/en/htlc.md
+++ b/_topics/en/htlc.md
@@ -93,6 +93,9 @@ optech_mentions:
   - title: "HTLC aggregation with covenants"
     url: /en/newsletters/2023/11/08/#htlc-aggregation-with-covenants
 
+  - title: "Core Lightning #7190 introduces `chainlag` to allow safely sending payments during block sync"
+    url: /en/newsletters/2024/05/17/#core-lightning-7190
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: Hash Time Locked Contracts from Bitcoin Wiki

--- a/_topics/en/onion-messages.md
+++ b/_topics/en/onion-messages.md
@@ -74,6 +74,9 @@ optech_mentions:
   - title: "LDK #2723 adds support for sending onion messages using direct connections"
     url: /en/newsletters/2024/01/03/#ldk-2723
 
+  - title: "LDK #2973 adds support for intercepting onion messages to facilitate async payments"
+    url: /en/newsletters/2024/05/17/#ldk-2973
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: Blinded paths

--- a/_topics/en/silent-payments.md
+++ b/_topics/en/silent-payments.md
@@ -56,6 +56,9 @@ optech_mentions:
   - title: Notes from Bitcoin developer discussion about multiple aspects of silent payments
     url: /en/newsletters/2024/05/01/#coredev-tech-berlin-event
 
+  - title: "BIPs #1458 adds BIP352 for silent payments"
+    url: /en/newsletters/2024/05/17/#bips-1458
+
 ## Optional.  Same format as "primary_sources" above
 see_also:
   - title: Output linking


### PR DESCRIPTION
**Goal is for Friday email distribution to some of our readers.**  Other readers will receive it on Monday. See #1641 for details.  This is a soft goal; if we miss it, we'll try again next week.

- [x] Lede, releases/RCs, topic entries on Thursday @harding 
- [x] Merge summaries @Gustavojfe 

Because this is (I hope) a Friday release and there are two subsequent Fridays in the month, there's no Client/Services section this week.  If we don't permanently move to Fridays, we might have to do a double client/services+stack exchange section.

Upfront thanks to everyone for helping with this experiment and for being willing to consider an alternative publication date!