### PR TITLE
Localize a few pages: about, workshops, internal/sources

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,10 +20,10 @@
         </label>
 
         <div class="trigger">
-            <a class="page-link" href="/about/">About</a>
+            <a class="page-link" href="/en/about/">About</a>
             <a class="page-link" href="/en/publications/">Publications</a>
             <a class="page-link" href="/en/topics/">Topics</a>
-            <a class="page-link" href="/workshops/">Workshops</a>
+            <a class="page-link" href="/en/workshops/">Workshops</a>
             <a class="page-link" href="/en/compatibility/">Compatibility</a>
             <a class="page-link" href="https://dashboard.bitcoinops.org/">Dashboard</a>
         </div>

--- a/_posts/cs/newsletters/2022-05-18-newsletter.md
+++ b/_posts/cs/newsletters/2022-05-18-newsletter.md
@@ -582,7 +582,7 @@ Wences Casares, John Pfeffer a Alex Morcos.
 [sanders op_tx]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020458.html
 [ingala desc]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html
 [supporters]: /#supporters
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [news191 pinning]: /en/newsletters/2022/03/16/#ideas-for-improving-rbf-policy
 [MyCitadel Wallet]: https://github.com/mycitadel/mycitadel-desktop
 [RGB]: https://www.rgbfaq.com/what-is-rgb

--- a/_posts/cs/newsletters/2023-05-10-newsletter.md
+++ b/_posts/cs/newsletters/2023-05-10-newsletter.md
@@ -267,7 +267,7 @@ zpravodajů pokračovat.
 [hnr powswap]: https://raw.githubusercontent.com/blockrate-binaries/paper/master/blockrate-binaries-paper.pdf
 [powswap]: https://powswap.com/
 [news188 phantom]: /en/newsletters/2022/02/23/#ldk-1199
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [financial supporters]: /#members
 [review club 27501]: https://bitcoincore.reviews/27501
 [prioritisetransaction rpc]: https://developer.bitcoin.org/reference/rpc/prioritisetransaction.html

--- a/_posts/cs/newsletters/2023-11-08-newsletter.md
+++ b/_posts/cs/newsletters/2023-11-08-newsletter.md
@@ -192,7 +192,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo] a
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
 [core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
 [lnd 0.17.1-beta.rc1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta.rc1
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [bishop lists]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html
 [delvingbitcoin]: https://delvingbitcoin.org/
 [halseth agg]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004181.html

--- a/_posts/cs/newsletters/2024-07-12-newsletter.md
+++ b/_posts/cs/newsletters/2024-07-12-newsletter.md
@@ -113,7 +113,7 @@ repo]._
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="2949,1487" %}
 [bitcoin core 26.2]: https://bitcoincore.org/bin/bitcoin-core-26.2/
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [interesting transaction]: https://stacker.news/items/600187
 [news19 bip69]: /en/newsletters/2018/10/30/#bip69-discussion
 [news151 bip69]: /en/newsletters/2021/06/02/#bolts-872

--- a/_posts/en/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/en/2018-07-20-announcing-bitcoin-optech.md
@@ -41,7 +41,7 @@ utilizing the Bitcoin blockchain to discuss efficient use of the blockchain and
 ways to engage with the open source community.
 
 [newsletters]: /en/newsletters
-[workshop]: /workshops
+[workshop]: /en/workshops
 
 Over the coming months, we plan to:
 

