### PR TITLE
Fix broken link to Consensus Cleanup BIP draft

### DIFF
--- a/_topics/en/consensus-cleanup-soft-fork.md
+++ b/_topics/en/consensus-cleanup-soft-fork.md
@@ -19,7 +19,7 @@ excerpt: >
 ## "[title](link)"
 primary_sources:
     - title: Draft BIP for Consensus Cleanup
-      link: https://github.com/darosior/bips/blob/consensus_cleanup/bip-cc.md
+      link: https://github.com/darosior/bips/blob/consensus_cleanup/bip-0054.md
 
 ## Optional.  Each entry requires "title", "url", and "date".  May also use "feature:
 ## true" to bold entry


### PR DESCRIPTION
This implements the fix for the broken link in the Consensus Cleanup topic proposed by @tartly8 in #2283.