### PR TITLE
Update _config.yml (Add support for Indonesian language (id))

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,5 +94,8 @@ languages:
     name: French
   - code: pt
     name: Portuguese
+  - code: id
+    name: Indonesia
+
 ## In-text aliases
 trb: "709,632" # TapRoot Block (activation)


### PR DESCRIPTION
This PR adds support for the Indonesian language (ISO code: id) to the Bitcoin Optech website.

- Updates the `_config.yml` file to include 'id' in the languages list.
- This change allows contributors to submit translations for newsletters and blog posts in Indonesian.
- The addition of 'id' follows the same format used by other languages (en, fr, es, etc.).
- No other content is modified in this PR.

Once this PR is merged, contributors can create translated files under:
  - _posts/id/newsletters/  (for newsletters)
  - _posts/id/             (for blog posts)

This is the first step to enable Indonesian translations on the site.