### PR TITLE
Podcast: add SuperScalar Deep Dive

### DIFF
--- a/_includes/functions/podcast-bullet.md
+++ b/_includes/functions/podcast-bullet.md
@@ -1,0 +1,7 @@
+<li id="{{ include.podcast_slug | slice: 1, include.podcast_slug.size }}" class="anchor-list">
+        <p>
+          <a href="{{ include.podcast_slug }}" class="anchor-list-link">●</a>
+          {{ include.title }}
+          {% include functions/podcast-note.md slug=include.slug timestamp=include.timestamp reference=include.reference has_transcript_section=include.has_transcript_section %}
+        </p>
+      </li>

--- a/_includes/functions/podcast-note.md
+++ b/_includes/functions/podcast-note.md
@@ -1,9 +1,9 @@
-(<a title="Play this segment of the podcast" onClick="seek('{{reference.timestamp}}')" class="seek">{{reference.timestamp}}</a><noscript>{{reference.timestamp}}</noscript>)
-<a href="{{page.reference}}{{reference.slug}}">
+(<a title="Play this segment of the podcast" onClick="seek('{{include.timestamp}}')" class="seek">{{include.timestamp}}</a><noscript>{{include.timestamp}}</noscript>)
+{% if include.reference %}<a href="{{include.reference}}{{include.slug}}">
     <i class="fa fa-link" title="Link to related content"></i>
-</a>
-{% if reference.has_transcript_section %}
-    <a href="{{reference.slug}}-transcript">
+</a>{% endif %}
+{% if include.has_transcript_section %}
+    <a href="{{include.slug}}-transcript">
         <i class="fa fa-file-text-o" title="Read this segment of the transcription"></i>
     </a>
 {% endif %}

--- a/_includes/newsletter-references.md
+++ b/_includes/newsletter-references.md
@@ -12,20 +12,14 @@
     <!-- Special sections are section that do not have list items, therefore
     we display the timestamp and transcript links in the header -->
       {% assign reference = section.items | first %}
-      <span style="font-size:0.5em">{% include functions/podcast-note.md %}</span>
+      <span style="font-size:0.5em">{% include functions/podcast-note.md slug=reference.slug timestamp=reference.timestamp reference=page.reference has_transcript_section=reference.has_transcript_section %}</span>
     {% endif %}
   </h2>
   {% unless page.special_sections contains section.name %}
     <ul>
       {% for reference in section.items %}
       {% assign podcast_slug = reference.podcast_slug | default: reference.slug %}
-      <li id="{{ podcast_slug | slice: 1, podcast_slug.size }}" class="anchor-list">
-        <p>
-          <a href="{{ podcast_slug }}" class="anchor-list-link">●</a>
-          {{ reference.title }}
-          {% include functions/podcast-note.md %}
-        </p>
-      </li>
+      {% include functions/podcast-bullet.md slug=reference.slug timestamp=reference.timestamp reference=page.reference podcast_slug=podcast_slug title=reference.title has_transcript_section=reference.has_transcript_section %}
       {% endfor %}
     </ul>
   {% endunless %}

--- a/_posts/en/podcast/2024-10-31-deepdive-superscalar.md
+++ b/_posts/en/podcast/2024-10-31-deepdive-superscalar.md
@@ -1,0 +1,38 @@
+---
+title: 'SuperScalar Deep Dive Podcast'
+permalink: /en/podcast/2024/10/31/
+name: 2024-10-31-deepdive-superscalar
+slug: 2024-10-31-deepdive-superscalar
+type: podcast
+layout: podcast-episode
+lang: en
+---
+Dave Harding and Mike Schmidt are joined by ZmnSCPxj to discuss his [SuperScalar
+proposal][superscalar delving].
+
+{% include functions/podcast-links.md %}
+
+{% include functions/podcast-player.md url="https://d3ctxlq1ktw2nl.cloudfront.net/staging/2024-9-31/389033095-44100-2-c3a12b9495a9b.m4a" %}
+
+<br />
+<ul>
+    {% include functions/podcast-bullet.md timestamp="0:40" slug="why" podcast_slug="#why" title="Why a deep dive?" %}
+    {% include functions/podcast-bullet.md timestamp="1:58" slug="overview" podcast_slug="#overview" title="Proposal overview" %}
+    {% include functions/podcast-bullet.md timestamp="4:13" slug="liquidity" podcast_slug="#liquidity" title="Importance of reallocating liquidity" %}
+    {% include functions/podcast-bullet.md timestamp="9:42" slug="overloading" podcast_slug="#overloading" title="What about overloading channels with liquidity from the start?" %}
+    {% include functions/podcast-bullet.md timestamp="13:05" slug="multi-single" podcast_slug="#multi-single" title="Discussion of multi-LSP vs single LSP approaches" %}
+    {% include functions/podcast-bullet.md timestamp="15:22" slug="unilateral" podcast_slug="#unilateral" title="Ensuring unilateral exit is possible" %}
+    {% include functions/podcast-bullet.md timestamp="20:21" slug="malicious" podcast_slug="#malicious" title="Malicious users forcing unilateral closes" %}
+    {% include functions/podcast-bullet.md timestamp="27:11" slug="tunable-penalties" podcast_slug="#tunable-penalties" title="Decker–Wattenhofer channels vs John Law's tunable penalties" %}
+    {% include functions/podcast-bullet.md timestamp="38:44" slug="lock-times" podcast_slug="#lock-times" title="Decker–Wattenhofer relative lock times impact on users" %}
+    {% include functions/podcast-bullet.md timestamp="40:01" slug="trustless" podcast_slug="#trustless" title="Discussion of trustless non-P2P protocol structure" %}
+    {% include functions/podcast-bullet.md timestamp="44:08" slug="ark" podcast_slug="#ark" title="Contrasting SuperScalar with Ark" %}
+    {% include functions/podcast-bullet.md timestamp="48:44" slug="implementation" podcast_slug="#implementation" title="Implementation discussion" %}
+</ul>
+
+## Transcription
+
+_transcription coming soon_
+
+{% include references.md %}
+[superscalar delving]: https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143/


### PR DESCRIPTION
Two commits here

First one is a refactor of the podcast linking includes so I can reuse component in an non-newsletter podcast.

I tried to keep the diff small including spacing, but you can check using the commands: (provided in another PR by @harding)

1. Checkout this branch
2. Build the tip: make clean all (all tests should pass except the fixme)
3. Backup the generated site: cp -a _site _new_site
4. Checkout the merge root, something like git reset --hard HEAD^2
5. Build the site again: make clean build
6. Diff the resultant HTML: diff -ruN _site _new_site | colordiff | less -R

Second adds the SuperScalar podcast. I am using dropbox to host the audio file before publication, so the timestamp seeking might be slow.

Current publication targeting for 10/31.

If there are better ways to jekyll this, open to suggestions. @harding if this ruins hugo compatibility, let me know.