### PR TITLE
Use CommonMark block markdown style for Kramdown markdown=1

### DIFF
--- a/_includes/functions/compat-gallery.md
+++ b/_includes/functions/compat-gallery.md
@@ -9,8 +9,10 @@
   {% endif %}
   {% endcapture %}
 <div markdown="1" class="compat-usability">
+
 [![{{example.caption|escape_once}}]({{example.image}})]({{link}})
 <br /><span class="compat-caption">{{example.caption}}</span>
+
 </div>
   {% assign break = forloop.index | modulo:2 %}
   {% if break == 0 %}<br clear="both" />{% endif %}

--- a/_includes/snippets/recap-ad.md
+++ b/_includes/snippets/recap-ad.md
@@ -23,6 +23,7 @@ recap-ad.md: creates an advertisement for the next recap
 {% assign recap_formatted_time_utc = include.when | date: "%H:%M" %}
 {% endcapture %}{% capture recap_ad_text %}
 <div markdown="1" class="callout">
+
 {% case page.lang %}
 {% when "cs" %}
 

--- a/_includes/snippets/stub-topic.md
+++ b/_includes/snippets/stub-topic.md
@@ -1,5 +1,7 @@
 <div style="background-color: lightgrey; text-align: center;" markdown="1">
+
 *This topic description is a stub.  We would welcome a [pull
 request](https://github.com/{{site.github_username}}/{{site.repository_name}}/edit/master/{{page.path}})
 providing more background information about the topic.*
+
 </div>

--- a/_includes/specials/bech32/09-qrcode.md
+++ b/_includes/specials/bech32/09-qrcode.md
@@ -29,6 +29,7 @@ same dimensions).
 {:.center}
 
 <div markdown="1" id="bip21-complications">
+
 Unfortunately, the `?` and `&` needed for passing additional parameters
 in a BIP21 URI are not part of the QR code uppercase character set, so
 only binary mode can be used for those characters.  Additionally, BIP21 specifies that query
@@ -49,6 +50,7 @@ code possible:
 
 ![BIP21/bech32 mixed character mode](/img/posts/2019-05-bip21-bech32-qr-mixed.png)
 {:.center}
+
 </div>
 
 In summary, when using bech32 addresses in QR codes, consider

--- a/_includes/specials/taproot/en/03-p2wpkh-to-p2tr.md
+++ b/_includes/specials/taproot/en/03-p2wpkh-to-p2tr.md
@@ -85,7 +85,11 @@ pages of the Bitcoin Wiki so other developers can learn from your code.
       </tr>
 
       <tr>
-        <th markdown="1">Implicit scripts (e.g. [BIP44][])</th>
+        <th markdown="1">
+
+        Implicit scripts (e.g. [BIP44][])
+
+        </th>
         <td>Seed words</td>
         <td>Automatic (no user action required)</td>
         <td>Must scan for all supported scripts, O(n)</td>
@@ -102,7 +106,11 @@ pages of the Bitcoin Wiki so other developers can learn from your code.
       </tr>
 
       <tr>
-        <th markdown="1">Explicit scripts ([descriptors][topic descriptors])</th>
+        <th markdown="1">
+
+        Explicit scripts ([descriptors][topic descriptors])
+
+        </th>
         <td>Seed words and descriptor</td>
         <td>User must back up the new descriptor</td>
         <td>Only scans for the script templates that were actually used, O(n); n=1 for a new wallet</td>

--- a/_includes/specials/taproot/ja/03-p2wpkh-to-p2tr.md
+++ b/_includes/specials/taproot/ja/03-p2wpkh-to-p2tr.md
@@ -73,7 +73,11 @@ Bitcoin Wikiの[taproot uses][wiki taproot uses]ページや
       </tr>
 
       <tr>
-        <th markdown="1">Implicit scripts (例：[BIP44][])</th>
+        <th markdown="1">
+
+        Implicit scripts (例：[BIP44][])
+
+        </th>
         <td>シードワード</td>
         <td>自動（ユーザー操作は不要）</td>
         <td>サポートされているすべてのスクリプトをスキャン、O(n)</td>
@@ -90,7 +94,11 @@ Bitcoin Wikiの[taproot uses][wiki taproot uses]ページや
       </tr>
 
       <tr>
-        <th markdown="1">Explicit scripts ([descriptor][topic descriptors])</th>
+        <th markdown="1">
+
+        Explicit scripts ([descriptor][topic descriptors])
+
+        </th>
         <td>シードワードとdescriptor</td>
         <td>ユーザーは新しいdescriptorのバックアップが必要</td>
         <td>実際に使用されたスクリプトテンプレートのみをスキャン、O(n); 新しいウォレットの場合はn=1</td>

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -10,11 +10,11 @@ layout: page
       {% assign _chapter_match = true %}
       {% unless forloop.first %}
         {% assign _prev_index = forloop.index0 | minus: 1 %}
-        {% capture _previous_chapter %}[{{site.data.scaling.toc[_prev_index].name}}]({{site.data.scaling.toc[_prev_index].permalink}}){% endcapture %}
+        {% capture _previous_chapter %}<a href="{{site.data.scaling.toc[_prev_index].permalink}}">{{site.data.scaling.toc[_prev_index].name}}</a>{% endcapture %}
       {% endunless %}
       {% unless forloop.last %}
         {% assign _next_index = forloop.index0 | plus: 1 %}
-        {% capture _next_chapter %}[{{site.data.scaling.toc[_next_index].name}}]({{site.data.scaling.toc[_next_index].permalink}}){% endcapture %}
+        {% capture _next_chapter %}<a href="{{site.data.scaling.toc[_next_index].permalink}}">{{site.data.scaling.toc[_next_index].name}}</a>{% endcapture %}
       {% endunless %}
       {% break %}
     {% endif %}
@@ -22,8 +22,8 @@ layout: page
   {% unless _chapter_match %}{% include ERROR72_no_matching_chapter %}{% endunless %}
   {% unless _next_chapter %}{% capture _next_chapter %}[Return to table of contents](../){% endcapture %}{% endunless %}
   {%- capture _links -%}
-    <span class="float-left" markdown="1">**Previous:**<br>{{_previous_chapter}}</span>
-    <span class="float-right" markdown="1">**Next:**<br>{{_next_chapter}}</span>
+    <span class="float-left">**Previous:**<br>{{_previous_chapter}}</span>
+    <span class="float-right">**Next:**<br>{{_next_chapter}}</span>
   {%- endcapture %}
 {% endcapture %}<br><br>{{_links | markdownify}}
 

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -124,8 +124,16 @@ layout: post
   {% endif %}
 
   <br>{{newline}}{{newline}}
-<span class="float-left" markdown="1">**Previous Topic:**<br>{{prev_link}}</span>
-<span class="float-right" markdown="1">**Next Topic:**<br>{{next_link | default: first_link }}</span>
+<p class="float-left" markdown="1">
+
+**Previous Topic:**<br>{{prev_link}}
+
+</p>
+<p class="float-right" markdown="1">
+
+**Next Topic:**<br>{{next_link | default: first_link }}
+
+</p>
 
   {:.center}
   [Edit page]({{gh_base}}/edit/master/{{page.path}})<br>

--- a/_posts/cs/newsletters/2022-05-18-newsletter.md
+++ b/_posts/cs/newsletters/2022-05-18-newsletter.md
@@ -535,7 +535,9 @@ Wences Casares, John Pfeffer a Alex Morcos.
 {% assign sorted_praise = page.praise | sort_natural: "author" %}
 {% for comment in sorted_praise %}
   <blockquote markdown="1">
+
   {{comment.text | default: 'TODO'}}
+
   </blockquote>
 
   {:.right}

--- a/_posts/cs/newsletters/2024-02-28-newsletter.md
+++ b/_posts/cs/newsletters/2024-02-28-newsletter.md
@@ -146,48 +146,100 @@ projektech.
   <tr>
 	<th></th>
 	<th>Předem podepsané</th>
-	<th markdown="span">BIP345 `OP_VAULT`</th>
-	<th markdown="span">`OP_CAT` se Schnorrem</th>
+	<th markdown="span">
+
+        BIP345 `OP_VAULT`
+
+        </th>
+	<th markdown="span">
+
+        `OP_CAT` se Schnorrem
+
+        </th>
   </tr>
 
   <tr>
 	<th>Dostupnost</th>
-	<td markdown="span">**Nyní**</td>
-	<td markdown="span">Vyžaduje soft fork s `OP_VAULT` a [OP_CTV][topic op_checktemplateverify]</td>
-	<td markdown="span">Vyžaduje soft fork s `OP_CAT`</td>
+	<td markdown="span">
+
+        **Nyní**
+
+        </td>
+	<td markdown="span">
+
+        Vyžaduje soft fork s `OP_VAULT` a [OP_CTV][topic op_checktemplateverify]
+
+        </td>
+	<td markdown="span">
+
+        Vyžaduje soft fork s `OP_CAT`
+
+        </td>
   </tr>
 
   <tr>
 	<th markdown="span">Útok nahrazení adresy na poslední chvíli</th>
 	<td markdown="span">Zranitelné</td>
-	<td markdown="span">**Nejsou zranitelné**</td>
-	<td markdown="span">**Nejsou zranitelné**</td>
+	<td markdown="span">
+
+        **Nejsou zranitelné**
+
+        </td>
+	<td markdown="span">
+
+        **Nejsou zranitelné**
+
+        </td>
   </tr>
 
   <tr>
 	<th markdown="span">Vybrání části prostředků</th>
 	<td markdown="span">Pokud zajištěno předem</td>
-	<td markdown="span">**Ano**</td>
+	<td markdown="span">
+
+        **Ano**
+
+        </td>
 	<td markdown="span">Ne</td>
   </tr>
 
   <tr>
 	<th markdown="span">Statické a neinteraktivně odvoditelné adresy pro vklady</th>
 	<td markdown="span">Ne</td>
-	<td markdown="span">**Ano**</td>
-	<td markdown="span">**Ano**</td>
+	<td markdown="span">
+
+        **Ano**
+
+        </td>
+	<td markdown="span">
+
+        **Ano**
+
+        </td>
   </tr>
 
   <tr>
 	<th markdown="span">Redukce poplatků dávkovým návratem do úschovny</th>
 	<td markdown="span">Ne</td>
-	<td markdown="span">**Ano**</td>
+	<td markdown="span">
+
+        **Ano**
+
+        </td>
 	<td markdown="span">Ne</td>
   </tr>
 
   <tr>
-	<th markdown="span">Provozní účinnost v nejlepším případě, tedy pouze legitimní platby<br>*(hrubý odhad Optechu)*</th>
-	<td markdown="span">**2× velikost běžné single-sig**</td>
+	<th markdown="span">
+
+        Provozní účinnost v nejlepším případě, tedy pouze legitimní platby<br>*(hrubý odhad Optechu)*
+
+        </th>
+	<td markdown="span">
+
+        **2× velikost běžné single-sig**
+
+        </td>
 	<td markdown="span">3× velikost běžné single-sig</td>
 	<td markdown="span">4× velikost běžné single-sig</td>
   </tr>

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -125,6 +125,7 @@ generic format capable of creating a signature proof for any spendable
 Bitcoin script.
 
 <div markdown="1" class="callout">
+
 ### 2018 summary<br>Major releases of popular infrastructure projects
 
 - [Bitcoin Core 0.16][] released in February included default support in the
@@ -150,6 +151,7 @@ Bitcoin script.
   communication between Bitcoin programs.
 
 </div>
+
 ## April
 
 LN protocol developers Christian Decker, Rusty Russell, and Olaoluwa
@@ -188,6 +190,7 @@ soft fork proposal.
 ## May
 
 <div id="dandelion" markdown="1">
