### PR TITLE
Fix link to Feature Matrix contributions

### DIFF
--- a/en/matrix.md
+++ b/en/matrix.md
@@ -384,7 +384,7 @@ th, td {
 
 <br/>
 _Contributions and corrections are welcome. Please see the [contibuting
-guidelines](https://github.com/bitcoinops/bitcoinops.github.io/blob/master/CONTRIBUTING.md#compatibility-matrix-data)
+guidelines](https://github.com/bitcoinops/bitcoinops.github.io/blob/master/CONTRIBUTING.md#bitcoin-feature-matrix-data)
 for details._
 {: style="text-align: center;"}
 


### PR DESCRIPTION
Sorry, [I linked to the old section name](a9a9771ad0e7182816ab164ab6cb1b685f87d269) on the compatibility page and overlooked that the matrix pull request changed the title of the corresponding section.