### PR TITLE
Update html-proofer gem for better performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
 end
 
 group :testing do
-  gem 'html-proofer'
+  gem 'html-proofer', "~> 3.0"
   gem 'mdl'
   gem 'json-schema'
   gem 'toml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,11 +13,11 @@ GEM
     eventmachine (1.2.7)
     ffi (1.11.3)
     forwardable-extended (2.6.0)
-    html-proofer (3.15.0)
+    html-proofer (3.19.4)
       addressable (~> 2.3)
       mercenary (~> 0.3)
-      nokogumbo (~> 2.0)
-      parallel (~> 1.3)
+      nokogiri (~> 1.13)
+      parallel (~> 1.10)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
@@ -59,7 +59,7 @@ GEM
       mixlib-cli (~> 2.1, >= 2.1.1)
       mixlib-config (~> 2.2, >= 2.2.1)
     mercenary (0.3.6)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.8.8)
     minima (2.5.0)
       jekyll (~> 3.5)
       jekyll-feed (~> 0.9)
@@ -67,16 +67,16 @@ GEM
     mixlib-cli (2.1.1)
     mixlib-config (2.2.18)
       tomlrb
-    nokogiri (1.10.7)
-      mini_portile2 (~> 2.4.0)
-    nokogumbo (2.0.2)
-      nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.19.1)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    parallel (1.24.0)
     parslet (1.8.2)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.1)
-    rainbow (3.0.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -90,15 +90,15 @@ GEM
     toml (0.2.0)
       parslet (~> 1.8.0)
     tomlrb (1.2.9)
-    typhoeus (1.3.1)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
-    yell (2.2.0)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer
+  html-proofer (~> 3.0)
   jekyll
   jekyll-redirect-from
   json-schema


### PR DESCRIPTION
The following command to check for broken links:

```
bundle exec htmlproofer --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site
```

Currently (version 3.15.0) takes 271.221 seconds in my local environment. 
If upgrade to 3.19.4, it will take 128.295 seconds, which is about half the time.

One of the factors that contributed to the performance improvement is https://github.com/gjtorikian/html-proofer/pull/590, and the rest is likely due to external dependent libraries.

Upgrading html-proofer to 4.0 or later will break the current build, so I'm sticking to the 3.0 series.