### PR TITLE
Improve workshop page UX by separating current status from history

### DIFF
--- a/en/workshop-history.md
+++ b/en/workshop-history.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: Workshop History
+permalink: /en/workshop-history/
+---
+
+# Bitcoin Optech Workshop History
+
+[← Back to Workshops](/en/workshops/)
+
+## Workshops #3, #4 and #5 - Schnorr and Taproot Seminars {#taproot-workshop}
+
+- San Francisco, September 24 2019
+- New York, September 27 2019
+- London, February 5 2020
+
+*Schnorr signatures* and *Taproot* are proposed changes to the Bitcoin
+protocol that promise greatly improved privacy, fungibility, scalability and
+functionality.
+
+Bitcoin Optech hosted two seminar format workshops which included a mixture of
+presentations, coding exercises and discussions, and gave engineers at
+member companies an understanding of how these new technologies work and how
+they can be applied to their products and services. The workshops also provided
+engineers an opportunity to take part in the feedback process while these
+technologies are still in the proposal stage.
+
+[All material from the workshops][taproot workshop blog post] is available on this website, so engineers can
+learn about the schnorr/taproot proposals at home.
+
+## Workshop #2 - Paris, November 12-13 2018
+
+Bitcoin Optech held our second roundtable workshop in Paris on November 12-13 2018.
+The format was the same as the first workshop in San Francisco.
+
+In attendance were 24 engineers from Bitcoin companies and open source
+projects.
+
+#### Topics
+
+- Replace-by-fee vs. child-pays-for-parent as fee replacement techniques
+- Partially Signed Bitcoin Transactions ([BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki))
+- [Output script descriptors](https://gist.github.com/sipa/e3d23d498c430bb601c5bca83523fa82) for wallet interoperability
+- Lightning wallet integration and applications for exchanges
+- Approaches to coin selection & consolidation
+
+#### Thanks
+
+Thanks to Ledger for hosting the workshop and helping with organization.
+
+## Workshop #1 - San Francisco, July 17 2018
+
+Bitcoin Optech held our first roundtable workshop in San Francisco on July 17 2018:
+
+- Topics were discussed in a roundtable format in which every participant had an
+  equal opportunity to engage.
+
+- Each topic had a moderator and notetaker. The moderator was responsible for a
+  brief introduction of a topic and keeping discussion on track and on time.
+
+- To make sure that participants were comfortable to speak freely, notes and
+  action items were distributed to participants but not beyond. Participants
+  were free to share discussion details internally at their companies and
+  publicly, but did not attribute any particular statement to a given individual
+  (Chatham House Rules).
+
+In attendance were 14 engineers from SF Bay Area Bitcoin companies and open
+source projects.
+
+#### Topics
+
+- Coin selection
+- Fee estimation, RBF, CPFP best practices
+- Optech community and communication
+
+#### Thanks
+
+Thanks to Square for hosting the workshop and Coinbase for helping with
+organization.
+
+{% include references.md %}
+
+[taproot workshop blog post]: /en/schorr-taproot-workshop/

--- a/en/workshops.md
+++ b/en/workshops.md
@@ -13,76 +13,10 @@ and the specific scaling challenges that they are facing.
 If you have any requests or suggestions for future workshop events, please
 [contact us][optech email].
 
-## Workshops #3, #4 and #5 - Schnorr and Taproot Seminars {#taproot-workshop}
+## Current Status
 
-- San Francisco, September 24 2019
-- New York, September 27 2019
-- London, February 5 2020
+**Currently, no workshops are scheduled.** We are evaluating potential future workshop topics and formats based on community feedback and technical developments in the Bitcoin ecosystem.
 
-*Schnorr signatures* and *Taproot* are proposed changes to the Bitcoin
-protocol that promise greatly improved privacy, fungibility, scalability and
-functionality.
-
-Bitcoin Optech hosted two seminar format workshops which included a mixture of
-presentations, coding exercises and discussions, and gave engineers at
-member companies an understanding of how these new technologies work and how
-they can be applied to their products and services. The workshops also provided
-engineers an opportunity to take part in the feedback process while these
-technologies are still in the proposal stage.
-
-[All material from the workshops][taproot workshop blog post] is available on this website, so engineers can
-learn about the schnorr/taproot proposals at home.
-
-## Workshop #2 - Paris, November 12-13 2018
-
-Bitcoin Optech held our second roundtable workshop in Paris on November 12-13 2018.
-The format was the same as the first workshop in San Francisco.
-
-In attendance were 24 engineers from Bitcoin companies and open source
-projects.
-
-#### Topics
-
-- Replace-by-fee vs. child-pays-for-parent as fee replacement techniques
-- Partially Signed Bitcoin Transactions ([BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki))
-- [Output script descriptors](https://gist.github.com/sipa/e3d23d498c430bb601c5bca83523fa82) for wallet interoperability
-- Lightning wallet integration and applications for exchanges
-- Approaches to coin selection & consolidation
-
-#### Thanks
-
-Thanks to Ledger for hosting the workshop and helping with organization.
-
-## Workshop #1 - San Francisco, July 17 2018
-
-Bitcoin Optech held our first roundtable workshop in San Francisco on July 17 2018:
-
-- Topics were discussed in a roundtable format in which every participant had an
-  equal opportunity to engage.
-
-- Each topic had a moderator and notetaker. The moderator was responsible for a
-  brief introduction of a topic and keeping discussion on track and on time.
-
-- To make sure that participants were comfortable to speak freely, notes and
-  action items were distributed to participants but not beyond. Participants
-  were free to share discussion details internally at their companies and
-  publicly, but did not attribute any particular statement to a given individual
-  (Chatham House Rules).
-
-In attendance were 14 engineers from SF Bay Area Bitcoin companies and open
-source projects.
-
-#### Topics
-
-- Coin selection
-- Fee estimation, RBF, CPFP best practices
-- Optech community and communication
-
-#### Thanks
-
-Thanks to Square for hosting the workshop and Coinbase for helping with
-organization.
+[📚 View Workshop History](/en/workshop-history/)
 
 {% include references.md %}
-
-[taproot workshop blog post]: /en/schorr-taproot-workshop/


### PR DESCRIPTION
- Update main workshops page to prominently display current status
- Move historical workshop information (2018-2020) to separate page
- Improve user perception by highlighting that site is actively maintained
- Preserve all historical workshop content in dedicated history page