### PR TITLE
Blog: taproot workshop url fixup

### DIFF
--- a/_posts/en/2019-10-29-schnorr-taproot-workshop.md
+++ b/_posts/en/2019-10-29-schnorr-taproot-workshop.md
@@ -1,11 +1,13 @@
 ---
 title: Bitcoin Optech Schnorr Taproot Workshop
-permalink: /en/schorr-taproot-workshop/
+permalink: /en/schnorr-taproot-workshop/
 name: 2019-10-29-schnorr-taproot-workshop
 type: posts
 layout: post
 lang: en
 slug: 2019-10-21-schnorr-taproot-workshop
+redirect_from:
+  - /en/schorr-taproot-workshop/
 
 excerpt: >
   A self-study course for learning about the schnorr/taproot softfork proposal.

--- a/_posts/es/2019-10-29-schnorr-taproot-workshop.md
+++ b/_posts/es/2019-10-29-schnorr-taproot-workshop.md
@@ -1,11 +1,13 @@
 ---
 title: Bitcoin Optech Schnorr Taproot Workshop
-permalink: /es/schorr-taproot-workshop/
+permalink: /es/schnorr-taproot-workshop/
 name: 2019-10-29-schnorr-taproot-workshop-es
 type: posts
 layout: post
 lang: es
 slug: 2019-10-21-schnorr-taproot-workshop-es
+redirect_from:
+  - /es/schorr-taproot-workshop/
 
 excerpt: >
   Un curso de autoaprendizaje para entender más sobre la propuesta de soft-fork schnorr/taproot.

--- a/_posts/ja/2019-10-29-schnorr-taproot-workshop-ja.md
+++ b/_posts/ja/2019-10-29-schnorr-taproot-workshop-ja.md
@@ -1,11 +1,13 @@
 ---
 title: Bitcoin Optech Schnorr Taproot Workshop
-permalink: /ja/schorr-taproot-workshop/
+permalink: /ja/schnorr-taproot-workshop/
 name: 2019-10-29-schnorr-taproot-workshop-ja
 type: posts
 layout: post
 lang: ja
 slug: 2019-10-21-schnorr-taproot-workshop-ja
+redirect_from:
+  - /ja/schorr-taproot-workshop/
 
 excerpt: >
   schnorr / taproot ソフトフォークの提案について学ぶための自習コース。


### PR DESCRIPTION
Historical URL fixup that is easy enough. Seen via https://github.com/bitcoinops/bitcoinops.github.io/pull/1899#pullrequestreview-2315999484

cc: @harding in case these declarations will be problematic for the hugo conversion