### PR TITLE
matrix: Record Nunchuk’s MuSig2 support

### DIFF
--- a/_data/matrix/Nunchuk.yaml
+++ b/_data/matrix/Nunchuk.yaml
@@ -21,7 +21,7 @@ feature:
   psbt_version: "V0"
   psbt_export: "Yes"
   psbt_update_finalize: "Yes"
-  musig2: "No Support"
+  musig2: "Yes"
   coinjoin: "No Support"
   payjoin_BIP78: "No Support"
   payjoin_alternate: "No Support"


### PR DESCRIPTION
Source: https://bitcoinops.org/en/newsletters/2025/01/24/#nunchuk-adds-taproot-musig2-features