### PR TITLE
lnurl: Fix link to LNURL Documents (LUDs)

### DIFF
--- a/_topics/en/lnurl.md
+++ b/_topics/en/lnurl.md
@@ -19,7 +19,7 @@ topic-categories:
 ## "[title](link)"
 primary_sources:
     - title: "LNURL Documents (LUDs)"
-      link: https://github.com/lnurl/lud
+      link: https://github.com/lnurl/luds
 
 ## Optional.  Each entry requires "title" and "url".  May also use "feature:
 ## true" to bold entry and "date"


### PR DESCRIPTION
Pretty self-explanatory. The "primary code" link on this page is broken. https://bitcoinops.org/en/topics/lnurl/