### PR TITLE
Refactor: replace deprecated global link defs with local link defs

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -52,24 +52,6 @@
 [rust bitcoin repo]: https://github.com/rust-bitcoin/rust-bitcoin
 [rust-lightning repo]: https://github.com/rust-bitcoin/rust-lightning
 
-{% comment %}<!-- deprecated links; don't use these any more -->{% endcomment %}
-{% assign pagedate_epoch = page.date | date: '%s' %}
-{% assign deprecated_links_v0_epoch = '2020-09-24' | date: '%s' %}
-{% if pagedate_epoch < deprecated_links_v0_epoch %}
-[cve-2012-2459]: https://bitcointalk.org/?topic=102395
-[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842
-[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144
-[eltoo]: https://blockstream.com/eltoo.pdf
-[erlay]: https://arxiv.org/pdf/1905.10518.pdf
-[hwi]: https://github.com/bitcoin-core/HWI
-[miniscript]: /en/topics/miniscript/
-[musig]: https://eprint.iacr.org/2018/068
-{% assign _link_descriptors = 'https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md' %}
-[descriptor]: {{_link_descriptors}}
-[output script descriptor]: {{_link_descriptors}}
-[output script descriptors]: {{_link_descriptors}}
-{% endif %}
-
 {% comment %}<!-- BIPs, BLIPs, and BINANAs in order lowest to highest
 Note: as of 2019-02-24/Jekyll 3.8.3, this is currently inefficient as
 the loop is run each time this file is included (but it still only adds

--- a/_includes/specials/bech32/07-altbech32.md
+++ b/_includes/specials/bech32/07-altbech32.md
@@ -49,4 +49,5 @@ probably worth your time to implement it for Bitcoin too.
 [blockstream liquid]: https://blockstream.com/liquid/
 [confidential assets]: https://elementsproject.org/features/confidential-transactions
 [blech32 py]: https://github.com/ElementsProject/elements/commit/9cb2fa051fcbe0fe66f15e6b88d224d1935376f4#diff-265badc7e18059096c32a61b0eada470
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 {% endauto_anchor %}

--- a/_includes/specials/bech32/zh/07-altbech32.md
+++ b/_includes/specials/bech32/zh/07-altbech32.md
@@ -23,4 +23,5 @@
 [blockstream liquid]: https://blockstream.com/liquid/
 [confidential assets]: https://elementsproject.org/features/confidential-transactions
 [blech32 py]: https://github.com/ElementsProject/elements/commit/9cb2fa051fcbe0fe66f15e6b88d224d1935376f4#diff-265badc7e18059096c32a61b0eada470
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 {% endauto_anchor %}

--- a/_posts/en/2019-06-14-exec-briefing.md
+++ b/_posts/en/2019-06-14-exec-briefing.md
@@ -88,3 +88,5 @@ technical topics at a high-level for decision makers at Bitcoin businesses.
 [softfork slides]: /img/posts/2019-exec-briefing/softfork.pdf
 [newsletters]: /en/newsletters/
 [workshops]: /workshops/
+[eltoo]: https://blockstream.com/eltoo.pdf
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/2019-10-29-schnorr-taproot-workshop.md
+++ b/_posts/en/2019-10-29-schnorr-taproot-workshop.md
@@ -211,3 +211,4 @@ community feedback process for these proposals.
 [transcript]: https://diyhpl.us/wiki/transcripts/bitcoinops/schnorr-taproot-workshop-2019/notes/
 [readme]: https://github.com/bitcoinops/taproot-workshop/blob/master/README.md
 [workshop repository]: https://github.com/bitcoinops/taproot-workshop/
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2018-07-17-newsletter.md
+++ b/_posts/en/newsletters/2018-07-17-newsletter.md
@@ -130,3 +130,4 @@ flag, and several notable recent Bitcoin Core merges.
 [#13570]: https://github.com/bitcoin/bitcoin/pull/13570
 [#13096]: https://github.com/bitcoin/bitcoin/pull/13096
 [tx-as-internal-node]: https://bitslog.wordpress.com/2018/06/09/leaf-node-weakness-in-bitcoin-merkle-tree-design/
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2018-07-24-newsletter.md
+++ b/_posts/en/newsletters/2018-07-24-newsletter.md
@@ -170,6 +170,7 @@ to share your experiences in implementing better Bitcoin technology, please cont
 [announce cdesk]: https://www.coindesk.com/bitcoins-biggest-startups-are-backing-a-new-effort-to-keep-fees-low/
 [inv]: https://bitcoin.org/en/developer-reference#inv
 [workshop announce]: /en/newsletters/2018/06/26/#first-optech-workshop
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 
 {% include references.md %}
 {% include linkers/issues.md issues="13697,13557,12196,9662,12196,13604,13298,13652" %}

--- a/_posts/en/newsletters/2018-07-31-newsletter.md
+++ b/_posts/en/newsletters/2018-07-31-newsletter.md
@@ -174,3 +174,4 @@ c-lightning: git log --topo-order -p d84d358562a3bcdf48856fdea24511907ff53fd9..0
 
 [lnd ee2f2573c1b1b33288d05ba59a1e8ef9e8fb621c]: https://github.com/lightningnetwork/lnd/commit/ee2f2573c1b1b33288d05ba59a1e8ef9e8fb621c
 [newsletter #3]: /en/newsletters/2018/07/10/#transaction-fees-remain-very-low
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-08-07-newsletter.md
+++ b/_posts/en/newsletters/2018-08-07-newsletter.md
@@ -150,3 +150,4 @@ repo], and [C-lightning][core lightning repo].*
 [consolidate info]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation
 [rbf data]: https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1&from=now-1y&to=now
 [newsletter #5]: /en/newsletters/2018/07/24/#first-use-of-output-script-descriptors
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-10-09-newsletter.md
+++ b/_posts/en/newsletters/2018-10-09-newsletter.md
@@ -285,3 +285,4 @@ newsletter's author.
 [eltoo protocol]: https://blockstream.com/2018/04/30/eltoo-next-lightning.html
 [bitcoin-dev timewarp]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-August/016316.html
 [ln scriptless scripts]: https://lists.launchpad.net/mimblewimble/msg00086.html
+[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144

--- a/_posts/en/newsletters/2018-10-16-newsletter.md
+++ b/_posts/en/newsletters/2018-10-16-newsletter.md
@@ -132,3 +132,4 @@ on some of the transcripts for the event in Tokyo last week:
 [kanzure reorg transcript]: http://diyhpl.us/wiki/transcripts/scalingbitcoin/tokyo-2018/edgedevplusplus/reorgs/
 [kanzure reorg vid]: https://youtu.be/EUUQbveGF5E?t=4
 [UHO]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-May/015967.html
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-10-30-newsletter.md
+++ b/_posts/en/newsletters/2018-10-30-newsletter.md
@@ -229,3 +229,4 @@ it to write a good description, and I doubt non-LN devs care -->{% endcomment %}
 [newsletter #9]: /en/newsletters/2018/08/21/#output-script-descriptors-enhancements
 [newsletter #12]: /en/newsletters/2018/09/11/#bitcoin-core-14096
 [newsletter #17]: /en/newsletters/2018/10/16/#script-descriptors-and-descript
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-11-06-newsletter.md
+++ b/_posts/en/newsletters/2018-11-06-newsletter.md
@@ -159,3 +159,4 @@ repo].*
 [cashaddr patch]: https://github.com/trezor/trezor-crypto/commit/2bbbc3e15573294c6dd0273d2a8542ba42507eb0
 [ln bolt11 ss]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-November/001489.html
 [newsletter #16]: /en/newsletters/2018/10/09/#multiparty-ecdsa-for-scriptless-lightning-network-payment-channels
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-11-13-newsletter.md
+++ b/_posts/en/newsletters/2018-11-13-newsletter.md
@@ -162,3 +162,4 @@ repo].*
 [mallers]: https://twitter.com/JackMallers
 [newsletter #19]: /en/newsletters/2018/10/30/#lightning-residency-and-hackday
 [newsletter #3]: /en/newsletters/2018/07/10/#merchant-adoption
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/en/newsletters/2018-12-04-newsletter.md
+++ b/_posts/en/newsletters/2018-12-04-newsletter.md
@@ -166,3 +166,4 @@ repo].*
 [ln1.1 accepted proposals]: https://github.com/lightningnetwork/lightning-rfc/wiki/Lightning-Specification-1.1-Proposal-States
 [ln spec meetings]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-November/001673.html
 [0.17.1 milestone]: https://github.com/bitcoin/bitcoin/milestone/39?closed=1
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -684,3 +684,5 @@ newsletters] or follow our [RSS feed][].*
 [techniques for reducing transaction fees]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees
 [payment batching]: https://bitcointechtalk.com/saving-up-to-80-on-bitcoin-transaction-fees-by-batching-payments-4147ab7009fb
 [towns consolidation]: /en/xapo-utxo-consolidation/
+[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842
+[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144

--- a/_posts/en/newsletters/2019-02-05-newsletter.md
+++ b/_posts/en/newsletters/2019-02-05-newsletter.md
@@ -313,3 +313,4 @@ and [libsecp256k1][libsecp256k1 repo].*
 [btcpay utxo]: https://github.com/btcpayserver/btcpayserver-docker/tree/master/contrib/FastSync
 [newsletter #21]: /en/newsletters/2018/11/13/#lightning-application-residency-videos
 [newsletter #31]: /en/newsletters/2019/01/29/#c-lightning-2283
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-02-12-newsletter.md
+++ b/_posts/en/newsletters/2019-02-12-newsletter.md
@@ -132,3 +132,4 @@ projects.
 [reserve audit tool]: https://blockstream.com/2019/02/04/standardizing-bitcoin-proof-of-reserves/
 [eclair tor]: https://github.com/ACINQ/eclair/blob/master/TOR.md
 [rbf report]: /en/rbf-in-the-wild/
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-02-19-newsletter.md
+++ b/_posts/en/newsletters/2019-02-19-newsletter.md
@@ -258,3 +258,7 @@ None this week.
 [electrum personal server]: https://github.com/chris-belcher/electrum-personal-server
 [key origin information]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#key-origin-identification
 [newsletter #5]: /en/newsletters/2018/07/24/#bitcoin-core-9662
+[hwi]: https://github.com/bitcoin-core/HWI
+[descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[miniscript]: /en/topics/miniscript/

--- a/_posts/en/newsletters/2019-02-26-newsletter.md
+++ b/_posts/en/newsletters/2019-02-26-newsletter.md
@@ -154,4 +154,4 @@ answers made since our last update.*
 [liquid]: https://blockstream.com/liquid/
 [schnorr docs]: https://github.com/ElementsProject/secp256k1-zkp/blob/secp256k1-zkp/src/modules/musig/musig.md
 [productivity hints]: https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md
-
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-03-12-newsletter.md
+++ b/_posts/en/newsletters/2019-03-12-newsletter.md
@@ -279,3 +279,7 @@ merge affected.*
 [newsletter #36 ml]: /en/newsletters/2019/03/05/#bitcoin-dev-mailing-list-outage
 [newsletter #36 cleanup]: /en/newsletters/2019/03/05/#cleanup-soft-fork-proposal
 [newsletter #13]: /en/newsletters/2018/09/18/#bitcoin-core-14054
+[cve-2012-2459]: https://bitcointalk.org/?topic=102395
+[miniscript]: /en/topics/miniscript/
+[musig]: https://eprint.iacr.org/2018/068
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-05-07-newsletter.md
+++ b/_posts/en/newsletters/2019-05-07-newsletter.md
@@ -221,3 +221,5 @@ wiki page for changes -->{% endcomment %}
 [tap ref]: https://github.com/sipa/bitcoin/commits/taproot
 [bech32 series]: /en/bech32-sending-support/
 [newsletter #40]: /en/newsletters/2019/04/02/#bitcoin-core-schedules-switch-to-default-bech32-receiving-addresses
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2019-05-14-newsletter.md
+++ b/_posts/en/newsletters/2019-05-14-newsletter.md
@@ -597,3 +597,4 @@ the fault of the newsletter author.
 [example implementation]: https://github.com/sipa/bitcoin/commits/taproot
 [bech32 series]: /en/bech32-sending-support/
 [newsletter #3]: /en/newsletters/2018/07/10/#featured-news-schnorr-signature-proposed-bip
+[cve-2012-2459]: https://bitcointalk.org/?topic=102395

--- a/_posts/en/newsletters/2019-05-21-newsletter.md
+++ b/_posts/en/newsletters/2019-05-21-newsletter.md
@@ -190,3 +190,4 @@ wiki page for changes -->{% endcomment %}
 [bech32 series]: /en/bech32-sending-support/
 [newsletter #34]: /en/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
 [newsletter #39]: /en/newsletters/2019/03/26/#version-2-p2p-transport-proposal
+[eltoo]: https://blockstream.com/eltoo.pdf

--- a/_posts/en/newsletters/2019-05-29-newsletter.md
+++ b/_posts/en/newsletters/2019-05-29-newsletter.md
@@ -420,3 +420,5 @@ the author.
 [newsletter #32]: /en/newsletters/2019/02/05/#miniscript
 [newsletter #18]: /en/newsletters/2018/10/23/#two-papers-published-on-fast-multiparty-ecdsa
 [newsletter #47]: /en/newsletters/2019/05/21/#proposed-anyprevout-sighash-modes
+[miniscript]: /en/topics/miniscript/
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-06-05-newsletter.md
+++ b/_posts/en/newsletters/2019-06-05-newsletter.md
@@ -195,3 +195,4 @@ wiki page for changes -->{% endcomment %}
 [Bitcoin Core PR Review Club]:https://bitcoin-core-review-club.github.io/
 [core prs]: https://github.com/bitcoin/bitcoin/pulls
 [newsletter #26]: /en/newsletters/2018/12/18/#minisketch-library-released
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/en/newsletters/2019-06-12-newsletter.md
+++ b/_posts/en/newsletters/2019-06-12-newsletter.md
@@ -253,3 +253,7 @@ wiki page for changes -->{% endcomment %}
 [newsletter #47]: /en/newsletters/2019/05/21/#proposed-anyprevout-sighash-modes
 [newsletter #48]: /en/newsletters/2019/05/29/#proposed-new-opcode-for-transaction-output-commitments
 [newsletter #24]: /en/newsletters/2018/12/04/#cpfp-carve-out
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[hwi]: https://github.com/bitcoin-core/HWI
+[eltoo]: https://blockstream.com/eltoo.pdf
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-06-19-newsletter.md
+++ b/_posts/en/newsletters/2019-06-19-newsletter.md
@@ -292,3 +292,4 @@ wiki page for changes -->{% endcomment %}
 [prometheus]: https://prometheus.io/
 [pos ref anchor]: https://github.com/bitcoin/bips/pull/555#issuecomment-315517707
 [newsletter #30]: /en/newsletters/2019/01/22/#pr-opened-for-spontaneous-ln-payments
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-07-10-newsletter.md
+++ b/_posts/en/newsletters/2019-07-10-newsletter.md
@@ -114,3 +114,4 @@ wiki page for changes -->{% endcomment %}
 [tlv pr]: https://github.com/lightningnetwork/lightning-rfc/pull/607
 [pickhardt jit]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-March/001891.html
 [zmn jit]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-July/002055.html
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-07-17-newsletter.md
+++ b/_posts/en/newsletters/2019-07-17-newsletter.md
@@ -101,3 +101,4 @@ wiki page for changes -->{% endcomment %}
 [guix vid]: https://www.youtube.com/watch?v=DKOG0BQMmmg&feature=youtu.be&t=19828
 [guix transcript]: http://diyhpl.us/wiki/transcripts/breaking-bitcoin/2019/bitcoin-build-system/
 [newsletter #46]: /en/newsletters/2019/05/14/#addition-of-derivation-paths-to-bip174-psbts
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-07-31-newsletter.md
+++ b/_posts/en/newsletters/2019-07-31-newsletter.md
@@ -246,3 +246,4 @@ answers made since our last update.*
 [newsletter #43]: /en/newsletters/2019/04/23/#basic-bip158-support-merged-in-bitcoin-core
 [newsletter #56]: /en/newsletters/2019/07/24/#bitcoin-core-16152
 [newsletter #37]: /en/newsletters/2019/03/12/#version-2-addr-message-proposed
+[descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-08-21-newsletter.md
+++ b/_posts/en/newsletters/2019-08-21-newsletter.md
@@ -109,3 +109,4 @@ on the Optech website.  {% include specials/bech32/23-compat.md %}
 [news34 pr15368]: /en/newsletters/2019/02/19/#bitcoin-core-15368
 [hc heights]: #hardcoded-previous-soft-fork-activation-blocks
 [cl release]: https://github.com/ElementsProject/lightning/releases/tag/v0.7.2.1
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-08-28-newsletter.md
+++ b/_posts/en/newsletters/2019-08-28-newsletter.md
@@ -193,3 +193,4 @@ author.
 [miniscript vid]: https://www.youtube.com/watch?v=XM1lzN4Zfks
 [miniscript xs]: http://diyhpl.us/wiki/transcripts/stanford-blockchain-conference/2019/miniscript/
 [miniscript summary]: /en/newsletters/2019/02/05#miniscript
+[miniscript]: /en/topics/miniscript/

--- a/_posts/en/newsletters/2019-09-11-newsletter.md
+++ b/_posts/en/newsletters/2019-09-11-newsletter.md
@@ -179,3 +179,5 @@ infrastructure projects.
 [signet]: https://en.bitcoin.it/wiki/Signet
 [less gossip]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-September/002134.html
 [txprobe paper]: https://arxiv.org/pdf/1812.00942.pdf
+[eltoo]: https://blockstream.com/eltoo.pdf
+[miniscript]: /en/topics/miniscript/

--- a/_posts/en/newsletters/2019-09-18-newsletter.md
+++ b/_posts/en/newsletters/2019-09-18-newsletter.md
@@ -270,3 +270,6 @@ Bishop, we found the following topic particularly interesting:
 [paper txprobe]: https://arxiv.org/pdf/1812.00942.pdf
 [coinscope]: https://www.cs.umd.edu/projects/coinscope/coinscope.pdf
 [sb ts]: https://diyhpl.us/wiki/transcripts/scalingbitcoin/tel-aviv-2019/
+[eltoo]: https://blockstream.com/eltoo.pdf
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf
+[miniscript]: /en/topics/miniscript/

--- a/_posts/en/newsletters/2019-09-25-newsletter.md
+++ b/_posts/en/newsletters/2019-09-25-newsletter.md
@@ -131,3 +131,4 @@ clarifies that since 0.10.0, Bitcoin Core uses [headers-first][] IBD
 [tapscript limits]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-September/017306.html
 [watchtower discussion]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-September/002156.html
 [headers-first]: https://bitcoin.org/en/p2p-network-guide#headers-first
+[eltoo]: https://blockstream.com/eltoo.pdf

--- a/_posts/en/newsletters/2019-10-02-newsletter.md
+++ b/_posts/en/newsletters/2019-10-02-newsletter.md
@@ -148,3 +148,4 @@ projects.
 [optech ln warning]: /en/newsletters/2019/09/04/#upgrade-ln-implementations
 [workshop transcript]: http://diyhpl.us/wiki/transcripts/bitcoinops/schnorr-taproot-workshop-2019/notes/
 [russell disclosure]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-September/002174.html
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/en/newsletters/2019-10-09-newsletter.md
+++ b/_posts/en/newsletters/2019-10-09-newsletter.md
@@ -170,3 +170,4 @@ changes to popular Bitcoin infrastructure projects.
 [zmn internal tagging]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-October/002180.html
 [gui bech32]: /en/newsletters/2019/04/16/#bitcoin-core-15711
 [orig output tagging]: /en/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
+[eltoo]: https://blockstream.com/eltoo.pdf

--- a/_posts/en/newsletters/2019-10-16-newsletter.md
+++ b/_posts/en/newsletters/2019-10-16-newsletter.md
@@ -227,3 +227,4 @@ notable changes to popular Bitcoin infrastructure projects.
 [css ts]: https://diyhpl.us/wiki/transcripts/cryptoeconomic-systems/2019/
 [css vids]: https://www.youtube.com/channel/UCJkYmuzqAnIKn3NPg5lc0Wg/videos
 [eclair 0.3.2]: https://github.com/ACINQ/eclair/releases/tag/v0.3.2
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-11-06-newsletter.md
+++ b/_posts/en/newsletters/2019-11-06-newsletter.md
@@ -150,3 +150,4 @@ projects.
 [naumenko addr relay]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-October/017428.html
 [news70 simplified commitments]: /en/newsletters/2019/10/30/#ln-simplified-commitments
 [jager anchor]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-October/002264.html
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/en/newsletters/2019-11-13-newsletter.md
+++ b/_posts/en/newsletters/2019-11-13-newsletter.md
@@ -293,3 +293,4 @@ popular Bitcoin infrastructure projects.
 [news60 16248]: /en/newsletters/2019/08/21/#bitcoin-core-16248
 [bse bech32 extension]: {{bse}}91602
 [topics announcement]: /en/topics-announcement/
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/en/newsletters/2019-11-27-newsletter.md
+++ b/_posts/en/newsletters/2019-11-27-newsletter.md
@@ -301,4 +301,4 @@ endcomment %}
 [heartbleed]: https://bitcoin.org/en/alert/2014-04-11-heartbleed
 [cve-2014-3570]: https://www.reddit.com/r/Bitcoin/comments/2rrxq7/on_why_010s_release_notes_say_we_have_reason_to/
 [libsecp256k1 sig speedup]: https://bitcoincore.org/en/2016/02/23/release-0.12.0/#x-faster-signature-validation
-
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-12-04-newsletter.md
+++ b/_posts/en/newsletters/2019-12-04-newsletter.md
@@ -157,3 +157,4 @@ infrastructure projects.
 [coincovenants]: https://bitcointalk.org/index.php?topic=278122.0
 [simplicity]: https://blockstream.com/simplicity.pdf
 [covenant allusion]: https://freenode.irclog.whitequark.org/bitcoin-wizards/2019-11-28#25861296
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/newsletters/2019-12-28-newsletter.md
+++ b/_posts/en/newsletters/2019-12-28-newsletter.md
@@ -798,3 +798,6 @@ schedule on January 8th.*
 [wuille sbc miniscript]: /en/newsletters/2019/02/05/#miniscript
 [xlation es]: /es/publications/
 [xlation ja]: /ja/publications/
+[eltoo]: https://blockstream.com/eltoo.pdf
+[hwi]: https://github.com/bitcoin-core/HWI
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/en/newsletters/2020-05-27-newsletter.md
+++ b/_posts/en/newsletters/2020-05-27-newsletter.md
@@ -177,3 +177,4 @@ version 0.20.*
 [zmn padding]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017886.html
 [RFC6979]:https://tools.ietf.org/html/rfc6979
 [Ed25519]:https://ed25519.cr.yp.to/
+[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842

--- a/_posts/en/newsletters/2020-06-24-newsletter.md
+++ b/_posts/en/newsletters/2020-06-24-newsletter.md
@@ -252,3 +252,4 @@ BOLTs][bolts repo].*
 [news101 fee overpayment attack]: /en/newsletters/2020/06/10/#fee-overpayment-attack-on-multi-input-segwit-transactions
 [core version]: https://bitcoin.org/en/release/v0.19.0.1
 [broken docs]: https://btcinformation.org/en/developer-examples#regtest-mode
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-07-01-newsletter.md
+++ b/_posts/en/newsletters/2020-07-01-newsletter.md
@@ -369,3 +369,4 @@ release candidates.*
 [potzblitz]: https://www.youtube.com/playlist?list=PLwgam6YBS0-jk1TlXD7QXDjTYJh-eJn_X
 [news68 ruffing]: /en/newsletters/2019/10/16/#the-quest-for-practical-threshold-schnorr-signatures
 [cpp compiler support]: https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B17_features
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-07-08-newsletter.md
+++ b/_posts/en/newsletters/2020-07-08-newsletter.md
@@ -227,3 +227,4 @@ release candidates.*
 [wuille churn]: https://bitcoincore.reviews/18991.html#l-365
 [btchip-python]: https://github.com/LedgerHQ/btchip-python
 [coinscope paper]: https://www.cs.umd.edu/projects/coinscope/coinscope.pdf
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-07-15-newsletter.md
+++ b/_posts/en/newsletters/2020-07-15-newsletter.md
@@ -118,3 +118,4 @@ infrastructure projects.
 [eviction-logic]: https://github.com/bitcoin/bitcoin/issues/19500#issuecomment-657257874
 [news32 bcc14929]: /en/newsletters/2019/02/05/#bitcoin-core-14929
 [ban vs discourage]: https://github.com/bitcoin/bitcoin/blob/f4de89edfa8be4501534fec0c662c650a4ce7ef2/src/banman.h#L29-L55
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-07-22-newsletter.md
+++ b/_posts/en/newsletters/2020-07-22-newsletter.md
@@ -187,3 +187,4 @@ release candidates.*
 [news30 probing]: /en/newsletters/2019/01/22/#eclair-762
 [zap 0.7.0]: https://github.com/LN-Zap/zap-desktop/releases/tag/v0.7.0-beta
 [btcpay 1.0.5.0]: https://blog.btcpayserver.org/btcpay-server-1-0-5-0/
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-07-29-newsletter.md
+++ b/_posts/en/newsletters/2020-07-29-newsletter.md
@@ -233,3 +233,4 @@ release candidates.*
 [wtxid relay backport]: https://github.com/bitcoin/bitcoin/pull/19606
 [stack exchange miner signaling]: https://bitcoin.stackexchange.com/questions/97041/how-does-a-miner-put-his-vote-for-certain-bip/97047#97047
 [news96 simplicity]: /en/newsletters/2020/05/06/#simplicity-next-generation-smart-contracting
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-08-05-newsletter.md
+++ b/_posts/en/newsletters/2020-08-05-newsletter.md
@@ -301,3 +301,4 @@ release candidates.*
 [flood and loot]: https://arxiv.org/abs/2006.08513
 [thunderhub]: https://www.thunderhub.io/
 [balance of satoshis]: https://github.com/alexbosworth/balanceofsatoshis
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-08-12-newsletter.md
+++ b/_posts/en/newsletters/2020-08-12-newsletter.md
@@ -215,3 +215,4 @@ release candidates.*
 [19031 handshake]: https://bitcoincore.reviews/19031#l-121
 [19031 v2 deprecate]: https://lists.torproject.org/pipermail/tor-dev/2020-June/014365.html
 [19031 v2 schedule]: https://blog.torproject.org/v2-deprecation-timeline
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-08-19-newsletter.md
+++ b/_posts/en/newsletters/2020-08-19-newsletter.md
@@ -206,3 +206,4 @@ release candidates.*
 [bitcoinissafe.com]: https://bitcoinissafe.com/
 [lightning terminal blog]: https://lightning.engineering/posts/2020-08-04-lightning-terminal/
 [news39 lightning loop announced]: /en/newsletters/2019/03/26/#loop-announced
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-08-26-newsletter.md
+++ b/_posts/en/newsletters/2020-08-26-newsletter.md
@@ -162,3 +162,4 @@ release candidates.*
 [stack exchange signet setup]: https://bitcoin.stackexchange.com/questions/98553/how-do-i-get-set-up-on-signet/98554#98554
 [bitcoin wiki change avoidance]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Change_avoidance
 [psbt ext]: /en/newsletters/2019/03/12/#extension-fields-to-partially-signed-bitcoin-transactions-psbts
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-09-02-newsletter.md
+++ b/_posts/en/newsletters/2020-09-02-newsletter.md
@@ -267,3 +267,4 @@ highlight a selection of the transcripts from the previous month.*
 [r point evenness update]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-August/018081.html
 [news111 proposed tiebreaker]: /en/newsletters/2020/08/19/#proposed-uniform-tiebreaker-in-schnorr-signatures
 [btcd 0.21.0-beta]: https://github.com/btcsuite/btcd/releases/tag/v0.21.0-beta
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-09-09-newsletter.md
+++ b/_posts/en/newsletters/2020-09-09-newsletter.md
@@ -194,3 +194,4 @@ link to for BitBox seems unfair. -harding -->{% endcomment %}
 [belcher coinswap]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-August/018080.html
 [news82 lnd acl]: /en/newsletters/2020/01/29/#upgrade-to-lnd-0-9-0-beta
 [review club client]: https://bitcoincore.reviews/19339#l-104
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-09-16-newsletter.md
+++ b/_posts/en/newsletters/2020-09-16-newsletter.md
@@ -221,3 +221,4 @@ release candidates.*
 [news104 scorched earth]: /en/newsletters/2020/07/01/#discussion-of-htlc-mining-incentives
 [sighash]: https://btcinformation.org/en/developer-guide#signature-hash-types
 [bindings readme]: https://github.com/rust-bitcoin/rust-lightning/tree/main/lightning-c-bindings
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/en/newsletters/2020-09-23-newsletter.md
+++ b/_posts/en/newsletters/2020-09-23-newsletter.md
@@ -315,3 +315,4 @@ release candidates.*
 [ledger coin control article]: https://www.ledger.com/coin-control-now-available-in-ledger-live
 [sparrow twitter thread]: https://twitter.com/craigraw/status/1301045693814132736
 [joinmarket 0.7.0]: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/release-notes/release-notes-0.7.0.md
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/es/2019-10-29-schnorr-taproot-workshop.md
+++ b/_posts/es/2019-10-29-schnorr-taproot-workshop.md
@@ -216,3 +216,4 @@ retroalimentación de la comunidad para estas propuestas.
 [transcript]: https://diyhpl.us/wiki/transcripts/bitcoinops/schnorr-taproot-workshop-2019/notes/
 [readme]: https://github.com/bitcoinops/taproot-workshop/blob/master/README.md
 [workshop repository]: https://github.com/bitcoinops/taproot-workshop/
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/es/newsletters/2019-11-27-newsletter.md
+++ b/_posts/es/newsletters/2019-11-27-newsletter.md
@@ -300,3 +300,4 @@ repo] y [Lightning BOLTs][bolts repo].*
 [heartbleed]: https://bitcoin.org/en/alert/2014-04-11-heartbleed
 [cve-2014-3570]: https://www.reddit.com/r/Bitcoin/comments/2rrxq7/on_why_010s_release_notes_say_we_have_reason_to/
 [libsecp256k1 sig speedup]: https://bitcoincore.org/en/2016/02/23/release-0.12.0/#x-faster-signature-validation
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/ja/2019-10-29-schnorr-taproot-workshop-ja.md
+++ b/_posts/ja/2019-10-29-schnorr-taproot-workshop-ja.md
@@ -163,3 +163,4 @@ Taprootは、複数の支出パスをコミットすることを許可し、行�
 [transcript]: https://diyhpl.us/wiki/transcripts/bitcoinops/schnorr-taproot-workshop-2019/notes/
 [readme]: https://github.com/bitcoinops/taproot-workshop/blob/master/README.md
 [workshop repository]: https://github.com/bitcoinops/taproot-workshop/
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/ja/newsletters/2019-10-02-newsletter.md
+++ b/_posts/ja/newsletters/2019-10-02-newsletter.md
@@ -61,3 +61,4 @@ sketchのサイズは、取得する必要があるtxidのサイズとほぼ等�
 [optech ln warning]: /en/newsletters/2019/09/04/#upgrade-ln-implementations
 [workshop transcript]: http://diyhpl.us/wiki/transcripts/bitcoinops/schnorr-taproot-workshop-2019/notes/
 [russell disclosure]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-September/002174.html
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/ja/newsletters/2019-10-09-newsletter.md
+++ b/_posts/ja/newsletters/2019-10-09-newsletter.md
@@ -77,6 +77,4 @@ Transaction outputに強制的にタグがつけられることに対してど�
 [zmn internal tagging]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-October/002180.html
 [gui bech32]: /en/newsletters/2019/04/16/#bitcoin-core-15711
 [orig output tagging]: /en/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
-
-
-
+[eltoo]: https://blockstream.com/eltoo.pdf

--- a/_posts/ja/newsletters/2019-10-16-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-10-16-newsletter-ja.md
@@ -115,4 +115,4 @@ lang: ja
 [css ts]: https://diyhpl.us/wiki/transcripts/cryptoeconomic-systems/2019/
 [css vids]: https://www.youtube.com/channel/UCJkYmuzqAnIKn3NPg5lc0Wg/videos
 [eclair 0.3.2]: https://github.com/ACINQ/eclair/releases/tag/v0.3.2
-
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/ja/newsletters/2019-11-06-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-11-06-newsletter-ja.md
@@ -65,6 +65,4 @@ lang: ja
 [naumenko addr relay]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-October/017428.html
 [news70 simplified commitments]: /ja/newsletters/2019/10/30
 [jager anchor]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-October/002264.html
-
-
-
+[output script descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/ja/newsletters/2019-11-27-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-11-27-newsletter-ja.md
@@ -118,4 +118,4 @@ endcomment %}
 [heartbleed]: https://bitcoin.org/en/alert/2014-04-11-heartbleed
 [cve-2014-3570]: https://www.reddit.com/r/Bitcoin/comments/2rrxq7/on_why_010s_release_notes_say_we_have_reason_to/
 [libsecp256k1 sig speedup]: https://bitcoincore.org/en/2016/02/23/release-0.12.0/#x-faster-signature-validation
-
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/ja/newsletters/2019-12-04-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-12-04-newsletter-ja.md
@@ -64,4 +64,4 @@ lang: ja
 [coincovenants]: https://bitcointalk.org/index.php?topic=278122.0
 [simplicity]: https://blockstream.com/simplicity.pdf
 [covenant allusion]: https://freenode.irclog.whitequark.org/bitcoin-wizards/2019-11-28#25861296
-
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
+++ b/_posts/ja/newsletters/2019-12-28-newsletter-ja.md
@@ -427,3 +427,6 @@ implementation]を達成しました。ペイメントを複数パートに分�
 [wuille sbc miniscript]: /en/newsletters/2019/02/05/#miniscript
 [xlation es]: /es/publications/
 [xlation ja]: /ja/publications/
+[eltoo]: https://blockstream.com/eltoo.pdf
+[hwi]: https://github.com/bitcoin-core/HWI
+[erlay]: https://arxiv.org/pdf/1905.10518.pdf

--- a/_posts/zh/newsletters/2018-07-24-newsletter.md
+++ b/_posts/zh/newsletters/2018-07-24-newsletter.md
@@ -76,6 +76,7 @@ git log --merges b25a4c2284babdf1e8cf0ec3b1402200dd25f33f..07ce278455757fb46dab9
 [announce cdesk]: https://www.coindesk.com/bitcoins-biggest-startups-are-backing-a-new-effort-to-keep-fees-low/
 [inv]: https://bitcoin.org/en/developer-reference#inv
 [workshop announce]: /en/newsletters/2018/06/26/#first-optech-workshop
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 
 {% include references.md %}
 {% include linkers/issues.md issues="13697,13557,12196,9662,12196,13604,13298,13652" %}

--- a/_posts/zh/newsletters/2018-08-07-newsletter.md
+++ b/_posts/zh/newsletters/2018-08-07-newsletter.md
@@ -63,3 +63,4 @@ lang: zh
 [fee metrics]: https://statoshi.info/dashboard/db/fee-estimates
 [consolidate info]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees#Consolidation
 [rbf data]: https://dashboard.bitcoinops.org/d/ZsCio4Dmz/rbf-signalling?orgId=1&from=now-1y&to=now
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2018-10-09-newsletter.md
+++ b/_posts/zh/newsletters/2018-10-09-newsletter.md
@@ -126,3 +126,4 @@ lang: zh
 [eltoo protocol]: https://blockstream.com/2018/04/30/eltoo-next-lightning.html
 [bitcoin-dev timewarp]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-August/016316.html
 [ln scriptless scripts]: https://lists.launchpad.net/mimblewimble/msg00086.html
+[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144

--- a/_posts/zh/newsletters/2018-10-16-newsletter.md
+++ b/_posts/zh/newsletters/2018-10-16-newsletter.md
@@ -64,3 +64,4 @@ CoreDev.tech 是一个仅限邀请的活动，面向比特币基础设施项目�
 [kanzure reorg transcript]: http://diyhpl.us/wiki/transcripts/scalingbitcoin/tokyo-2018/edgedevplusplus/reorgs/
 [kanzure reorg vid]: https://youtu.be/EUUQbveGF5E?t=4
 [UHO]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-May/015967.html
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2018-10-30-newsletter.md
+++ b/_posts/zh/newsletters/2018-10-30-newsletter.md
@@ -96,3 +96,4 @@ it to write a good description, and I doubt non-LN devs care -->{% endcomment %}
 [newsletter #9]: /zh/newsletters/2018/08/21/#output-script-descriptors-enhancements
 [newsletter #12]: /zh/newsletters/2018/09/11/#bitcoin-core-14096
 [newsletter #17]: /zh/newsletters/2018/10/16/#script-descriptors-and-descript
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2018-12-04-newsletter.md
+++ b/_posts/zh/newsletters/2018-12-04-newsletter.md
@@ -70,3 +70,4 @@ lang: zh
 [ln1.1 accepted proposals]: https://github.com/lightningnetwork/lightning-rfc/wiki/Lightning-Specification-1.1-Proposal-States
 [ln spec meetings]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-November/001673.html
 [0.17.1 milestone]: https://github.com/bitcoin/bitcoin/milestone/39?closed=1
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2018-12-28-newsletter.md
+++ b/_posts/zh/newsletters/2018-12-28-newsletter.md
@@ -333,3 +333,5 @@ Segwit 支出有两类：
 [techniques for reducing transaction fees]: https://en.bitcoin.it/wiki/Techniques_to_reduce_transaction_fees
 [payment batching]: https://bitcointechtalk.com/saving-up-to-80-on-bitcoin-transaction-fees-by-batching-payments-4147ab7009fb
 [towns consolidation]: /en/xapo-utxo-consolidation/
+[cve-2017-12842]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12842
+[cve-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144

--- a/_posts/zh/newsletters/2019-02-05-newsletter.md
+++ b/_posts/zh/newsletters/2019-02-05-newsletter.md
@@ -127,3 +127,4 @@ lang: zh
 [btcpay utxo]: https://github.com/btcpayserver/btcpayserver-docker/tree/master/contrib/FastSync
 [newsletter #21]: /zh/newsletters/2018/11/13/#闪电网络应用实习视频
 [newsletter #31]: /zh/newsletters/2019/01/29/#c-lightning-2283
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2019-02-12-newsletter.md
+++ b/_posts/zh/newsletters/2019-02-12-newsletter.md
@@ -49,3 +49,4 @@ lang: zh
 [reserve audit tool]: https://blockstream.com/2019/02/04/standardizing-bitcoin-proof-of-reserves/
 [eclair tor]: https://github.com/ACINQ/eclair/blob/master/TOR.md
 [rbf report]: /en/rbf-in-the-wild/
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2019-02-19-newsletter.md
+++ b/_posts/zh/newsletters/2019-02-19-newsletter.md
@@ -86,3 +86,7 @@ lang: zh
 [electrum personal server]: https://github.com/chris-belcher/electrum-personal-server
 [key origin information]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#key-origin-identification
 [newsletter #5]: /zh/newsletters/2018/07/24/#bitcoin-core-9662
+[hwi]: https://github.com/bitcoin-core/HWI
+[descriptor]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[hwi]: https://github.com/bitcoin-core/HWI
+[miniscript]: /en/topics/miniscript/

--- a/_posts/zh/newsletters/2019-02-26-newsletter.md
+++ b/_posts/zh/newsletters/2019-02-26-newsletter.md
@@ -62,3 +62,4 @@ lang: zh
 [liquid]: https://blockstream.com/liquid/
 [schnorr docs]: https://github.com/ElementsProject/secp256k1-zkp/blob/secp256k1-zkp/src/modules/musig/musig.md
 [productivity hints]: https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/zh/newsletters/2019-03-12-newsletter.md
+++ b/_posts/zh/newsletters/2019-03-12-newsletter.md
@@ -87,3 +87,7 @@ lang: zh
 [newsletter #36 ml]: /zh/newsletters/2019/03/05/#bitcoin-dev-mailing-list-outage
 [newsletter #36 cleanup]: /zh/newsletters/2019/03/05/#cleanup-soft-fork-proposal
 [newsletter #13]: /zh/newsletters/2018/09/18/#bitcoin-core-14054
+[cve-2012-2459]: https://bitcointalk.org/?topic=102395
+[miniscript]: /en/topics/miniscript/
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[musig]: https://eprint.iacr.org/2018/068

--- a/_posts/zh/newsletters/2019-04-30-newsletter.md
+++ b/_posts/zh/newsletters/2019-04-30-newsletter.md
@@ -63,3 +63,4 @@ endcomment %}
 [dust convo]: https://github.com/bitcoin/bitcoin/pull/2577#issuecomment-17738577
 [bitcoincore.org]: https://bitcoincore.org/
 [bech32 series]: /zh/bech32-sending-support/
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md

--- a/_posts/zh/newsletters/2019-05-07-newsletter.md
+++ b/_posts/zh/newsletters/2019-05-07-newsletter.md
@@ -92,3 +92,5 @@ wiki page for changes -->{% endcomment %}
 [tap ref]: https://github.com/sipa/bitcoin/commits/taproot
 [bech32 series]: /zh/bech32-sending-support/
 [newsletter #40]: /zh/newsletters/2019/04/02/#bitcoin-core-schedules-switch-to-default-bech32-receiving-addresses
+[output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
+[hwi]: https://github.com/bitcoin-core/HWI

--- a/_posts/zh/newsletters/2019-05-14-newsletter.md
+++ b/_posts/zh/newsletters/2019-05-14-newsletter.md
@@ -300,3 +300,4 @@ wiki page for changes -->{% endcomment %}
 [example implementation]: https://github.com/sipa/bitcoin/commits/taproot
 [bech32 series]: /zh/bech32-sending-support/
 [newsletter #3]: /zh/newsletters/2018/07/10/#特别新闻schnorr-签名提议-bip
+[cve-2012-2459]: https://bitcointalk.org/?topic=102395

--- a/_posts/zh/newsletters/2019-05-21-newsletter.md
+++ b/_posts/zh/newsletters/2019-05-21-newsletter.md
@@ -75,3 +75,4 @@ wiki page for changes -->{% endcomment %}
 [bech32 series]: /zh/bech32-sending-support/
 [newsletter #34]: /zh/newsletters/2019/02/19/#discussion-about-tagging-outputs-to-enable-restricted-features-on-spending
 [newsletter #39]: /zh/newsletters/2019/03/26/#version-2-p2p-transport-proposal
+[eltoo]: https://blockstream.com/eltoo.pdf


### PR DESCRIPTION
Part of #1551 

Back in 2020, when we first added the topic index, we added a Jekyll function to deprecate some link definitions that we had been using.  Rather than port that function to Hugo and carry over that technical debt, I've integrated each old link into the source files that called it.  This produces identical HTML output to HEAD, which can be verified using something like:

1. Checkout this branch
2. Build the site: `make clean all` (all tests should pass)
3. Backup the HTML output: `cp -a _site _new_site`
4. Checkout the commit before this PR: `git reset --hard HEAD^`
5. Build the site again: `make clean all`
6. Compare the HTML output: `diff -ruN _site _new_site | colordiff | less -R`  (should be identical except for the dynamic date in the RSS file)