--- a/_posts/en/2018-12-28-2018-optech-annual_report.md
+++ b/_posts/en/2018-12-28-2018-optech-annual_report.md
@@ -78,9 +78,9 @@ scale.
 {% include references.md %}
 
 [newsletter #6]: /en/newsletters/2018/07/31/#field-report-consolidation-of-4-million-utxos-at-xapo
-[optech team]: /about/
+[optech team]: /en/about/
 [announcement]: /en/announcing-bitcoin-optech/
-[workshops]: /workshops/
+[workshops]: /en/workshops/
 [newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /en/dashboard-announcement/

--- a/_posts/en/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/en/2019-02-11-rbf-in-the-wild.md
@@ -17,7 +17,7 @@ Opt-in Replace by Fee (RBF) was standardized in December 2015. But who is
 supporting it and what is the user experience like? This post presents a study of
 [BIP125][] opt-in RBF as seen by users of popular Bitcoin wallets and block explorers. The
 findings were initially presented during the most recent [Bitcoin Optech
-Workshop in Paris](/workshops/).
+Workshop in Paris](/en/workshops/).
 
 Understanding how other wallets, exchanges, and block explorers handle opt-in
 RBF transactions is an important consideration for Bitcoin services. In order
@@ -401,9 +401,9 @@ reach out to [mike@bitcoinops.org](mailto:mike@bitcoinops.org).
     by users of second layer protocols.
 
 {% include references.md %}
-[optech team]: /about/
+[optech team]: /en/about/
 [announcement]: /en/announcing-bitcoin-optech/
-[workshops]: /workshops/
+[workshops]: /en/workshops/
 [newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /en/dashboard-announcement/

--- a/_posts/en/2019-06-14-exec-briefing.md
+++ b/_posts/en/2019-06-14-exec-briefing.md
@@ -87,6 +87,6 @@ technical topics at a high-level for decision makers at Bitcoin businesses.
 [lightning slides]: /img/posts/2019-exec-briefing/lightning.pdf
 [softfork slides]: /img/posts/2019-exec-briefing/softfork.pdf
 [newsletters]: /en/newsletters/
-[workshops]: /workshops/
+[workshops]: /en/workshops/
 [eltoo]: https://blockstream.com/eltoo.pdf
 [musig]: https://eprint.iacr.org/2018/068

--- a/_posts/en/2021-02-19-pausing-memberships.md
+++ b/_posts/en/2021-02-19-pausing-memberships.md
@@ -74,6 +74,6 @@ future we'll be able to get back to running workshops and social events.
 [compatibility matrix]: /en/compatibility/
 [topic index]: /en/topics/
 [taproot workbooks]: /en/schorr-taproot-workshop/
-[workshops]: /workshops/
+[workshops]: /en/workshops/
 [Haegwan Kim]: https://twitter.com/haegwankim
 

--- a/_posts/en/newsletters/2018-09-11-newsletter.md
+++ b/_posts/en/newsletters/2018-09-11-newsletter.md
@@ -92,7 +92,7 @@ wait until version 0.18 in about six months from now.*
 {% include linkers/issues.md issues="12775,12490,14096,1899" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
-[workshop]: /workshops
+[workshop]: /en/workshops
 [documentation for output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 [news10 news]: /en/newsletters/2018/08/28/#pr-opened-for-initial-bip151-support
 [decker w3c]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-August/001404.html

--- a/_posts/en/newsletters/2018-09-18-newsletter.md
+++ b/_posts/en/newsletters/2018-09-18-newsletter.md
@@ -169,7 +169,7 @@ wait until version 0.18 in about six months from now.*
 {% include linkers/issues.md issues="14054,1843,1516,7965,14168,10973,14180,1860" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
-[workshop]: /workshops
+[workshop]: /en/workshops
 [news8 news]: /en/newsletters/2018/08/14/#pay-to-end-point-p2ep-idea-proposed
 [c-lightning 0.6.1]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.1
 [BIP322 proposal]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-September/016393.html

--- a/_posts/en/newsletters/2018-12-28-newsletter.md
+++ b/_posts/en/newsletters/2018-12-28-newsletter.md
@@ -660,7 +660,7 @@ newsletters] or follow our [RSS feed][].*
 [optech annual report]: /en/2018-optech-annual-report/
 [optech dashboard]: https://dashboard.bitcoinops.org/
 [optech newsletters]: /en/newsletters/
-[optech workshops]: /workshops/
+[optech workshops]: /en/workshops/
 [p2ep]: https://blockstream.com/2018/08/08/improving-privacy-using-pay-to-endpoint/
 [satoshis.place]: https://satoshis.place/
 [scaling bitcoin conference]: https://tokyo2018.scalingbitcoin.org/

--- a/_posts/en/newsletters/2019-05-29-newsletter.md
+++ b/_posts/en/newsletters/2019-05-29-newsletter.md
@@ -414,7 +414,7 @@ the author.
 [ivgi tweet]: https://twitter.com/shesek/status/1131733590235131905
 [updated qr paragraph]: /en/bech32-sending-support/#qrcode-edit
 [optech twitter]: https://twitter.com/bitcoinoptech
-[optech contributors]: /about/#contributors
+[optech contributors]: /en/about/#contributors
 [special section about the proposal]: #proposed-transaction-output-commitments
 [bech32 series]: /en/bech32-sending-support/
 [newsletter #32]: /en/newsletters/2019/02/05/#miniscript

--- a/_posts/en/newsletters/2019-06-12-newsletter.md
+++ b/_posts/en/newsletters/2019-06-12-newsletter.md
@@ -241,7 +241,7 @@ wiki page for changes -->{% endcomment %}
 [proof-of-concept newsletter]: /en/newsletters/2018/06/08/
 [newsletter rss]: /feed.xml
 [optech twitter]: https://www.twitter.com/bitcoinoptech
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [member companies]: /#members
 [countersign blurb]: /en/newsletters/2018/12/28/#august
 [cpfp carve out]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html

--- a/_posts/en/newsletters/2019-08-14-newsletter.md
+++ b/_posts/en/newsletters/2019-08-14-newsletter.md
@@ -96,4 +96,4 @@ you pay to access all of segwit's benefits.*
 [vault2]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-August/017231.html
 [pubkey32]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-August/017247.html
 [pr pubkey32]: https://github.com/sipa/bips/pull/52
-[taproot-workshop]: /workshops#taproot-workshop
+[taproot-workshop]: /en/workshops#taproot-workshop

--- a/_posts/en/newsletters/2020-06-03-newsletter.md
+++ b/_posts/en/newsletters/2020-06-03-newsletter.md
@@ -267,7 +267,7 @@ their work hours to contribute to Optech.
 [lopp size]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017905.html
 [lopp calc]: https://jlopp.github.io/bitcoin-transaction-size-calculator/
 [optech calc]: /en/tools/calc-size/
-[about page]: /about/
+[about page]: /en/about/
 [ivgi bwt]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017906.html
 [bwt api]: https://github.com/shesek/bwt#http-api
 [bwt plugin]: https://github.com/shesek/bwt#electrum-plugin

--- a/_posts/en/newsletters/2020-12-23-newsletter.md
+++ b/_posts/en/newsletters/2020-12-23-newsletter.md
@@ -928,7 +928,7 @@ schedule on January 6th.*
 [somsen sas post]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017846.html
 [somsen sas video]: https://www.youtube.com/watch?v=TlCxpdNScCA
 [##taproot-activation]: /en/newsletters/2020/07/22/#taproot-activation-discussions
-[taproot workshop]: /workshops/#taproot-workshop
+[taproot workshop]: /en/workshops/#taproot-workshop
 [todd segwit review]: https://petertodd.org/2016/segwit-consensus-critical-code-review#peer-to-peer-networking
 [topics index]: /en/topics/
 [tx origin wiki]: https://en.bitcoin.it/wiki/Privacy#Traffic_analysis

--- a/_posts/en/newsletters/2021-05-26-newsletter.md
+++ b/_posts/en/newsletters/2021-05-26-newsletter.md
@@ -255,7 +255,7 @@ BOLTs][bolts repo].*
 [shigeyuki azuchi]: https://github.com/azuchi
 [akio nakamura]: https://github.com/AkioNak
 [supporters]: /#supporters
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [info]: mailto:info@bitcoinops.org
 [bip141 commitment]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure
 [se 273 merge mining]: https://bitcoin.stackexchange.com/questions/273/how-does-merged-mining-work

--- a/_posts/en/newsletters/2022-05-18-newsletter.md
+++ b/_posts/en/newsletters/2022-05-18-newsletter.md
@@ -608,7 +608,7 @@ Alex Morcos.
 [sanders op_tx]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020458.html
 [ingala desc]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html
 [supporters]: /#supporters
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [news191 pinning]: /en/newsletters/2022/03/16/#ideas-for-improving-rbf-policy
 [MyCitadel Wallet]: https://github.com/mycitadel/mycitadel-desktop
 [RGB]: https://www.rgbfaq.com/what-is-rgb

--- a/_posts/en/newsletters/2023-05-10-newsletter.md
+++ b/_posts/en/newsletters/2023-05-10-newsletter.md
@@ -285,7 +285,7 @@ publish the next 250 newsletters. {% assign timestamp="54:17" %}
 [hnr powswap]: https://raw.githubusercontent.com/blockrate-binaries/paper/master/blockrate-binaries-paper.pdf
 [powswap]: https://powswap.com/
 [news188 phantom]: /en/newsletters/2022/02/23/#ldk-1199
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [financial supporters]: /#members
 [review club 27501]: https://bitcoincore.reviews/27501
 [prioritisetransaction rpc]: https://developer.bitcoin.org/reference/rpc/prioritisetransaction.html

--- a/_posts/en/newsletters/2023-11-08-newsletter.md
+++ b/_posts/en/newsletters/2023-11-08-newsletter.md
@@ -218,7 +218,7 @@ Proposals (BIPs)][bips repo], [Lightning BOLTs][bolts repo], and
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
 [core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
 [lnd 0.17.1-beta.rc1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta.rc1
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [bishop lists]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html
 [delvingbitcoin]: https://delvingbitcoin.org/
 [halseth agg]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004181.html

--- a/_posts/en/newsletters/2024-07-12-newsletter.md
+++ b/_posts/en/newsletters/2024-07-12-newsletter.md
@@ -123,7 +123,7 @@ repo], and [BINANAs][binana repo]._
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="2949,1487" %}
 [bitcoin core 26.2]: https://bitcoincore.org/bin/bitcoin-core-26.2/
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [interesting transaction]: https://stacker.news/items/600187
 [LND v0.18.2-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.2-beta
 [news19 bip69]: /en/newsletters/2018/10/30/#bip69-discussion

--- a/_posts/fr/newsletters/2020-12-23-newsletter.md
+++ b/_posts/fr/newsletters/2020-12-23-newsletter.md
@@ -952,7 +952,7 @@ impatients de voir ce qu'ils nous réservent en 2021.
 [somsen sas post]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-May/017846.html
 [somsen sas video]: https://www.youtube.com/watch?v=TlCxpdNScCA
 [##taproot-activation]: /en/newsletters/2020/07/22/#taproot-activation-discussions
-[atelier taproot]: /workshops/#taproot-workshop
+[atelier taproot]: /en/workshops/#taproot-workshop
 [todd segwit review]: https://petertodd.org/2016/segwit-consensus-critical-code-review#peer-to-peer-networking
 [index des sujets]: /en/topics/
 [tx origin wiki]: https://en.bitcoin.it/wiki/Privacy#Traffic_analysis

--- a/_posts/fr/newsletters/2023-05-10-newsletter.md
+++ b/_posts/fr/newsletters/2023-05-10-newsletter.md
@@ -294,7 +294,7 @@ lorsque nous publierons les 250 prochains bulletins d'information.
 [hnr powswap]: https://raw.githubusercontent.com/blockrate-binaries/paper/master/blockrate-binaries-paper.pdf
 [powswap]: https://powswap.com/
 [news188 phantom]: /en/newsletters/2022/02/23/#ldk-1199
-[sponsors fondateurs]: /about/#founding-sponsors
+[sponsors fondateurs]: /en/about/#founding-sponsors
 [soutiens financiers]: /#members
 [review club 27501]: https://bitcoincore.reviews/27501
 [prioritisetransaction rpc]: https://developer.bitcoin.org/reference/rpc/prioritisetransaction.html

--- a/_posts/fr/newsletters/2023-11-08-newsletter.md
+++ b/_posts/fr/newsletters/2023-11-08-newsletter.md
@@ -179,7 +179,7 @@ versions ou d'aider à tester les versions candidates.*
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
 [core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
 [lnd 0.17.1-beta.rc1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta.rc1
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [bishop lists]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html
 [delvingbitcoin]: https://delvingbitcoin.org/
 [halseth agg]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004181.html

--- a/_posts/fr/newsletters/2024-07-12-newsletter.md
+++ b/_posts/fr/newsletters/2024-07-12-newsletter.md
@@ -117,7 +117,7 @@ Bitcoin (BIPs)][bips repo], [Lightning BOLTs][bolts repo], [Lightning BLIPs][bli
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="2949,1487" %}
 [bitcoin core 26.2]: https://bitcoincore.org/bin/bitcoin-core-26.2/
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [transaction intéressante]: https://stacker.news/items/600187
 [LND v0.18.2-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.2-beta
 [news19 bip69]: /en/newsletters/2018/10/30/#bip69-discussion

--- a/_posts/ja/newsletters/2021-05-26-newsletter.md
+++ b/_posts/ja/newsletters/2021-05-26-newsletter.md
@@ -215,7 +215,7 @@ John Pfeffer、Alex Morcosを中心とした寛大な[支援者][supporters]に�
 [shigeyuki azuchi]: https://github.com/azuchi
 [akio nakamura]: https://github.com/AkioNak
 [supporters]: /#supporters
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [info]: mailto:info@bitcoinops.org
 [bip141 commitment]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure
 [se 273 merge mining]: https://bitcoin.stackexchange.com/questions/273/how-does-merged-mining-work

--- a/_posts/ja/newsletters/2022-05-18-newsletter.md
+++ b/_posts/ja/newsletters/2022-05-18-newsletter.md
@@ -528,7 +528,7 @@ Alex Morcosを含む[多くのサポーター][supporters]にも感謝します�
 [sanders op_tx]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020458.html
 [ingala desc]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html
 [supporters]: /#supporters
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [news191 pinning]: /ja/newsletters/2022/03/16/#rbf
 [MyCitadel Wallet]: https://github.com/mycitadel/mycitadel-desktop
 [RGB]: https://www.rgbfaq.com/what-is-rgb

--- a/_posts/ja/newsletters/2023-05-10-newsletter.md
+++ b/_posts/ja/newsletters/2023-05-10-newsletter.md
@@ -242,7 +242,7 @@ Zhiwei "Jeffrey" Hu、
 [hnr powswap]: https://raw.githubusercontent.com/blockrate-binaries/paper/master/blockrate-binaries-paper.pdf
 [powswap]: https://powswap.com/
 [news188 phantom]: /ja/newsletters/2022/02/23/#ldk-1199
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [financial supporters]: /#members
 [review club 27501]: https://bitcoincore.reviews/27501
 [prioritisetransaction rpc]: https://developer.bitcoin.org/reference/rpc/prioritisetransaction.html

--- a/_posts/ja/newsletters/2023-11-08-newsletter.md
+++ b/_posts/ja/newsletters/2023-11-08-newsletter.md
@@ -175,7 +175,7 @@ Proposals（BIP）][bips repo]、[Lightning BOLTs][bolts repo]および
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
 [core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
 [lnd 0.17.1-beta.rc1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta.rc1
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [bishop lists]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html
 [delvingbitcoin]: https://delvingbitcoin.org/
 [halseth agg]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004181.html

--- a/_posts/ja/newsletters/2024-07-12-newsletter.md
+++ b/_posts/ja/newsletters/2024-07-12-newsletter.md
@@ -98,7 +98,7 @@ Proposals（BIP）][bips repo]、[Lightning BOLTs][bolts repo]、
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="2949,1487" %}
 [bitcoin core 26.2]: https://bitcoincore.org/bin/bitcoin-core-26.2/
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [interesting transaction]: https://stacker.news/items/600187
 [LND v0.18.2-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.2-beta
 [news19 bip69]: /en/newsletters/2018/10/30/#bip69-discussion

--- a/_posts/zh/2018-07-20-announcing-bitcoin-optech.md
+++ b/_posts/zh/2018-07-20-announcing-bitcoin-optech.md
@@ -20,7 +20,7 @@ excerpt: >
 在 Wences Casares、John Pfeffer 和 Chaincode Labs 的慷慨支持下，我们过去几个月与整个生态系统中的工程师和经理会面；开始为比特币工程师制作[每周 Newsletter][newsletters]，重点介绍他们如何更有效地使用区块链；并在旧金山组织了我们的第一个[研讨会][workshop]，汇集了来自交易所、托管和钱包公司的工程师，利用比特币区块链讨论如何高效使用区块链以及与开源社区的互动方式。
 
 [newsletters]: /zh/newsletters
-[workshop]: /workshops
+[workshop]: /en/workshops
 
 在接下来的几个月里，我们计划：
 

--- a/_posts/zh/2019-02-11-rbf-in-the-wild.md
+++ b/_posts/zh/2019-02-11-rbf-in-the-wild.md
@@ -12,7 +12,7 @@ excerpt: >
   一项关于支持可选择 RBF (BIP125) 的钱包和区块浏览器在可用性问题上的研究。
 
 ---
-可选择通过费用替代（RBF）于 2015 年 12 月标准化。但谁在支持它，用户体验如何？这篇文章展示了用户在流行的比特币钱包和区块浏览器中看到的 [BIP125][] 可选择 RBF 的研究结果。研究成果最初在最近一次 [Bitcoin Optech 研讨会](/workshops/)中展示。
+可选择通过费用替代（RBF）于 2015 年 12 月标准化。但谁在支持它，用户体验如何？这篇文章展示了用户在流行的比特币钱包和区块浏览器中看到的 [BIP125][] 可选择 RBF 的研究结果。研究成果最初在最近一次 [Bitcoin Optech 研讨会](/en/workshops/)中展示。
 
 理解其他钱包、交易所和区块浏览器如何处理可选择 RBF 交易对比特币服务来说是一个重要的考虑因素。为了让交易所或钱包支持 RBF，他们希望知道 RBF 得到了广泛的支持，并且接收钱包或区块浏览器中的用户体验不会混淆。
 
@@ -241,9 +241,9 @@ BRD 在替换交易上显示“失败”标签。在测试中，“失败”交�
 
 
 {% include references.md %}
-[optech team]: /about/
+[optech team]: /en/about/
 [announcement]: /zh/announcing-bitcoin-optech/
-[workshops]: /workshops/
+[workshops]: /en/workshops/
 [newsletters]: /zh/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [dashboard blog post]: /zh/dashboard-announcement/

--- a/_posts/zh/newsletters/2018-09-11-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-11-newsletter.md
@@ -47,7 +47,7 @@ lang: zh
 {% include linkers/issues.md issues="12775,12490,14096,1899" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
-[workshop]: /workshops
+[workshop]: /en/workshops
 [documentation for output script descriptors]: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 [news10 news]: /zh/newsletters/2018/08/28/#新闻
 [decker w3c]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-August/001404.html

--- a/_posts/zh/newsletters/2018-09-18-newsletter.md
+++ b/_posts/zh/newsletters/2018-09-18-newsletter.md
@@ -55,7 +55,7 @@ lang: zh
 {% include linkers/issues.md issues="14054,1843,1516,7965,14168,10973,14180,1860" %}
 
 [bcc 0.17]: https://bitcoincore.org/bin/bitcoin-core-0.17.0/
-[workshop]: /workshops
+[workshop]: /en/workshops
 [news8 news]: /zh/newsletters/2018/08/14/#新闻
 [c-lightning 0.6.1]: https://github.com/ElementsProject/lightning/releases/tag/v0.6.1
 [BIP322 proposal]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-September/016393.html

--- a/_posts/zh/newsletters/2018-12-28-newsletter.md
+++ b/_posts/zh/newsletters/2018-12-28-newsletter.md
@@ -309,7 +309,7 @@ Segwit 支出有两类：
 [optech annual report]: /en/2018-optech-annual-report/
 [optech dashboard]: https://dashboard.bitcoinops.org/
 [optech newsletters]: /en/newsletters/
-[optech workshops]: /workshops/
+[optech workshops]: /en/workshops/
 [p2ep]: https://blockstream.com/2018/08/08/improving-privacy-using-pay-to-endpoint/
 [satoshis.place]: https://satoshis.place/
 [scaling bitcoin conference]: https://tokyo2018.scalingbitcoin.org/

--- a/_posts/zh/newsletters/2019-05-29-newsletter.md
+++ b/_posts/zh/newsletters/2019-05-29-newsletter.md
@@ -171,7 +171,7 @@ endcomment %}
 [ivgi tweet]: https://twitter.com/shesek/status/1131733590235131905
 [updated qr paragraph]: /zh/bech32-sending-support/#qrcode-edit
 [optech twitter]: https://twitter.com/bitcoinoptech
-[optech contributors]: /about/#contributors
+[optech contributors]: /en/about/#contributors
 [special section about the proposal]: #提议的交易输出承诺
 [bech32 series]: /zh/bech32-sending-support/
 [newsletter #32]: /zh/newsletters/2019/02/05/#miniscript

--- a/_posts/zh/newsletters/2023-05-10-newsletter.md
+++ b/_posts/zh/newsletters/2023-05-10-newsletter.md
@@ -153,7 +153,7 @@ Zhiwei "Jeffrey" Hu
 [hnr powswap]: https://raw.githubusercontent.com/blockrate-binaries/paper/master/blockrate-binaries-paper.pdf
 [powswap]: https://powswap.com/
 [news188 phantom]: /en/newsletters/2022/02/23/#ldk-1199
-[founding sponsors]: /about/#founding-sponsors
+[founding sponsors]: /en/about/#founding-sponsors
 [financial supporters]: /#members
 [review club 27501]: https://bitcoincore.reviews/27501
 [prioritisetransaction rpc]: https://developer.bitcoin.org/reference/rpc/prioritisetransaction.html

--- a/_posts/zh/newsletters/2023-11-08-newsletter.md
+++ b/_posts/zh/newsletters/2023-11-08-newsletter.md
@@ -107,7 +107,7 @@ lang: zh
 [bitcoin core 26.0rc2]: https://bitcoincore.org/bin/bitcoin-core-26.0/
 [core lightning 23.11rc1]: https://github.com/ElementsProject/lightning/releases/tag/v23.11rc1
 [lnd 0.17.1-beta.rc1]: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.1-beta.rc1
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [bishop lists]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html
 [delvingbitcoin]: https://delvingbitcoin.org/
 [halseth agg]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004181.html

--- a/_posts/zh/newsletters/2024-07-12-newsletter.md
+++ b/_posts/zh/newsletters/2024-07-12-newsletter.md
@@ -63,7 +63,7 @@ Proposals (BIPs)][bips repo]、[Lightning BOLTs][bolts repo]、[Lightning BLIPs]
 {% include references.md %}
 {% include linkers/issues.md v=2 issues="2949,1487" %}
 [bitcoin core 26.2]: https://bitcoincore.org/bin/bitcoin-core-26.2/
-[sources]: /internal/sources/
+[sources]: /en/internal/sources/
 [interesting transaction]: https://stacker.news/items/600187
 [LND v0.18.2-beta]: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.2-beta
 [news19 bip69]: /zh/newsletters/2018/10/30/#bip69-discussion

--- a/en/about.md
+++ b/en/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About
 permalink: /en/about/
+redirect_from: /about
 ---
 
 The Bitcoin Operations Technology Group (Optech) works to bring the best

--- a/en/about.md
+++ b/en/about.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: About
-permalink: /about/
+permalink: /en/about/
 ---
 
 The Bitcoin Operations Technology Group (Optech) works to bring the best
@@ -16,7 +16,7 @@ and announcements][blog], a [podcast][], and help facilitate improved relations 
 businesses and the open source community.
 
 [scaling book]: https://github.com/bitcoinops/scaling-book
-[workshops]: /workshops
+[workshops]: /en/workshops
 [weekly newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/

--- a/en/internal/sources.md
+++ b/en/internal/sources.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: Sources
-permalink: /internal/sources/
+permalink: /en/internal/sources/
+breadcrumbs: false
 ---
 # Sources for the Optech Newsletter
 

--- a/en/internal/sources.md
+++ b/en/internal/sources.md
@@ -3,6 +3,7 @@ layout: page
 title: Sources
 permalink: /en/internal/sources/
 breadcrumbs: false
+redirect_from: /internal/sources
 ---
 # Sources for the Optech Newsletter
 

--- a/en/workshops.md
+++ b/en/workshops.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Workshops
-permalink: /workshops/
+permalink: /en/workshops/
 ---
 
 Bitcoin Optech will run a series of workshops to bring Bitcoin engineers

--- a/en/workshops.md
+++ b/en/workshops.md
@@ -2,6 +2,7 @@
 layout: page
 title: Workshops
 permalink: /en/workshops/
+redirect_from: /workshops
 ---
 
 Bitcoin Optech will run a series of workshops to bring Bitcoin engineers

--- a/index.md
+++ b/index.md
@@ -20,12 +20,12 @@ and the open source community.
 
 [Learn more about us][about].
 
-[workshops]: /workshops
+[workshops]: /en/workshops
 [weekly newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/
 [blog]: /en/blog/
 [podcast]: /en/podcast/
-[about]: /about
+[about]: /en/about
 [compatibility]: /en/compatibility/
 
 {% assign posts_en = site.posts | where:"lang","en" %}


### PR DESCRIPTION
Part of #1551 

Moves the following pages:

- /about -> /en/about
- /workshops -> /en/workshops
- /internal/sources -> /en/internal/sources

All internal links to those pages are updated (as verified by the first commit passing tests) and redirects are added from the old URLs to the new pages for anyone linking externally (second commit).

This move is good on its own, but it's motivated by my Hugo WIP using multilingual mode which wants all pages in a language hierarchy (e.g. /en/). 