+
 A [draft BIP][BIP156] for the Dandelion protocol was published to
 the Bitcoin-Dev mailing list in May.  Dandelion can privately relay
 transactions so that the IP address of the spender can't be reliably
@@ -203,9 +206,11 @@ they've never seen a transaction they previously helped relay.  This
 makes the nodes vulnerable to denial of service attacks that can waste
 the node's bandwidth and memory---problems which developers are still
 [working on addressing][daftuar dandelion] before adopting this protocol.
+
 </div>
 
 <div markdown="1" class="callout">
+
 ### 2018 summary<br>Notable technical conferences and other events
 
 - [BPASE][bpase], January, Stanford University
@@ -296,6 +301,7 @@ private atomic swaps on the same chain (providing for improved
 coinjoin), and other advances that improve efficiency, privacy, or both.
 
 <div id="p2ep" markdown="1">
+
 Meanwhile, participants in a privacy roundtable described a method
 called Pay-to-EndPoint ([P2EP][]) that can significantly improve wallet
 resistance to block chain analysis by applying a limited form of
@@ -348,6 +354,7 @@ originally documented proposal, it's been updated as research into
 developing the protocol has proceeded.
 
 <div markdown="1" class="callout">
+
 ### 2018 summary<br>Bitcoin Optech
 
 After starting [Optech][] in May, we've signed up 15 companies as
@@ -398,6 +405,7 @@ channel or onchain using a splice out (withdrawal) from that payment
 channel.
 
 <div markdown="1" class="callout">
+
 ### 2018 summary<br>New open source infrastructure solutions
 
 - [Electrs][] released in July provides an efficient reimplementation of
@@ -469,6 +477,7 @@ Protocol developer Anthony Towns concisely [summarized][schnorr and
 more] what might be contained in a proposal if it were released today.
 
 <div markdown="1" class="callout">
+
 ### 2018 summary<br>Use of fee-reduction techniques
 
 ![Plot of compressed pubkey, segwit, payment batching, and opt-in RBF use in 2018](/img/posts/2018-12-overall.png)

--- a/_posts/en/newsletters/2019-12-28-newsletter.md
+++ b/_posts/en/newsletters/2019-12-28-newsletter.md
@@ -133,6 +133,7 @@ software solutions for their needs rather than having to choose one
 solution or another.
 
 <div markdown="1" id="miniscript">
+
 Also in February, Pieter Wuille gave a [presentation][wuille sbc
 miniscript] during the [Stanford Blockchain Conference][] on
 [miniscript][topic miniscript], a spin-off from his work on output
