### PR TITLE
ZH News48: fix links broken by previous commit

### DIFF
--- a/_posts/zh/newsletters/2019-05-29-newsletter.md
+++ b/_posts/zh/newsletters/2019-05-29-newsletter.md
@@ -177,3 +177,5 @@ endcomment %}
 [newsletter #32]: /zh/newsletters/2019/02/05/#miniscript
 [newsletter #18]: /zh/newsletters/2018/10/23/#two-papers-published-on-fast-multiparty-ecdsa
 [newsletter #47]: /zh/newsletters/2019/05/21/#proposed-anyprevout-sighash-modes
+[musig]: https://eprint.iacr.org/2018/068
+[miniscript]: /en/topics/miniscript/


### PR DESCRIPTION
#1802 used old links that were replaced in #1809.  This fixes that.

I plan to merge once tests pass.