### PR TITLE
Scaling book reference cleanup

### DIFF
--- a/en/about.md
+++ b/en/about.md
@@ -11,12 +11,11 @@ order to lower costs and improve customer experiences.
 
 An initial focus for the group is working with its member organizations to
 reduce transaction sizes and minimize the effect of subsequent transaction fee
-increases.  We provide [workshops][], [documentation][scaling book],
+increases.  We provide [workshops][],
 [weekly newsletters][], [original research][dashboard], [case studies
 and announcements][blog], a [podcast][], and help facilitate improved relations between
 businesses and the open source community.
 
-[scaling book]: https://github.com/bitcoinops/scaling-book
 [workshops]: /en/workshops
 [weekly newsletters]: /en/newsletters/
 [dashboard]: https://dashboard.bitcoinops.org/


### PR DESCRIPTION
I missed references to the original home of the scaling book, https://github.com/bitcoinops/scaling-book, in reviewing https://github.com/bitcoinops/bitcoinops.github.io/pull/1830 (apologies!)

This commit removes the most obvious version of that in about.md but there are 3 more (sans localizations):

- _posts/en/2018-12-28-2018-optech-annual_report.md
- _posts/en/2019-02-11-rbf-in-the-wild.md
- _posts/en/newsletters/2019-12-28-newsletter.md

If we plan to leave the scaling book repo, these references are probably fine to leave. Feedback welcome.