@@ -165,11 +166,13 @@ feedback] and [opening a PR][Bitcoin Core #16800] to add support to
 Bitcoin Core.  Miniscript would also be used by LN developers in
 December to [analyze and optimize][anchor miniscript] several new
 scripts for upgraded versions of some of their onchain transactions.
+
 </div>
 
 ## March
 
 <div markdown="1" id="cleanup">
+
 In March, Matt Corallo proposed the [consensus cleanup soft fork][topic
 consensus cleanup] to eliminate potential problems in Bitcoin's
 consensus code.  If adopted, the fixes would eliminate the [time warp
@@ -184,9 +187,11 @@ for the worst case CPU usage and validity caching) received some
 [criticism][news37 cleanup discussion].  Perhaps it was for that reason
 that the proposal didn't make any obvious progress towards
 implementation in the second half of the year.
+
 </div>
 
 <div markdown="1" id="signet">
+
 March also saw Kalle Alm request initial feedback on [signet][topic
 signet], which would eventually become [BIP325][].  The signet protocol
 allows creating testnets where all valid new blocks must be signed by a
@@ -202,6 +207,7 @@ Signet would mature throughout the year and eventually be
 [integrated][cl signet] into software such as C-Lightning as well as
 used for a demonstration of [eltoo][].  A [pull request][Bitcoin Core
 #16411] adding support to Bitcoin Core remains open.
+
 </div>
 
 {:#loop}
@@ -216,6 +222,7 @@ expected or that the user receives a refund of all costs except for any
 onchain transaction fees.  This makes Loop almost completely trustless.
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2019 summary<br>Major releases of popular infrastructure projects
 
 - [C-Lightning 0.7][] released in March added a plugin system that
@@ -283,6 +290,7 @@ and refactoring existing code on the path towards a goal of ultimately
 adding AssumeUTXO to Bitcoin Core.
 
 <div markdown="1" id="trampoline">
+
 Also in April, Pierre-Marie Padiou [proposed][trampoline proposed] the idea of [trampoline payments][topic
 trampoline payments], a method for allowing lightweight LN nodes to
 outsource pathfinding to heavyweight routing nodes.  A lightweight
@@ -299,11 +307,13 @@ recipient or just another trampoline node.
 A [PR][trampolines pr] adding features for trampoline payments to the LN
 specification is currently open and the Eclair implementation of LN has
 added [experimental support][exp tramp] for relaying trampoline payments.
+
 </div>
 
 ## May
 
 <div markdown="1" id="taproot">
+
 In May, Pieter Wuille proposed a [taproot soft fork][topic taproot]
 consisting of [bip-taproot][] and [bip-tapscript][] (which both depend
 on last year's [bip-schnorr][] proposal).  If implemented, this change
@@ -326,9 +336,11 @@ The proposals received significant discussion and review throughout the
 rest of the year, including through a series of [group review sessions][taproot
 review] organized by Anthony Towns that had more than 150 people sign up
 to help review.
+
 </div>
 
 <div markdown="1" id="anyprevout">
+
 Towns also proposed in May two new signature hashes to be used in
 combination with tapscript, `SIGHASH_ANYPREVOUT` and
 `SIGHASH_ANYPREVOUTANYSCRIPT`.  A signature hash (sighash) is the hash
@@ -347,9 +359,11 @@ Eltoo can simplify several aspects of channel construction and
 management; it's especially desirable for simplifying [channels
 involving more than two participants][topic channel factories] that can
 significantly reduce onchain channel costs.
+
 </div>
 
 <div markdown="1" id="ctv">
+
 A third soft fork proposed this month came from Jeremy Rubin, who
 [described][coshv] a new opcode now called `OP_CHECKTEMPLATEVERIFY`
 (CTV).  This would allow a limited form of [covenant][topic covenants]
@@ -366,9 +380,11 @@ Rubin would continue working on CTV for the remainder of the year,
 including opening PRs ([1][Bitcoin Core #17268], [2][Bitcoin Core #17292]) for improvements to parts
 of Bitcoin Core where optimizations could make a deployed version of CTV
 more effective.
+
 </div>
 
 <div markdown="1" class="callout" id="conferences">
+
 ### 2019 summary<br>Notable technical conferences and other events
 
 - [Stanford Blockchain Conference][], January, Stanford University
@@ -380,11 +396,13 @@ more effective.
 - [Edge Dev++][], September, Tel Aviv
 - [Scaling Bitcoin][], September, Tel Aviv
 - [Cryptoeconomic Systems Summit][], October, MIT
+
 </div>
 
 ## June
 
 <div markdown="1" id="erlay-and-other-p2p-improvements">
+
 Gleb Naumenko, Pieter Wuille, Gregory Maxwell, Sasha Fedorova, and Ivan
 Beschastnikh published a [paper][erlay] about [erlay][topic erlay],
 a protocol for relaying unconfirmed transaction announcements between nodes
@@ -406,9 +424,11 @@ problem described in the [TxProbe][] paper by Sergi Delgado-Segura and
 others) and the addition of [two extra outbound connections][] used only
 for the relay of new blocks, improving resistance against eclipse
 attacks.
+
 </div>
 
 <div markdown="1" id="watchtowers">
+
 After a significant amount of prior work, June also saw the
 [merge][altruist watchtowers] of altruist [LN watchtowers][topic
 watchtowers] into LND.  Altruist watchtowers don't receive any reward
@@ -424,11 +444,13 @@ the remainder of the year, including a [proposed
 specification][watchtower spec] and [discussion][eltoo watchtowers]
 about how they could be combined with next-generation payment channels
 such as [eltoo][topic eltoo].
+
 </div>
 
 ## July
 
 <div markdown="1" id="reproducibility">
+
 In July, the Bitcoin Core project [merged][guix merge] Carl Dong's PR adding
 support for reproducible builds of Bitcoin Core's Linux binaries using
 GNU Guix (pronounced "geeks").  Although Bitcoin Core has long provided
@@ -449,11 +471,13 @@ Gitian-based mechanism).
 Independently, documentation was added this year to both the
 [C-Lightning][cl repro] and [LND][lnd repro] repositories describing how
 to create reproducible builds of their software using trusted compilers.
+
 </div>
 
 ## August
 
 <div markdown="1" id="vaults">
+
 In August, Bryan Bishop described a method for implementing [vaults on
 Bitcoin without using covenants][].  *Vaults* is a term used to describe a
 script that limits an attacker's ability to steal funds even if they
@@ -469,9 +493,11 @@ proposals as well as a mitigation for the weakness that would limit the
 maximum amount of funds that could be stolen from a vault by an
 attacker.  The development of practical vaults could be useful for both
 individual users and large custodial organizations such as exchanges.
+
 </div>
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2019 summary<br>Bitcoin Optech
 
 In Optech's second year, we signed up six new member companies, held an
@@ -495,6 +521,7 @@ feed][].
 ## September
 
 <div markdown="1" id="snicker">
+
 Adam Gibson [proposed][snicker] a novel form of non-interactive
 [coinjoin][topic coinjoin] for the existing Bitcoin system.  The
 protocol, called SNICKER, involves a user selecting one of their UTXOs
@@ -512,6 +539,7 @@ SNICKER's major advantages over other coinjoin approaches are that it
 doesn't require the users be online at the same time and that it should
 be easy to add support for it to any wallet that already has [BIP174][]
 PSBT support, which is an increasing number of wallets.
+
 </div>
 
 {:#ln-cve}
@@ -532,6 +560,7 @@ communication protocol will help avoid other failures of this type.
 ## October
 
 <div markdown="1" id="anchor-outputs">
+
 LN developers made significant progress in October and November towards
 addressing a long-standing concern about ensuring that users can always
 close their channels without excessive delays.  If a user decides that
@@ -567,9 +596,11 @@ on the [revisions][anchor outputs] to the LN scripts and protocol
 messages necessary to start using the change.  As of this writing, those
 specification changes are awaiting final implementation and acceptance
 before seeing deployment on the network.
+
 </div>
 
 <div markdown="1" class="callout" id="new-infrastructure">
+
 ### 2019 summary<br>New open source infrastructure solutions
 
 - [Proof of reserves tool][] released in February allows exchanges and
@@ -587,11 +618,13 @@ before seeing deployment on the network.
   June) provides a non-custodial service that allows users to add or
   remove funds from their LN channels without closing existing channels
   or opening new channels.
+
 </div>
 
 ## November
 
 <div markdown="1" id="bech32-mutability">
+
 Discussion in November about using bech32 addresses for [taproot][topic
 taproot] payments brought additional attention to an [issue][bech32
 malleability issue] discovered in May.  According to [BIP173][],
@@ -617,6 +650,7 @@ addresses.  He also described a small tweak to the bech32 algorithm that
 will allow other applications using bech32, as well as next-generation
 Bitcoin address formats, to use BCH error detection without this
 problem.
+
 </div>
 
 {:#openssl}

--- a/_posts/en/newsletters/2020-12-23-newsletter.md
+++ b/_posts/en/newsletters/2020-12-23-newsletter.md
@@ -144,6 +144,7 @@ possible solutions to this problem for both Bitcoin's current ECDSA
 signature system and the proposed [schnorr signature][topic schnorr signatures] system.
 
 <div markdown="1" class="callout" id="taproot">
+
 ### 2020 summary<br>Taproot, tapscript, and schnorr signatures
 
 Nearly every month of 2020 saw some notable development related to the
@@ -423,6 +424,7 @@ operator to opt in to creating and serving compact block filters by
 enabling just two configuration options.
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2020 summary<br>Major releases of popular infrastructure projects
 
 - [LND 0.9.0-beta][] released in January improved the access control list
@@ -619,6 +621,7 @@ broadcast time.  This simplifies the LN protocol and improves several
 aspects of its security.
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2020 summary<br>Bitcoin Optech
 
 In Optech's third year, 10 new member companies joined<!-- Veriphi,
@@ -629,6 +632,7 @@ published 51 weekly newsletters<!-- 78 to 129 -->, added 20 new pages to
 our [topics index][], added several new wallets and services to our
 [compatibility index][], and published several contributed [blog
 posts][optech blog posts] about Bitcoin scaling technology.
+
 </div>
 
 ## September

--- a/_posts/en/newsletters/2021-07-28-newsletter.md
+++ b/_posts/en/newsletters/2021-07-28-newsletter.md
@@ -155,9 +155,17 @@ BOLTs][bolts repo].*
     </tr>
 
     <tr>
-     <th markdown="span">Third-party purchased liquidity ("[sidecar channels][]")</th>
+     <th markdown="span">
+
+     Third-party purchased liquidity ("[sidecar channels][]")
+
+     </th>
      <td>Yes, Alice can pay Bob to fund a channel to Carol</td>
-     <td markdown="span">[Maybe.]({{bse}}107786)</td>
+     <td markdown="span">
+
+     [Maybe.]({{bse}}107786)
+
+     </td>
     </tr>
 
   </table>

--- a/_posts/en/newsletters/2021-12-22-newsletter.md
+++ b/_posts/en/newsletters/2021-12-22-newsletter.md
@@ -135,6 +135,7 @@ counterarguments were presented and community support for taproot seemed
 to be unchanged.
 
 <div markdown="1" class="callout" id="taproot">
+
 ### 2021 summary<br>Taproot activation
 
 By the end of 2020, an implementation of the [taproot][topic taproot]
@@ -293,6 +294,7 @@ state.  That initial ability to receive funds makes dual-funding particularly us
 use of LN is receiving payments instead of sending them.
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2021 summary<br>Major releases of popular infrastructure projects
 
 - [Eclair 0.5.0][] added support for a scalable cluster mode (see
@@ -498,6 +500,7 @@ differently.  By the end of the year, a [variation][cl#4771] on the
 technique would be implemented in C-Lightning.
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2021 summary<br>Bitcoin Optech
 
 In Optech's fourth year, we published 51 weekly [newsletters][], added 30

--- a/_posts/en/newsletters/2022-05-18-newsletter.md
+++ b/_posts/en/newsletters/2022-05-18-newsletter.md
@@ -572,7 +572,9 @@ Alex Morcos.
 {% assign sorted_praise = page.praise | sort_natural: "author" %}
 {% for comment in sorted_praise %}
   <blockquote markdown="1">
+
   {{comment.text | default: 'TODO'}}
+
   </blockquote>
 
   {:.right}

--- a/_posts/en/newsletters/2022-12-21-newsletter.md
+++ b/_posts/en/newsletters/2022-12-21-newsletter.md
@@ -124,6 +124,7 @@ in March of support for the related Short Channel IDentifier (SCID)
 ![Illustration of zero-conf channels](/img/posts/2021-07-zeroconf-channels.png)
 
 <div markdown="1" class="callout" id="rbf">
+
 ### 2022 summary<br>Replace-By-Fee
 
 This year saw much discussion, and some significant actions, related to
@@ -269,6 +270,7 @@ Several additional libbitcoinkernel PRs would be merged through the
 year.
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2022 summary<br>Major releases of popular infrastructure projects
 
 - [Eclair 0.7.0][news185 eclair] added support for [anchor
@@ -448,6 +450,7 @@ would not know which onchain transactions were based on its BLS
 signatures.
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2022 summary<br>Bitcoin Optech
 
 In Optech's fifth year, we published 51 weekly [newsletters][] and added 11
@@ -547,6 +550,7 @@ Stratum version 2 mining protocol, and getting code merged into Bitcoin
 Core and other free software projects.
 
 <div markdown="1" class="callout" id="softforks">
+
 ### 2022 summary<br>Soft fork proposals
 
 January began with Jeremy Rubin [holding][news183a ctv] the first of
@@ -657,6 +661,7 @@ cryptocurrency systems but would be compatible with Bitcoin's existing
 UTXO-based system.
 
 </div>
+
 ## November
 
 {:#fat-errors}

--- a/_posts/en/newsletters/2024-02-28-newsletter.md
+++ b/_posts/en/newsletters/2024-02-28-newsletter.md
@@ -159,48 +159,100 @@ infrastructure projects.
   <tr>
     <th></th>
     <th>Presigned</th>
-    <th markdown="span">BIP345 `OP_VAULT`</th>
-    <th markdown="span">`OP_CAT` with schnorr</th>
+    <th markdown="span">
+
+    BIP345 `OP_VAULT`
+
+    </th>
+    <th markdown="span">
+
+    `OP_CAT` with schnorr
+
+    </th>
   </tr>
 
   <tr>
     <th>Availability</th>
-    <td markdown="span">**Now**</td>
-    <td markdown="span">Requires soft fork of `OP_VAULT` and [OP_CTV][topic op_checktemplateverify]</td>
-    <td markdown="span">Requires soft fork of `OP_CAT`</td>
+    <td markdown="span">
+
+    **Now**
+
+    </td>
+    <td markdown="span">
+
+    Requires soft fork of `OP_VAULT` and [OP_CTV][topic op_checktemplateverify]
+
+    </td>
+    <td markdown="span">
+
+    Requires soft fork of `OP_CAT`
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">Last-minute address replacement attack</th>
     <td markdown="span">Vulnerable</td>
-    <td markdown="span">**Not vulnerable**</td>
-    <td markdown="span">**Not vulnerable**</td>
+    <td markdown="span">
+
+    **Not vulnerable**
+
+    </td>
+    <td markdown="span">
+
+    **Not vulnerable**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">Partial amount withdrawals</th>
     <td markdown="span">Only if prearranged</td>
-    <td markdown="span">**Yes**</td>
+    <td markdown="span">
+
+    **Yes**
+
+    </td>
     <td markdown="span">No</td>
   </tr>
 
   <tr>
     <th markdown="span">Static and non-interactive computable deposit addresses</th>
     <td markdown="span">No</td>
-    <td markdown="span">**Yes**</td>
-    <td markdown="span">**Yes**</td>
+    <td markdown="span">
+
+    **Yes**
+
+    </td>
+    <td markdown="span">
+
+    **Yes**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">Batched re-vaulting/quarantining for fee savings</th>
     <td markdown="span">No</td>
-    <td markdown="span">**Yes**</td>
+    <td markdown="span">
+
+    **Yes**
+
+    </td>
     <td markdown="span">No</td>
   </tr>
 
   <tr>
-    <th markdown="span">Operational efficiency in best case, i.e. only legitimate spends<br>*(only very roughly estimated by Optech)*</th>
-    <td markdown="span">**2x size of regular single-sig**</td>
+    <th markdown="span">
+
+    Operational efficiency in best case, i.e. only legitimate spends<br>*(only very roughly estimated by Optech)*
+
+    </th>
+    <td markdown="span">
+
+    **2x size of regular single-sig**
+
+    </td>
     <td markdown="span">3x size of regular single-sig</td>
     <td markdown="span">4x size of regular single-sig</td>
   </tr>

--- a/_posts/fr/newsletters/2020-12-23-newsletter.md
+++ b/_posts/fr/newsletters/2020-12-23-newsletter.md
@@ -144,6 +144,7 @@ problème pour le système de signature ECDSA actuel de Bitcoin et le système
 proposé de [signature schnorr][topic schnorr signatures].
 
 <div markdown="1" class="callout" id="taproot">
+
 ### Sommaire 2020<br>Taproot, tapscript, et signatures schnorr
 
 Presque tous les mois de l'année 2020 ont été marqués par un développement
@@ -429,6 +430,7 @@ possibilité pour un opérateur de nœud d'opter pour la création et le service
 de filtres de blocs compacts en activant seulement deux options de configuration.
 
 <div markdown="1" class="callout" id="releases">
+
 ### Sommaire 2020<br>Mise à jour majeure des principaux projets d'infrastructure
 
 - [LND 0.9.0-beta][] a publié en janvier une amélioration du mécanisme
@@ -637,6 +639,7 @@ le nœud peut choisir un taux de frais approprié au moment de la diffusion. Cel
 simplifie le protocole LN et améliore plusieurs aspects de sa sécurité.
 
 <div markdown="1" class="callout" id="optech">
+
 ### Sommaire 2020<br>Bitcoin Optech
 
 Au cours de la troisième année d'existence d'Optech, 10 nouvelles sociétés

--- a/_posts/fr/newsletters/2021-12-22-newsletter.md
+++ b/_posts/fr/newsletters/2021-12-22-newsletter.md
@@ -142,6 +142,7 @@ Un grand nombre de contre-arguments ont été présentés et le soutien de
 la communauté pour taproot semble être inchangé.
 
 <div markdown="1" class="callout" id="taproot">
+
 ### Sommaire 2021<br>Activiation de Taproot
 
 Fin 2020, une implémentation de l'embranchement convergent [taproot][topic taproot]
@@ -309,6 +310,7 @@ dont l'utilisation principale de LN est de recevoir des paiements
 au lieu de les envoyer.
 
 <div markdown="1" class="callout" id="releases">
+
 ### Sommaire 2021<br>Mises à jour et version candidate
 
 - [Eclair 0.5.0][] a ajouté la prise en charge d'un mode cluster évolutif
@@ -541,6 +543,7 @@ de l'année, une [variation][cl#4771] de cette technique sera implémentée
 dans C-Lightning.
 
 <div markdown="1" class="callout" id="optech">
+
 ### Sommaire 2021<br>Bitcoin Optech
 
 Au cours de la quatrième année d'Optech, nous avons publié 51 [bulletins][]

--- a/_posts/fr/newsletters/2023-12-20-newsletter.md
+++ b/_posts/fr/newsletters/2023-12-20-newsletter.md
@@ -161,6 +161,7 @@ pénalité réglable de Law, qui n'a connu aucun développement logiciel public 
 ![Protocole de pénalité réglable](/img/posts/2023-03-tunable-commitment.dot.png)
 
 <div markdown="1" class="callout" id="softforks">
+
 ### Résumé 2023<br>Propositions de soft fork
 
 Une [proposition][jan op_vault] pour un nouvel opcode `OP_VAULT` a été publiée en Janvier par James O'Beirne, suivi en
@@ -300,6 +301,7 @@ ses compromis et comment le logiciel peut l'utiliser efficacement. Des travaux e
 pour Bitcoin Core ont également été [discutés][aug sp] lors d'une réunion du Bitcoin Core PR Review Club.
 
 <div markdown="1" class="callout" id="security">
+
 ### Résumé 2023<br>Vulnérabilités de sécurité
 
 Optech a signalé trois vulnérabilités de sécurité importantes cette année :
@@ -374,6 +376,7 @@ le traitement des transactions sérialisées régulières, ce qui est un comprom
 par satellite ou le transfert stéganographique.
 
 <div markdown="1" class="callout" id="releases">
+
 ### Résumé 2023<br>Mises à jour majeures des principaux projets d'infrastructure
 
 - [Eclair 0.8.0][jan eclair] a ajouté la prise en charge des [canaux sans confirmation][topic zero-conf channels] et des alias
@@ -530,6 +533,7 @@ il a payé, mais le verrouillage temporel pourrait également être utilisé par
 quantité excessive du capital du fournisseur.
 
 <div markdown="1" class="callout" id="optech">
+
 ### Résumé 2023<br>Bitcoin Optech
 
 {% comment %}<!-- commands to help me create this summary for next year

--- a/_posts/fr/newsletters/2024-02-28-newsletter.md
+++ b/_posts/fr/newsletters/2024-02-28-newsletter.md
@@ -132,47 +132,99 @@ versions candidates, ainsi que les changements apportés aux principaux logiciel
   <tr>
     <th></th>
     <th>Pré-signé</th>
-    <th markdown="span">BIP345 `OP_VAULT`</th>
-    <th markdown="span">`OP_CAT` avec schnorr</th>
+    <th markdown="span">
+
+    BIP345 `OP_VAULT`
+
+    </th>
+    <th markdown="span">
+
+    `OP_CAT` avec schnorr
+
+    </th>
   </tr>
 
   <tr>
     <th>Disponibilité</th>
-    <td markdown="span">**Maintenant**</td>
-    <td markdown="span">Nécessite un soft fork de `OP_VAULT` et [OP_CTV][topic op_checktemplateverify]</td>
-    <td markdown="span">Nécessite un soft fork de `OP_CAT`</td>
+    <td markdown="span">
+
+    **Maintenant**
+
+    </td>
+    <td markdown="span">
+
+    Nécessite un soft fork de `OP_VAULT` et [OP_CTV][topic op_checktemplateverify]
+
+    </td>
+    <td markdown="span">
+
+    Nécessite un soft fork de `OP_CAT`
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">Attaque de remplacement d'adresse de dernière minute</th>
     <td markdown="span">Vulnérable</td>
-    <td markdown="span">**Non vulnérable**</td>
-    <td markdown="span">**Non vulnérable**</td>
+    <td markdown="span">
+
+    **Non vulnérable**
+
+    </td>
+    <td markdown="span">
+
+    **Non vulnérable**
+
+    </td>
   </tr>
   <tr>
     <th markdown="span">Retraits partiels de montant</th>
     <td markdown="span">Seulement si préarrangé</td>
-    <td markdown="span">**Oui**</td>
+    <td markdown="span">
+
+    **Oui**
+
+    </td>
     <td markdown="span">Non</td>
   </tr>
 
   <tr>
     <th markdown="span">Adresses de dépôt calculables statiques et non interactives</th>
     <td markdown="span">Non</td>
-    <td markdown="span">**Oui**</td>
-    <td markdown="span">**Oui**</td>
+    <td markdown="span">
+
+    **Oui**
+
+    </td>
+    <td markdown="span">
+
+    **Oui**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">Regroupement pour re-vaulting/mise en quarantaine pour économie de frais</th>
     <td markdown="span">Non</td>
-    <td markdown="span">**Oui**</td>
+    <td markdown="span">
+
+    **Oui**
+
+    </td>
     <td markdown="span">Non</td>
   </tr>
 
   <tr>
-    <th markdown="span">Efficacité opérationnelle dans le meilleur cas, c'est-à-dire uniquement les dépenses légitimes<br>*(estimé très approximativement par Optech)*</th>
-    <td markdown="span">**2x la taille d'une signature unique régulière**</td>
+    <th markdown="span">
+
+    Efficacité opérationnelle dans le meilleur cas, c'est-à-dire uniquement les dépenses légitimes<br>*(estimé très approximativement par Optech)*
+
+    </th>
+    <td markdown="span">
+
+    **2x la taille d'une signature unique régulière**
+
+    </td>
     <td markdown="span">3x la taille d'une signature unique régulière</td>
     <td markdown="span">4x la taille d'une signature unique régulière</td>
   </tr>

--- a/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
@@ -99,6 +99,7 @@ https://github.com/btcpayserver/btcpayserver/pull/1152 -->.  HWIはハードウ�
 部分的署名ビットコイン・トランザクション  ([PSBTs][topic psbt])の組み合わせでやり取りすることを容易にします。2019年は標準化されたフォーマットやAPIのサポートが進んだことにより、ユーザが特定のソリューションのみを選択するのではなく、ニーズに応じてハードウェアとソフトウェア・ソリューションの適切な組み合わせを選択することが容易にできるようになりました。
 
 <div markdown="1" id="miniscript">
+
 さらに2月には、Pieter Wuilleが[Stanford Blockchain Conference][] にて彼が取り組んでいたoutput script descriptorsのスピンアウトである[miniscript][topic miniscript]に関する [プレゼンテーション][wuille sbc miniscript]を実施しました。Miniscriptはビットコイン・スクリプトの階層化表現であり、ソフトウェアによる自動分析を簡素化します。これにより、スクリプトを満たすためにウォレットが提供する必要があるデータ（例えば、署名、ハッシュプリイメージ）、スクリプトにより利用されるトランザクションデータ量とそれを満たすデータ、ならびに、スクリプトがコンセンサス・ルールと一般的なトランザクション・リレー・ポリシーをパスするかどうかが分析可能となります。
 
 Miniscriptに加えて、WuilleとAndrew PoelstraとSanket Kanjalkarは、miniscriptへコンパイルされるコンポーザブルなポリシー言語を提供しました（miniscript自体はBitcoin Scriptへ変換されます）。ポリシー言語により、コインを利用するために満たすべき条件を容易に記述することができます。複数のユーザでコインを共有してコントロールしたい場合、ポリシー言語のコンポーザビリティによりそれぞれのユーザーのサイン・ポリシーを一つのスクリプトで組み合わせることが容易になりました。
@@ -106,25 +107,32 @@ Miniscriptに加えて、WuilleとAndrew PoelstraとSanket Kanjalkarは、minisc
 これが広範囲に普及した場合、異なるビットコインを扱うシステムが共に１つのトランザクションに署名することが容易になり、ウォレットのフロントエンド、LNノード、コインジョイン・システム、マルチシグ・ウォレット、コンシューマ・ハードウェア・ウォレット、ハードウェア・署名・モジュール（HSM）やその他のハードウェア、ソフトウェアを統合するために必要なカスタムコードの量が、大幅に削減されます。
 
 Wuilleと彼の協力者らは、1年を通じてminiscriptに取り組み続け、続いて[コミュニティ・フィードバックを求め][news61 miniscript feedback]、ビットコイン・コアにサポートを追加する[PRを開きました][Bitcoin Core #16800]。Miniscriptは12月にLNディベロッパーにより、アップグレードされたバージョンによるオンチェーン・トランザクションの複数の新しいスクリプトを[分析し最適化する][anchor miniscript]ために利用されました。
+
 </div>
 
 ## March
 
 <div markdown="1" id="cleanup">
+
 3月には、Matt Corallo がビットコインのコンセンサス・コードの潜在的な問題を取り除く[consensus cleanup soft fork][topic consensus cleanup]を提案しました。これらが適用されることにより、[time warp attack][]の解消、レガシー・スクリプトの[ワーストケースのCPU使用量][worst case CPU usage]の低減、キャッシュしているトランザクション検証結果の信頼性向上、既知の（コストはかかる）[軽量クライアントへの攻撃][news37 merkle tree attacks]の解消が見込まれます。
 
 Time-warp のフィックスなど一部の提案は多くの人々の関心を引きつけましたが、ワーストケースのCPU使用量、検証結果のキャッシュのフィックスに関しての提案は、[批判][news37 cleanup discussion]も受けました。おそらく、それ故にこの年の後半にかけて実装に向けて当提案が進捗することはありませんでした。
+
 </div>
 
 <div markdown="1" id="signet">
+
 また3月には、Kalle Almが、[signet][topic signet]に関するイニシャル・フィードバックをリクエスト、後に[BIP325][]となりました。Singet プロトコルは、全ての有効なブロックが中央集権型パーティによって署名される必要があるテストネットを作ることが可能です。この中央集権化はビットコインとは正反対のものですが、テスターが破壊的なシナリオ（chain  reorganizationなど）を作成したり、単にソフトウェア相互運用性テストを実施したい場合などに、テストネットとして理想的なものとなります。既存のビットコインのテストネットでは、reorgやその他のディスラプションが頻繁に発生、またそれが長期間にわたることもあり、テスト実施を非現実的なものとしています。
 
 Signetは一年を通じて成熟していき、ゆくゆくはC-Lightningといったソフトウェアに[統合][cl signet]、[eltoo][]のデモなどに利用されていくでしょう。ビットコイン・コアにサポートを追加する[プルリクエスト][Bitcoin Core #16411]はオープンになっています。
+
 </div>
 
 {:#loop}
 さらに、3月にはLightning Labsが[Lightning Loop][]を発表し、チャネルをクローズすることなく、オンチェーンのUTXOにLNチャネルからファンドの一部を引き出すノン・カストディアル・ソリューションを提供しました。6月には、既存のチャネルにUTXOを送信（追加）できるようLoopを[アップグレード][loop-in]しました。Loopは通常のオフチェーン・LN・トランザクションで使用されているHash Time Locked Contracts (HTLCs)を使用し、想定通りユーザのファンドがLNチャネルに転送されているか、もしくは、オンチェーントランザクションフィー以外の全てのコストのリファンドをユーザが受け取ることを保証します。これによりLoopはほぼ完全にトラストレスになります。
+
 <div markdown="1" class="callout" id="releases">
+
 ### 2019 summary<br>Major releases of popular infrastructure projects
 
 - [C-Lightning 0.7][] は、3月にリリースされ、年末までにかなり利用されるプラグイン・システムを追加しました。また、監査性を強化した安全性の高い[再現可能なビルド][topic reproducible builds]をサポートする最初のC-Lightningリリースとなりました。
@@ -143,6 +151,7 @@ Signetは一年を通じて成熟していき、ゆくゆくはC-Lightningとい
   filters] （現時点ではRPCのみ）の初期サポートを追加し、[BIP37][] ブルーム・フィルターならびに[BIP70][] payment requestsをデフォルトにするプロトコルを無効化することでセキュリティを改善しました。また、GUIユーザーをbech32アドレスをデフォルトにしました。
 
 - [C-Lightning 0.8][]は12月にリリースされ、[multipath payments][topic multipath payments] のサポートを追加、デフォルトネットワークをテストネットからメインネットに変更しました。また、デフォルトでsqliteサポートに加えてpostgresqlサポートを提供するなど代替データベースをサポートする最初のメジャーリリースとなりました。
+
 </div>
 
 ## April
@@ -153,31 +162,38 @@ Signetは一年を通じて成熟していき、ゆくゆくはC-Lightningとい
 AssumeUTXOでは、ノードは最終的に初期のUTXOの状態を検証できるまで、バックグラウンドでブロックチェーンのヒストリーをダウンロード、検証することを提案しています。これにより、最終的にAssumeUTXOを利用しない通常のノードと同等のトラストレスなセキュリティを確保することができます。O'Beirneは年間を通じてプロジェクトに取り組み、 徐々に[新しい機能][dumptxoutset]を追加し、将来的にAssumeUTXOをビットコイン・コアに取り込むため既存コードのリファクタリングを実施しました。
 
 <div markdown="1" id="trampoline">
+
 また、4月には、Pierre-Marie Padiouが[トランポリン・ペイメント][topic trampoline payments]のアイデアを[提案][trampoline proposed]しました。これは、軽量LNノードがパス・ファインディングを重量ルーチング・ノードにアウトソースします。モバイルアップなどの軽量ノードは、すべてのLNルーティング・グラフをトラックすることが出来ないかもしれないため、ルート探索が困難になります。Padiouの提案は、軽量ノードにペイメントを近接ノードへルートし、そのノードに残りのパスを計算させるものです。ペイメントはトランポリンノードを経由して（跳ねて）行き先までたどり着きます。
 プライバシー向上のため、支払者は順番に複数のトランポリンノードからの支払いの跳ね返りを要求する場合があります。これにより支払いが最終的な受取人宛なのか、または別のトランポリンノードにルーティングしているかどうか各ノードは分からなくなります。
 
 LN仕様にトランポリン・ペイメントの機能を追加するための[PR][trampolines pr] は現在オープンになっており、Eclairの実装はトランポリン・ペイメントをリレーする [実験的なサポート][exp tramp] を追加しています。
+
 </div>
 
 ## May
 
 <div markdown="1" id="taproot">
+
 5月にはPieter Wuilleは、[bip-taproot][]と [bip-tapscript][]からなる[taproot soft fork][topic taproot]を提案しました。これらは共に昨年の [bip-schnorr][] の提案の内容を継承しています。これらが実装されると、シングルシグ、マルチシグや多くのコントラクトにおいて同じスタイルのscriptPubKeysを使用することが可能になります。マルチシグや複雑なコントラクトの多くの支払いが、同様に見え、シングルシグの支払いにように見えます。これにより、大きくユーザ・プライバシーとコイン・ファンジビリティを改善すると同時に、マルチシグ、コントラクト・ユースケースにて消費されるブロックチェーンスペースの量を削減できます。
 
 マルチシグとコントラクトの支払いがtaprootのプライバシーとスペース節約をフル活用出来ない場合でも、オンチェーンにコードのサブセットのみを入れれば良いだけかもしれません。それにより、現在よりもよいプライバシーとブロックチェーンスペース効率向上が見込まれます。Taprootに加えて、[tapscript][topic tapscript]によりビットコインのスクリプトの能力を改良します。主に、将来、新しいopcodeを追加することをより簡単にきれいにできるようにします。
 
 この提案は残りの1年に渡り、多くの議論とレビューが実施されました。その中にはAnthony Townsによって開催されました、150人以上がレビューの手助けをするためにサインアップした[group review sessions][taproot review] などが含まれます。
+
 </div>
 
 <div markdown="1" id="anyprevout">
+
 Townsは5月にtapscriptと組み合わせて利用できる2つの新しい署名ハッシュである、`SIGHASH_ANYPREVOUT`と`SIGHASH_ANYPREVOUTANYSCRIPT`を提案しました。
 
 署名ハッシュ(sighash)は、署名がコミットするトランザクションのフィールドと関連するデータのハッシュです。ビットコインにおいて異なるsighashはトランザクションの異なる部分にコミットします。それにより、署名者にオプションとして、他のユーザがトランザクションに対して特定の修正を実施できるようにします。2つの新しく提案されたsighashは、UTXO[BIP118][]の[SIGHASH_NOINPUT][topic sighash_anyprevout]と同様に機能します。意図的に利用するUTXOを特定しないことにより、（例えば、同一のpubkeyを利用するなど）スクリプトが満たしさえすれば、署名によりいかなるUTXOでも送信することができます。
 
 インプットがないスタイルのsighashの主要な提案された利用方法は、LN向けに以前提案された[eltoo][topic eltoo] update layerを可能にすることです。Eltooはチャネル構築と管理を複数の観点から簡素化します。特にオンチェーンのチャネルコストを大きく削減できるため[2つ以上の参加者が含まれるチャネル][topic channel factories]を簡素化することが望ましいとされています。
+
 </div>
 
 <div markdown="1" id="ctv">
+
 当月に提案された3つ目のソフトフォークは、Jeremy Rubinからのもので、`OP_CHECKTEMPLATEVERIFY`(CTV)と呼ばれる新しい[opcode][coshv]です。これにより、例えば、本スクリプトを使用したトランザクションの後続トランザクションのoutputには他の特定のoutputが含まれている必要があるなど、限られた形式の契約(covenants)が可能になります。
 
  これの推奨される使用法は、後で数十、数百、または数千の異なる受信者に支払うトランザクション（またはトランザクションのツリー）を使用してのみ使用できる少量のoutputを将来支払うことにコミットすることです。
@@ -185,9 +201,11 @@ Townsは5月にtapscriptと組み合わせて利用できる2つの新しい署�
 これにより、コインジョインスタイルのプライバシーを強化し、セキュリティ強化された保管庫をサポートし、取引手数料が急増した場合の支出コストを管理するための新しい手法が可能になります。
 
 Rubinは、CTVの展開バージョンをより効果的に可能にするべくBitcoin Coreの一部の改善のためにPRを開くなど、CTVへの貢献を、本年の終わりまで実施しています。
+
 </div>
 
 <div markdown="1" class="callout" id="conferences">
+
 ### 2019 summary<br>Notable technical conferences and other events
 
 - [Stanford Blockchain Conference][], January, Stanford University
@@ -199,18 +217,22 @@ Rubinは、CTVの展開バージョンをより効果的に可能にするべく
 - [Edge Dev++][], September, Tel Aviv
 - [Scaling Bitcoin][], September, Tel Aviv
 - [Cryptoeconomic Systems Summit][], October, MIT
+
 </div>
 
 ## June
 
 <div markdown="1" id="erlay-and-other-p2p-improvements">
+
 Gleb Naumenko、Pieter Wuille、Gregory Maxwell、Sasha Fedorova、Ivan
 Beschastnikhは[erlay][topic erlay]の[論文][erlay]を発表しました。アナウンスのバンドワイズを試算上84%削減する [libminisketch-based][topic minisketch] set reconciliationを利用した、ノード間でコンファームしていないトランザクションアナウンスをリレーするプロトコルです。論文ではerlayによりノードがデフォルトで接続するアウトバウンド接続の数を大幅に増加することが実現可能になることも記載されています。これは、ほとんどのPoWのブロックチェーンにないブロックをエクセプトすることでノードを騙す[エクリプス攻撃][eclipse attacks]に対する各ノードの耐性を改善します。より多くのアウトバウンド接続が可能になることで、トラックしたり、ノードが起点とするペイメントを遅延させるなど他の攻撃に対するノードの耐性を改善します。Erlayに関するワークは、追加の研究やreconciliation protocolの[BIP330][] の提案など一年間に渡り続きました。
 
 今年のP2Pリレーにおける他の改善は、ビットコイン・コアの[トランザクション・リレーのプライバシー改善][#14897]（Sergi Delgado-Seguraらによる[TxProbe][] 論文に記載されている問題を取り除く）と エクリプス攻撃に対する抵抗を改善する、新しいブロックのリレーにのみ使われる [2つの追加アウトバウンド接続][two extra outbound connections]の追加です。
+
 </div>
 
 <div markdown="1" id="watchtowers">
+
 数多くの先行ワークを経て、6月にLNDにaltruist(利他的) [LN watchtowers][topic watchtowers] が[マージ][altruist watchtowers]されました。Altruist watchtowersでは、クライアントのチャネルを保護することの対価として、プロトコル経由でいかなる報酬も受け取りません。それゆえ、ユーザは自分自身のwatchtowerを建てるか、watchtower operatorの慈善に依存しますが、他のユーザの代わりにペナルティ・トランザクションをwatchtowerが確実に送信することのデモとしては十分だと思われます。これにより長期間オフラインになるユーザーが資金を失わないことを確実にします。
 
 Altruist watchtowersは、最終的には [LND 0.7.0-beta][lnd 0.7-beta] でリリースされ、年内に追加の開発が実施されました。それらには、[watchtowerの仕様提案][watchtower spec] や [eltoo][topic eltoo]のような次世代のペイメント・チャネルとの組み合わせに関する[議論][eltoo watchtowers]が含まれます。
@@ -220,37 +242,45 @@ Altruist watchtowersは、最終的には [LND 0.7.0-beta][lnd 0.7-beta] でリ�
 ## July
 
 <div markdown="1" id="reproducibility">
+
 7月には、Carl DongのPRがビットコイン・コア・プロジェクトに[マージ][guix merge] されました。これは、GNU Guix （"geeks"と発音する）を利用してビットコイン・コアのLinuxバイナリーのビルド再現性のサポートを追加するものです。ビットコイン・コアは、これまで[Gitian][] システムを使った再現性のあるビルドをサポートしてきましたが、セットアップが難しく、数百ものUbuntu パッケージのセキュリティに依存しています。比べて、Guixはインストール、実行が容易で、Guixを用いてビットコイン・コアをビルドした場合、パッケージの依存関係がより少なくなります。長期的には、Guixのコントリビューターは、`bitcoind`のようなバイナリーが単独で監査可能なソースコードから得られたことをユーザーが検証できるようにするために[trusting trust][]問題を取り除けるように作業しています。
 
 2020年にリリースされるビットコイン・コアの最初のメジャー・バージョンでGuixが使われることに期待を寄せており（おそらく古いGitianベースのメカニズムと並行して使用される）、1年を通じてGuixビルド・サポートの作業が続けられました。
 
 また、[C-Lightning][cl repro]と[LND][lnd repro]のレポジトリーに信頼できるコンパイラーを使ってそれらのSWの再現性のあるビルドの作成方法に関するドキュメンテーションが追加されました。
+
 </div>
 
 ## August
 
 <div markdown="1" id="vaults">
+
 8月には、Bryan Bishopが[covenantsを使わないビットコインにおけるVaults][vaults on
 Bitcoin without using covenants]の実装手法を提案しました。*Vaults*は、仮に攻撃者がユーザの通常の秘密鍵を入手したとしても、攻撃者がファンドを盗む能力を制限するスクリプトを表すために使われる用語です。*[Covenant][topic covenants]*は他の特定のスクリプトに対してのみ送信できるスクリプトのことです。現在のビットコイン・スクリプト言語を利用してCovenantsを作成する既知の方法はありませんが、お金をvault contractにデポジットする際にユーザがいくつかのステップを実行するコードを走らすことができれば、Covenantsが必ずしも必要ではないことが分かりました。
 
 特に、Bishopはvaultの弱点とその軽減方法についても記載しました。攻撃者によってvaultから盗むことの出来る最大資金を制限することができるというものです。実用的なvaultの開発は、個人のユーザ、取引所などの大規模なカストディアン事業者にとっても有用です。
+
 </div>
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2019 summary<br>Bitcoin Optech
 
 2年目のOptechは、6社の新規メンバーのサインアップ、NYCブロックチェーン・ウィークに[executive briefing][optech executive briefing]の開催、 [24週連続][bech32 sending support] のbech32送信のサポートのプロモーション、websiteにウォレット、サービスの[compatibility matrix][]の追加、51週分の[newsletters][]の発行<!-- #28 to
 #78, inclusive -->、一部のニュースレター、ブログの[日本語][xlation ja]や[スペイン語][xlation es]などへの翻訳の開始、 [topics index][]の作成、[Scalability Workbook][]へのチャプターの作成、パブリックにリリースされた[jupyter notebooks][]を用いた2回の [schnorr/taproot workshops][] の開催、[BTSE][]と[BRD][]によるフィールドレポートの発行などを実施しました。
 
 2020年も大きなプランがあり、皆様には継続して[Twitter][]をフォロー、 [weekly newsletter][]を購読し、または、[RSS feed][]を追っていただけることを期待いたします。
+
 </div>
 
 ## September
 
 <div markdown="1" id="snicker">
+
 Adam Gibsonは既存ビットコイン・システム向けの非対話型・[コインジョイン][topic coinjoin]を[提案][snicker]しました。SNICKERと呼ばれるプロトコルは、ユーザが自身のUTXOの一つを選択し、グローバルなUTXOセットからランダムにUTXOを1つ選択し、同一のトランザクションで利用します。提案者がこのトランザクションの一部に署名し、パブリックサーバーに部分的署名ビットコイン・トランザクション([PSBT][topic psbt])のフォーマットでアップロードします。他のユーザーがサーバをチェックし、PSBTを確認したら、ダウンロードして署名し、ブロードキャストすることができます。これにより、両者が同時にオンラインである必要がなく、コインジョインを完成できます。提案者は、他のユーザがコインジョインをアクセプトするまで、同じUTXOを利用してPSBTsを作りたいだけ作成し、アップロードすることができます。
 
 他のコインジョインのアプローチに対するSNICKERの主要な優位性は、両者が同時にオンラインである必要がないこと、ならびに、[BIP174][] PSBTサポート対応済みのウォレット（多くのウォレットが対応してきています）であれば簡単にサポート可能である点です。
+
 </div>
 
 {:#ln-cve}
@@ -259,15 +289,18 @@ Adam Gibsonは既存ビットコイン・システム向けの非対話型・[�
 ## October
 
 <div markdown="1" id="anchor-outputs">
+
 LNディベロッパーにより、過度の遅延なくユーザがいつでもチャネルをクローズ可能にするという長年の課題への対応に関して、10月から11月に非常に重要な進捗がありました。
 ユーザが複数のチャネルのうちの１つをクローズしたいが、リモート・ピアに連絡がつかない場合、ユーザはチャネルの最新の*コミットメント・トランザクション*をブロードキャストします。これは、オフチェーンのコントラクトの最新のバージョンでチャネルのファンドをそれぞれのオンチェーンで支払うpre-signed transactionです。この際にコミットメント・トランザクションが、数日から数週間前の安いトランザクション・フィーの頃に作成され、セキュリティー上重要なタイムロック期限の前までに取り込まれるのに十分な高いフィーが設定されていな可能性があります。
 
 この問題の解決策としては、fee bump commitment trasctionを可能にすることが知られています。しかしながら、ビットコイン・コアのノードでは帯域やCPUを消費するDenial of Service (DoS) 攻撃を防ぐためにfee bumpingを制限しています。LNのようなトラストレスでマルチユーザーのプロトコルでは、カウンター・パーティが、あなたのLNコミットメント・トランザクションのコンファメーションを遅延させるために故意にアンチ・DoS・ポリシーを発動する攻撃者であるかもしれません（[transaction pinning][topic transaction pinning]と呼ばれる攻撃です）。このトランザクションは、タイムロックが解除されるまでにコンファームされないかもしれないため、攻撃者はカウンターパーティからファンドを盗むことが可能になります。
 
 昨年、Matt Coralloは、Child-Pays-For-Parent (CPFP) fee bumpingに関連するビットコイン・コアのトランザクション・リレー・ポリシーの一部から、特例を除くことを[提案][carve-out proposed]しました。この特例は、2者のコントラクト・プロトコル（例えば、現在のLN）が、それぞれのパーティーに、彼ら自身のfee bumpを作成することを保証することが可能です。Coralloのアイデアは、[CPFP carve-out][topic cpfp carve out] という名称でBitcoin Core 0.19の一部としてリリースされました。その前のリリースでも、その他のLNディベロッパーがこの変更を利用開始するために必要なLNスクリプトやプロトコル・メッセージの[改定][anchor outputs]は実施されていました。当ニュースレター執筆段階では、これらの仕様変更はネットワークへのデプロイの前の最終実装・受け入れ待ちです。
+
 </div>
 
 <div markdown="1" class="callout" id="new-infrastructure">
+
 ### 2019 summary<br>新しいオープン・ソース・インフラストラクチャー・ソリューション
 
 - [Proof of reserves tool][] は、2月にリリースされました。これにより取引所やその他のビットコイン・カストディアン業者が [BIP127][] reserve proofs を利用して特定のUTXOのセットに対してコントロールしていることを証明することができます。
@@ -281,6 +314,7 @@ LNディベロッパーにより、過度の遅延なくユーザがいつでも
 ## November
 
 <div markdown="1" id="bech32-mutability">
+
 [Taproot][topic taproot] paymentsに bech32アドレスを利用するという11月の議論は、5月に発見された[bech32アドレスの問題][bech32 malleability issue] で注目を集めました。[BIP173][]によると、ミス・コピーされたbech32 文字列が検出されない失敗率は最悪でも10億回に1回程度とされてきました。しかしながら、`p`で終わるbech32 文字列は、その前に`q`を削除、挿入しても有効な文字列となります。これは実用的には、segwit P2WPKH、P2WSH addressesに影響を与えません。一つのアドレスタイプを別のものに変えるには少なくとも19連続で`q`が追加される、または削除される必要がありますが、v0 segwit addressの文字列の長さは固定長であり、変更されると無効となるためです。<!-- "19 characters" math in
 _posts/en/newsletters/2019-11-13-newsletter.md -->
 

--- a/_posts/ja/newsletters/2021-07-28-newsletter.md
+++ b/_posts/ja/newsletters/2021-07-28-newsletter.md
@@ -132,7 +132,11 @@ Taprootの準備に関する最新のコラム、新しいソフトウェアの�
    </tr>
 
    <tr>
-    <th markdown="span">第三者による流動性の購入("[sidecar channels][]")</th>
+    <th markdown="span">
+
+    第三者による流動性の購入("[sidecar channels][]")
+
+    </th>
     <td>はい。アリスはボブにキャロルとのチャネルの資金の支払いが可能</td>
     <td markdown="span">[おそらく可能]({{bse}}107786)</td>
    </tr>

--- a/_posts/ja/newsletters/2021-12-22-newsletter.md
+++ b/_posts/ja/newsletters/2021-12-22-newsletter.md
@@ -118,6 +118,7 @@ Bitcoinの元々の機能の1つである公開鍵のハッシュは（Bitcoin�
 多数の反論が提示され、Taprootに対するコミュニティの支持は変わりませんでした。
 
 <div markdown="1" class="callout" id="taproot-activation">
+
 ### 2021年のまとめ<br>Taprootの有効化
 
 2020年の年末に、[Schnorr署名][topic schnorr signatures]と[Tapscript][topic tapscript]のサポートを含む
@@ -245,6 +246,7 @@ AMPの1つの重大な欠点を考慮から排除しています。
 デュアル・ファンディングは特に有用です。
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2021年のまとめ<br>人気のあるインフラストラクチャプロジェクトのメジャーリリース
 
 - [Eclair 0.5.0][]では、スケーラブルなクラスターモード（[ニュースレター #128][news128 akka]参照）、
@@ -410,6 +412,7 @@ Fidelity bondは、サードパーティのシステムでの不正行為の代�
 C-Lightningに実装される予定です。
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2021年のまとめ<br>Bitcoin Optech
 
 Optechの4年めは、51の週刊[ニュースレター][newsletters]を発行し、

--- a/_posts/ja/newsletters/2022-05-18-newsletter.md
+++ b/_posts/ja/newsletters/2022-05-18-newsletter.md
@@ -491,7 +491,9 @@ Alex Morcosを含む[多くのサポーター][supporters]にも感謝します�
 {% assign sorted_praise = page.praise | sort_natural: "author" %}
 {% for comment in sorted_praise %}
   <blockquote markdown="1">
+
   {{comment.text | default: 'TODO'}}
+
   </blockquote>
 
   {:.right}

--- a/_posts/ja/newsletters/2022-12-21-newsletter.md
+++ b/_posts/ja/newsletters/2022-12-21-newsletter.md
@@ -110,6 +110,7 @@ LDKの関連するSCID（Short Channel IDentifier）*エイリアス*フィー�
 ![ゼロ承認チャネルの図](/img/posts/2021-07-zeroconf-channels.png)
 
 <div markdown="1" class="callout" id="rbf">
+
 ### 2022年のまとめ<br>Replace-By-Fee
 
 今年は、RBF（[Replace By Fee][topic rbf]）に関して多くの議論といくつかの重要なアクションがありました。
@@ -228,6 +229,7 @@ Bitcoin Coreの[CPFPによる手数料の引き上げ][topic cpfp]の重大な�
 いくつかの追加のPRが今年中にマージされるでしょう。
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2022年のまとめ<br>人気のあるインフラストラクチャプロジェクトのメジャーリリース
 
 - [Eclair 0.7.0][news185 eclair]は、[アンカー・アウトプット][topic anchor outputs]や
@@ -373,6 +375,7 @@ Bitcoinに変更を加えることなくBitcoin互換の[署名アダプター][
 オラクルはどのオンチェーントランザクションがそのBLS署名に基づくものなのか知りません。
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2022年のまとめ<br>Bitcoin Optech
 
 Optechの5年めは、51の週間[ニュースレター][newsletters]を発行し、
@@ -454,6 +457,7 @@ Stratumバージョン2マイニングプロトコル、
 Bryan Bishopによって[書き起こされた][news223 xscribe]いくつかのセッションがありました。
 
 <div markdown="1" class="callout" id="softforks">
+
 ### 2022年のまとめ<br>ソフトフォークの提案
 
 1月、Jeremy Rubinが[OP_CHECKTEMPLATEVERIFY][topic op_checktemplateverify] (CTV)のソフトフォークの提案を

--- a/_posts/ja/newsletters/2023-12-20-newsletter.md
+++ b/_posts/ja/newsletters/2023-12-20-newsletter.md
@@ -174,6 +174,7 @@ LNの他のユーザーのコストが削減される可能性があります。
 ![Tunable Penaltyプロトコル](/img/posts/2023-03-tunable-commitment.dot.png)
 
 <div markdown="1" class="callout" id="softforks">
+
 ### 2023年のまとめ<br>ソフトフォークの提案
 
 新しい`OP_VAULT`opcodeの[提案][jan op_vault]が、1月にJames O'Beirneによって投稿され、
@@ -329,6 +330,7 @@ Bitcoin Coreにサイレントペイメントを実装する進行中の作業�
 Bitcoin Core PR Review Clubミーティングで[議論されました][aug sp]。
 
 <div markdown="1" class="callout" id="security">
+
 ### 2023年のまとめ<br>セキュリティの開示
 
 Optechは今年、3つの重大なセキュリティの脆弱性について報告しました:
@@ -417,6 +419,7 @@ Bitcoinトランザクションの一様に分散したデータを圧縮する�
 これは、衛星によるブロードキャストやステガノグラフィーによる転送では許容可能なトレードオフです。
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2023年のまとめ<br>人気のインフラストラクチャプロジェクトのメジャーリリース
 
 - [Eclair 0.8.0][jan eclair]は、[ゼロ承認チャネル][topic zero-conf channels]と
@@ -585,6 +588,7 @@ Liquidity Adsから作成されたチャネルがタイムロックを含むべ�
 悪意のある購入者や配慮のない購入者によって、過剰な量の提供者の資本をロックするために使用される可能性もあります。
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2023年のまとめ<br>Bitcoin Optech
 
 {% comment %}<!-- commands to help me create this summary for next year

--- a/_posts/ja/newsletters/2024-02-28-newsletter.md
+++ b/_posts/ja/newsletters/2024-02-28-newsletter.md
@@ -129,48 +129,96 @@ lang: ja
   <tr>
     <th></th>
     <th>事前署名版</th>
-    <th markdown="span">BIP345 `OP_VAULT`</th>
-    <th markdown="span">`OP_CAT`とSchnorr</th>
+    <th markdown="span">
+
+    BIP345 `OP_VAULT`
+
+    </th>
+    <th markdown="span">
+
+    `OP_CAT`とSchnorr
+
+    </th>
   </tr>
 
   <tr>
     <th>有効性</th>
-    <td markdown="span">**現在利用可能**</td>
-    <td markdown="span">`OP_VAULT`と[OP_CTV][topic op_checktemplateverify]のソフトフォークが必要</td>
-    <td markdown="span">`OP_CAT`のソフトフォークが必要</td>
+    <td markdown="span">
+
+    **現在利用可能**
+
+    </td>
+    <td markdown="span">
+
+    `OP_VAULT`と[OP_CTV][topic op_checktemplateverify]のソフトフォークが必要
+
+    </td>
+    <td markdown="span">
+
+    `OP_CAT`のソフトフォークが必要
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">直前のアドレス置換</th>
     <td markdown="span">脆弱</td>
-    <td markdown="span">**脆弱ではない**</td>
-    <td markdown="span">**脆弱ではない**</td>
+    <td markdown="span">
+
+    **脆弱ではない**
+
+    </td>
+    <td markdown="span">
+
+    **脆弱ではない**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">一部の引き出し</th>
     <td markdown="span">事前に取り決めがある場合のみ可能</td>
-    <td markdown="span">**可能**</td>
+    <td markdown="span">
+
+    **可能**
+
+    </td>
     <td markdown="span">不可能</td>
   </tr>
 
   <tr>
     <th markdown="span">静的で非対話型の計算可能なデポジットアドレス</th>
     <td markdown="span">不可能</td>
-    <td markdown="span">**可能**</td>
-    <td markdown="span">**可能**</td>
+    <td markdown="span">
+
+    **可能**
+
+    </td>
+    <td markdown="span">
+
+    **可能**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">手数料節約のためのRe-Vault/隔離のバッチ化</th>
     <td markdown="span">不可能</td>
-    <td markdown="span">**可能**</td>
+    <td markdown="span">
+
+    **可能**
+
+    </td>
     <td markdown="span">不可能</td>
   </tr>
 
   <tr>
     <th markdown="span">最良（つまり正当な使用）の場合の効率（Optechによる非常に大まかな推定）</th>
-    <td markdown="span">**通常のシングルシグの2倍のサイズ**</td>
+    <td markdown="span">
+
+    **通常のシングルシグの2倍のサイズ**
+
+    </td>
     <td markdown="span">通常のシングルシグの3倍のサイズ</td>
     <td markdown="span">通常のシングルシグの4倍のサイズ</td>
   </tr>

--- a/_posts/zh/newsletters/2018-12-28-newsletter.md
+++ b/_posts/zh/newsletters/2018-12-28-newsletter.md
@@ -62,6 +62,7 @@ lang: zh
 许多比特币用户都熟悉能够创建与其比特币地址对应的签名消息。目前还没有标准的方法来使用 P2SH 或 segwit 地址进行签名。三月的讨论最终变成了 [BIP322][]，提出了一个通用格式，能够为任何可支配的比特币脚本创建签名证明。
 
 <div markdown="1" class="callout">
+
 ### 2018 年总结<br>热门基础设施项目的主要发布
 
 - [Bitcoin Core 0.16][] 在二月发布，钱包默认支持接收 segwit 地址、支持 [BIP159][] 允许修剪节点信号表示其愿意提供最近区块，并进行了许多性能改进。
@@ -75,6 +76,7 @@ lang: zh
 - [Bitcoin Core 0.17][] 在十月发布，包含可选的部分支出避免功能、动态创建和加载钱包的能力以及 [BIP174][] 支持部分签名比特币交易，以便比特币程序之间进行通信。
 
 </div>
+
 ## 四月
 
 LN 协议开发人员 Christian Decker、Rusty Russell 和 Olaoluwa Osuntokun 宣布了 [Eltoo][]，一种 LN 的替代强制机制的提议。当前机制（[LN-penalty][]）要求使以前的链下余额更新变得不安全，以防用户尝试将其放到链上。Eltoo 机制允许在有限的时间窗口内将以前的余额更新链上支付给后来的余额更新。在正常操作中，各方通常只会在链上发布最终通道余额，但即使一方发布了旧余额，其通道对手方也可以简单地发布第二笔交易，将其纠正为最终余额。双方都不会失去任何东西，只有支付的交易费用。
@@ -87,12 +89,15 @@ Eltoo 需要一个新的可选签名哈希的软分叉，[BIP118][] SIGHASH_NOIN
 ## 五月
 
 <div id="dandelion" markdown="1">
+
 五月，一份[蒲公英协议的草案][BIP156] 发布到 Bitcoin-Dev 邮件列表。蒲公英 可以私密地中继交易，使得无法可靠地确定支出者的 IP 地址。即使不使用类似 Tor 的方法，这也能奏效，并且蒲公英可以与 Tor 结合使用，进一步降低隐私泄露的风险。蒲公英本身仅对中继全节点（非 P2P 轻客户端[^fn-dandelion-lite]）用户完全有利，需要与某种形式的加密结合，以防止 ISP 能够识别支出者。
 
 然而，蒲公英部分依赖中继节点假装它们从未见过之前帮助中继的交易。这使得节点容易受到拒绝服务攻击，攻击者可以浪费节点的带宽和内存——开发人员仍在[解决这些问题][daftuar dandelion]，以便采用该协议。
+
 </div>
 
 <div markdown="1" class="callout">
+
 ### 2018 年总结<br>值得注意的技术会议和其他事件
 
 - [BPASE][bpase]，一月，斯坦福大学
@@ -125,6 +130,7 @@ Eltoo 需要一个新的可选签名哈希的软分叉，[BIP118][] SIGHASH_NOIN
 签名方案与一月描述的 muSig 协议（或类似协议）兼容，因此包含了提高效率和隐私的好处。使用 Schnorr 还简化了 Taproot、Graftroot、更私密的 LN 支付通道、更私密的跨链原子交换、同链上的更私密的原子交换（提供改进的 coinjoin）和其他提高效率、隐私或两者的技术的实现。
 
 <div id="p2ep" markdown="1">
+
 与此同时，隐私圆桌会议的参与者描述了一种称为 Pay-to-EndPoint ([P2EP][]) 的方法，可以通过将有限形式的 coinjoin 应用于交互支付显著提高钱包对区块链分析的抵抗力。该提案的[简化形式][bustapay]也已被描述。该协议通过让交易的接收者将一些现有的比特币混入交易中，防止外部观察者能够自动假设交易的所有输入都来自同一个人。使用这种技术的人越多，输入关联假设就越不可靠——提高了所有比特币用户的隐私，而不仅仅是使用 P2EP 的人。
 
 {% capture today-private %}输入：<br>&nbsp;&nbsp;Alice (2 BTC)<br>&nbsp;&nbsp;Alice (2 BTC)<br><br>输出：<br>&nbsp;&nbsp;Alice 的找零 (1 BTC)<br>&nbsp;&nbsp;Bob 的收入 (3 BTC){% endcapture %}
@@ -151,6 +157,7 @@ Eltoo 需要一个新的可选签名哈希的软分叉，[BIP118][] SIGHASH_NOIN
 另外，Pieter Wuille 自二月以来一直在基于他、Gregory Maxwell 和其他人开发的协议撰写一个[草案文件][untrackable auth]，允许在加密之上进行可选的认证。类似于 [BIP150][]，这将使在互联网或绑定到可信节点的轻量级钱包中更容易安全地设置白名单节点。值得注意的是，这个当前的想法是启用认证而不向第三方透露身份，以便在匿名网络（如 Tor）上的节点或简单更改 IP 地址的节点不会被追踪其网络身份。尽管 Wuille 发现了他最初记录的提案中的缺陷，但随着开发协议的研究推进，提案已被更新。
 
 <div markdown="1" class="callout">
+
 ### 2018 年总结<br>Bitcoin Optech
 
 自五月启动 [Optech][] 以来，我们已经签约了 15 家公司成为会员，举办了两次[研讨会][optech workshops]，制作了 28 期每周 [Newsletter][optech newsletters]，建立了一个[仪表盘][optech dashboard]，并在一本关于可独立部署的扩展技术的书籍上取得了扎实的开端。要了解我们在 2018 年取得的成就以及我们 2019 年的计划，请参阅我们的简短[年度报告][optech annual report]。
@@ -171,6 +178,7 @@ Eltoo 需要一个新的可选签名哈希的软分叉，[BIP118][] SIGHASH_NOIN
 另外，LN 协议开发者 Rusty Russell 提出了一种[拼接][splicing]的方法，允许用户在不暂停该通道中的支付的情况下添加或减少通道中的资金。这特别有助于钱包隐藏管理余额的技术细节。例如，Alice 的钱包可以自动从同一个支付通道中链下使用 LN 通过该支付通道支付给 Bob 或链上使用拼接出（提现）从该支付通道支付给 Bob。
 
 <div markdown="1" class="callout">
+
 ### 2018 年总结<br>新的开源基础设施解决方案
 
 - [Electrs][] 于七月发布，提供了用 Rust 编程语言编写的高效重实现的 Electrum 风格的交易查找服务器。资源需求显著低于替代方案。Electrum 风格的服务器为许多钱包和其他服务提供了后端支持。
@@ -197,6 +205,7 @@ Pieter Wuille、Gregory Maxwell 和 Gleb Naumenko 研究了如何减少用于中
 最后，在 2018 年即将结束时，开发人员继续讨论如何将 Schnorr 签名、Taproot MAST、SIGHASH_NOINPUT_UNSAFE 和其他更改集成到一个具体的软分叉提案中。协议开发者 Anthony Towns 简明[总结][schnorr and more]了如果今天发布提案，可能包含的内容。
 
 <div markdown="1" class="callout">
+
 ### 2018 年总结<br>手续费减少技术的使用
 
 ![Plot of compressed pubkey, segwit, payment batching, and opt-in RBF use in 2018](/img/posts/2018-12-overall.png)

--- a/_posts/zh/newsletters/2022-12-21-newsletter.md
+++ b/_posts/zh/newsletters/2022-12-21-newsletter.md
@@ -90,6 +90,7 @@ LKD 对[无状态发票][topic stateless invoices]的初步支持，使它可以
 ![Illustration of zero-conf channels](/img/posts/2021-07-zeroconf-channels.png)
 
 <div markdown="1" class="callout" id="rbf">
+
 ### 2022 summary<br>Replace-By-Fee
 
 今年，我们看到了许多关于 “[手续费替换][topic rbf]（RBF）” 的讨论，以及一些重要的行动。我们一月份的周报[总结][news181 rbf]了一项来自 Jeremy Rubin 的提议：任意交易都可以在原版交易到达节点后的一段时间内被更高手续费的替代版本替换；超时之后，再应用现有的规则 —— 仅允许遵循 [BIP125][] 的替代版本替换原版。这将允许商家在替换窗口关闭之后接受未确认的交易，就像现在这样。更重要的是，它也许可以让依赖于可替换性来实现安全性的协议不必担心未携带 BIP125 信号的交易，只要一个协议节点或者瞭望塔拥有合理的机会、在知晓一笔交易后即时响应即可。
@@ -131,6 +132,7 @@ Lightning Labs [推出][news195 taro]了 Taro，这个协议（基于以前的�
 在 5 月份，我们还见证了比特币内核库项目（libbitcoinkernel）的[第一次合并][news198 lbk]，试图将尽可能多的 Bitcoin Core 共识代码分离到一个单独的库中，即使该代码仍附带有一些非共识代码。从长远来看，这一目标是精简 libbitcoinkernel 到只包含共识代码，让其他项目可以轻松使用该代码或让审计人员分析对 Bitcoin Core 的共识逻辑的变更。几个额外的 libbitcoinkernel PR 也在今年合并。
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2022 总结<br>流行基础设施项目的主要发布
 
 - [Eclair 0.7.0][news185 eclair] 添加了对[锚点输出][topic anchor outputs]、中继[洋葱消息][topic onion messages]以及在生产环境中使用 PostgreSQL 数据库的支持。
@@ -201,6 +203,7 @@ Lloyd Fournier [写了一篇][news213 bls]关于 [DLC][topic dlc] 预言机使�
 然后他们可以根据合约分配他们的存款资金，甚至不需要告知预言机他们计划使用它。到了结算合约的时候，每一方都可以自己运行程序。如果他们都同意运行结果，就可以合作结算合约，根本不需要预言机的参与；如果他们不同意，他们中的任何一方都可以将程序发送到预言机（可能需要为其服务支付少量费用）并收到 BLS 对程序源代码的证明以及运行程序的返回值。证明可以转换为允许在链上结算 DLC 的签名。与当前的 DLC 合约一样，预言机无法根据其 BLS 签名知道是哪些链上交易。
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2022 总结<br>Bitcoin Optech
 
 在 Optech 的第五年，我们发布了 51 份[周报][newsletters]，并在我们的[主题索引][topics index]中新增了 11 个页面。 Optech 今年总共发表了超过 70,000 字的有关比特币软件研发的文章，大致相当于一本 200 页的书。
@@ -235,6 +238,7 @@ eclipse attacks]更加困难。
 一次比特币协议开发者会议中，Bryan Bishop [主持][news223 xscribe] 了几项议题讨论，包括[传输加密][topic v2 p2p transport]、交易费和[经济安全性][topic fee sniping]、 FROST [门限签名][topic threshold signature]方案、使用GitHub进行源代码托管和开发讨论的可持续性、BIP 中的可证明规范、[包中继][topic package relay]和 [v3 交易中继][topic v3 transaction relay]、Stratum 第二版采矿协议、以及让代码合并到比特币核心和其他自由软件项目。
 
 <div markdown="1" class="callout" id="softforks">
+
 ### 2022 年软分叉提议总结
 
 一月伴随着 Jeremy Rubin [举行][news183a ctv]第一次 IRC 会议，审核和讨论 [OP_CHECKTEMPLATEVERIFY][topic op_checktemplateverify](CTV) 软分叉提案。同时，Peter Todd 在 Bitcoin-Dev 邮件列表中[发布][news183b ctv]了对该提案的一些担忧，最值得注意的是，他认为此前的软分叉已经使几乎所有比特币用户受益。

--- a/_posts/zh/newsletters/2023-11-08-newsletter.md
+++ b/_posts/zh/newsletters/2023-11-08-newsletter.md
@@ -94,9 +94,11 @@ lang: zh
 - [Eclair #2761][] 允许转发有限数量的 [HTLCs][topic htlc] 给对方，即使对方的余额已低于通道保证金的要求。这可以帮助解决 “通道拼接（[splicing][topic splicing]）” 或者[双向注资][topic dual funding]之后可能发生的 *资金滞留问题（suck funds problem）*。见[周报 #253][news253 stuck] 了解 Eclair 为资金滞留问题提出的另一项缓解措施。{% assign timestamp="41:02" %}
 
 <div markdown="1" class="callout">
+
 ## 想要了解更多？
 
 想要了解更多本周新闻部分提到的话题的讨论，请加入我们于每周四（周报发布的后一天）的 UTC 时间 15:00 在 [Twitter Spaces][@bitcoinoptech] 举办的 Bitcoin Optech 回顾。聊天室里的讨论也会记录在我们的[播客][podcast]页面并长期留存。
+
 </div>
 
 

--- a/_posts/zh/newsletters/2023-12-20-newsletter.md
+++ b/_posts/zh/newsletters/2023-12-20-newsletter.md
@@ -108,6 +108,7 @@ Russell O'Connor 和 Andrew Poelstra 为备份和存储 [BIP32][] 助记词[提�
 ![Tunable Penalty Protocol](/img/posts/2023-03-tunable-commitment.dot.png)
 
 <div markdown="1" class="callout" id="softforks">
+
 ### 2023 总结<br>软分叉提议
 
 James O'Beirne 在一月[提出][jan op_vault]了一种新的 `OP_VAULT` 操作码，[随后][feb op_vault]在二月为之编写了一份 BIP 草案以及提交到 Bitcoin Inquisition 的实现。几周后，Gregory Sanders [提出][feb op_vault2]了 `OP_VAULT` 的一种替代性设计。
@@ -164,6 +165,7 @@ Burak Keceli [提出了][may ark]一种新的 [joinpool][topic joinpools] 式协
 Josie Baker 和 Ruben Somsen [发布了][jun sp]一份用于[静默支付][topic silent payments]的 BIP 草案，这是一种可复用的支付代码，每次使用时都会产生一个唯一的链上地址，从而防止[输出关联（地址复用）][topic output linking]。输出关联可以显著降低用户（包括未直接参与交易的用户）的隐私。该草案详细介绍了该提案的好处、它的权衡以及软件如何有效地使用它。此外，在 Bitcoin Core PR 审核俱乐部会议期间还[讨论了][aug sp]正在进行的为 Bitcoin Core 实施静默支付的工作。
 
 <div markdown="1" class="callout" id="security">
+
 ### 2023 总结<br>安全披露
 
 Optech 今年报告了三个重大安全漏洞：
@@ -202,6 +204,7 @@ LND 添加了对“简单 taproot 通道”的[实验性支持][aug lnd taproot]
 今年九月，Tom Briar [发布了][sept compress]一份压缩比特币交易的规范和实现草案。该提案解决了压缩比特币交易中均匀分布数据的难题，用变长整数来表示整数，使用区块高度和位置来引用交易而不是其输出点 txid，并省略了 P2WPKH 交易中的公钥。虽然压缩格式节省了空间，但与处理常规序列化的交易相比，将其转换回可用格式需要更多的 CPU、内存和 I/O，在卫星广播或隐秘传输等情况下，这是可以接受的权衡。
 
 <div markdown="1" class="callout" id="releases">
+
 ### 2023 总结<br>流行基础设施项目的主要发布
 
 - [Eclair 0.8.0][jan eclair] 新增了对[零配置通道][topic zero-conf channels]和短通道标识符 (SCID) 别名的支持。
@@ -278,6 +281,7 @@ Robin Linus 和 Lukas George 在今年五月[描述][may state]了一种在比�
 十一月还有[流动性广告][topic liquidity advertisements]规范的[更新][nov liqad]，允许节点向新建立的[双向注资通道][topic dual funding]宣布提供部分资金以获得手续费的意愿，从而使请求的节点能够迅速开始接收闪电网络的付款。这些更新大部分都是次要的，但关于流动性广告创建的通道是否应包含时间锁的讨论一直[持续][dec liqad]到十二月。时间锁可以向买方提供激励性保证，即他们将实际收到所支付的流动性，但时间锁也可能被恶意或不考虑他人的买方用来对提供者锁定额外资本。
 
 <div markdown="1" class="callout" id="optech">
+
 ### 2023 总结<br>Bitcoin Optech
 
 {% comment %}<!-- commands to help me create this summary for next year

--- a/_posts/zh/newsletters/2024-02-28-newsletter.md
+++ b/_posts/zh/newsletters/2024-02-28-newsletter.md
@@ -45,13 +45,25 @@ lang: zh
   <tr>
     <th></th>
     <th>预签名</th>
-    <th markdown="span">BIP345 `OP_VAULT`</th>
-    <th markdown="span">`OP_CAT` 结合 schnorr</th>
+    <th markdown="span">
+
+    BIP345 `OP_VAULT`
+
+    </th>
+    <th markdown="span">
+
+    `OP_CAT` 结合 schnorr
+
+    </th>
   </tr>
 
   <tr>
     <th>可用性</th>
-    <td markdown="span">**当前**</td>
+    <td markdown="span">
+
+    **当前**
+
+    </td>
     <td markdown="span">需要 `OP_VAULT` 和 [OP_CTV][topic op_checktemplateverify] 软分叉</td>
     <td markdown="span">需要 `OP_CAT` 软分叉</td>
   </tr>
@@ -59,34 +71,62 @@ lang: zh
   <tr>
     <th markdown="span">最后时刻地址替换攻击</th>
     <td markdown="span">受影响</td>
-    <td markdown="span">**不受影响**</td>
-    <td markdown="span">**不受影响**</td>
+    <td markdown="span">
+
+    **不受影响**
+
+    </td>
+    <td markdown="span">
+
+    **不受影响**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">部分提款</th>
     <td markdown="span">仅当预先规划好时</td>
-    <td markdown="span">**是**</td>
+    <td markdown="span">
+
+    **是**
+
+    </td>
     <td markdown="span">否</td>
   </tr>
 
   <tr>
     <th markdown="span">静态且非交互的可计算提款地址</th>
     <td markdown="span">否</td>
-    <td markdown="span">**是**</td>
-    <td markdown="span">**是**</td>
+    <td markdown="span">
+
+    **是**
+
+    </td>
+    <td markdown="span">
+
+    **是**
+
+    </td>
   </tr>
 
   <tr>
     <th markdown="span">批量重新入库/隔离以节省手续费</th>
     <td markdown="span">否</td>
-    <td markdown="span">**是**</td>
+    <td markdown="span">
+
+    **是**
+
+    </td>
     <td markdown="span">否</td>
   </tr>
 
   <tr>
     <th markdown="span">最佳情况下的操作效率，例如只存在合法花费<br>*(only very roughly estimated by Optech)*</th>
-    <td markdown="span">**2x 普通单签的体积**</td>
+    <td markdown="span">
+
+    **2x 普通单签的体积**
+
+    </td>
     <td markdown="span">3x 普通单签的体积</td>
     <td markdown="span">4x 普通单签的体积</td>
   </tr>

--- a/_topics/en/adaptor-signatures.md
+++ b/_topics/en/adaptor-signatures.md
@@ -172,7 +172,10 @@ Besides coinswaps, there are several other [proposed uses][scriptless
 scripts repo] for adaptor signatures.
 
 <div class="qa_details">
-<details markdown="1"><summary>Click to display the same coinswap example in mathematical terms</summary>
+<details markdown="1">
+
+<summary>Click to display the same coinswap example in mathematical terms</summary>
+
 *In the following example, we assume the use of BIP340
 schnorr signatures.  We use lowercase variables for scalars and
 uppercase variables for elliptic curve points.  We represent
@@ -250,6 +253,7 @@ earlier:
 
 Bob uses that signature to broadcast the transaction Alice
 originally gave him.
+
 </details><br>
 </div>
 

--- a/en/topic-categories.md
+++ b/en/topic-categories.md
@@ -18,6 +18,7 @@ layout: page
 {% assign categories = raw_categories | split: "|" | sort_natural | uniq %}
 
 <div class="center" markdown="1">
+
 {{ categories | size }} categories for {{site.topics | size}} unique
 topics, with many topics appearing in multiple categories.
 

--- a/en/topic-dates.md
+++ b/en/topic-dates.md
@@ -74,10 +74,12 @@ before the main content -->
 {% endcapture %}
 
 <div class="center" markdown="1">
+
 {{number_of_events}} indexed events in {{number_of_months}} months <!-- {{mentions | size}} events including duplicates -->
 
 [2018](#d2018-12) | [2019](#d2019-12) | [2020](#d2020-12) |
 [2021](#d2021-12)
+
 </div>
 
 <div>{% comment %}<!-- enclosing in a div forces this to be interpreted

--- a/en/topics.md
+++ b/en/topics.md
@@ -25,6 +25,7 @@ rather than URL. -->{% endcomment %}
 {% assign number_of_aliases = number_of_entries | minus: number_of_topics %}
 
 <div class="center" markdown="1">
+
 {{number_of_topics}} topics (and
 {{number_of_aliases}} aliases in *italics* for topics with alternative
 names).


### PR DESCRIPTION
Part of #1551 

Kramdown allows an HTML block or span element to contain `markdown=1`, `markdown=span`, or `markdown=block` to trigger markdown parsing within that element.  Hugo's Goldmark Commonmark parser requires an empty space after the HTML element open and before the element close to trigger the same behavior.

This commit adds the Commonmark behavior in addition to the Kramdown behavior.  We'll have to maintain both until we're fully transitioned.

No test for this is provided.

This PR can be partly reviewed by diffing the site build before and after this commit:

```text
git checkout #this branch
make clean build
cp -a _site _newsite
git reset --hard HEAD^
make clean build
cp -a _site _oldsite
diff --ignore-blank-lines -ruNw _oldsite/ _site/ | colordiff | less -R
```

That will show you the changes.  I've spot checked most of the source differences and they look the same on the rendered page on my browser.