### PR TITLE
fix YAML for `x-only-public-keys`

### DIFF
--- a/_topics/en/x-only-public-keys.md
+++ b/_topics/en/x-only-public-keys.md
@@ -52,7 +52,7 @@ see_also:
   - title: Schnorr signatures
     link: topic schnorr signatures
 
-    title: Taproot
+  - title: Taproot
     link: topic taproot
 
 ## Optional.  Force the display (true) or non-display (false) of stub


### PR DESCRIPTION
there is a minor issue with the `see_also` key
resulting in broken YAML and "Schnorr signatures"
to not be displayed in the ["See also" section](https://bitcoinops.org/en/topics/x-only-public-keys/).