### PR TITLE
Update topics to reflect taproot activation

### DIFF
--- a/_topics/en/mast.md
+++ b/_topics/en/mast.md
@@ -69,6 +69,9 @@ have been several concrete proposals to add it to Bitcoin:
 - [BIP116][] `OP_MERKLEBRANCHVERIFY` and [BIP117][] tail call execution semantics
 - [bip-taproot][]'s merkle tree
 
+In November 2021, MAST was added to Bitcoin as part of the
+[taproot][topic taproot] soft fork.
+
 {:#naming}
 Note: the abbreviation MAST originally stood for *Merklized Abstract
 Syntax Trees* as [proposed][mast original proposal] by Russell

--- a/_topics/en/schnorr-signatures.md
+++ b/_topics/en/schnorr-signatures.md
@@ -11,8 +11,8 @@ topic-categories:
 excerpt: >
   **Schnorr signatures** are digital signatures that provide similar
   security to the ECDSA scheme used since Bitcoin's original
-  implementation and which can use Bitcoin's same elliptic curve
-  parameters, but which can provide other benefits.
+  implementation, but which provide other benefits. They were
+  added to Bitcoin as part of the taproot soft fork.
 
 ## Optional.  Produces a Markdown link with either "[title][]" or
 ## "[title](link)"
@@ -134,8 +134,8 @@ see_also:
 Schnorr is secure under the same cryptographic assumptions as
 [ECDSA][] and it is easier and faster to create secure multiparty
 signatures using schnorr with protocols such as [MuSig][topic musig].  A new
-signature type also provides an opportunity to change the signature
-serialization format from [BER/DER][] to something that's more compact
+signature type also provided an opportunity to change the signature
+serialization format from [BER/DER][] to one that is more compact
 and simpler to implement.
 
 {% include references.md %}

--- a/_topics/en/taproot.md
+++ b/_topics/en/taproot.md
@@ -10,7 +10,7 @@ topic-categories:
 
 ## Required.  Use Markdown formatting.  Only one paragraph.  No links allowed.
 excerpt: >
-  **Taproot** is a proposed soft fork change to Bitcoin that will allow
+  **Taproot** is an activated soft fork change to Bitcoin that allows
   payments to schnorr public keys that may optionally commit to a script
   that can be revealed at spend time.
 
@@ -264,9 +264,9 @@ see_also:
 ---
 Coins protected by taproot may be spent either by satisfying one of
 the committed scripts or by simply providing a signature that verifies
-against the public key (allowing the script to be kept private).
-Taproot is intended for use with schnorr signatures that simplify
-multiparty construction (e.g. using [MuSig][topic musig]) and with MAST to
+against the public key (allowing the scripts to be kept private).
+Taproot uses schnorr signatures that simplify multiparty construction
+(e.g. using [MuSig][topic musig]) and [MAST][topic mast] to
 allow committing to more than one script, any one of which may be
 used at spend time.
 

--- a/_topics/en/threshold-signature.md
+++ b/_topics/en/threshold-signature.md
@@ -103,7 +103,7 @@ resistance to communication problems.
 
 ### Comparison to multisig scripts
 
-Bitcoin's Script language (including the proposed [tapscript][topic
+Bitcoin's Script language (including the [tapscript][topic
 tapscript] modified alternative) allows providing a threshold *k* of
 signatures for a group of *n* keys, commonly called k-of-n multisig.
 This requires providing *k* signatures and *n* public keys in any


### PR DESCRIPTION
This hopefully removes all remaining mentions of taproot, schnorr signatures and MAST that describe them as _proposed_ additions to Bitcoin.

Better late than never.