### PR TITLE
Fix redirects on multiple pages

### DIFF
--- a/zh/about.md
+++ b/zh/about.md
@@ -2,7 +2,6 @@
 layout: page
 title: About
 permalink: /zh/about/
-redirect_from: /about
 ---
 
 Bitcoin Operations Technology Group（简称 Optech）致力于将最好的开源技术和技术手段引入使用比特币的企业，以降低成本并改善客户体验。

--- a/zh/workshops.md
+++ b/zh/workshops.md
@@ -2,7 +2,6 @@
 layout: page
 title: Workshops
 permalink: /zh/workshops/
-redirect_from: /workshops
 ---
 比特币 Optech 将举办一系列研讨会，将比特币工程师聚集在一起，讨论实施扩容技术的方式和挑战。每个研讨会都会根据参与的会员公司及其面临的具体扩容挑战进行定制。
 


### PR DESCRIPTION
I noticed via #2357 that the Chinese translation introduced redirects for top level pages to the Chinese translation that overwrite the English redirects, so I’m proposing to remove them, since the English version is the main site.

While looking these changes over, I also noticed a typo that propagated through several translations and added a redirect for the new matrix page.