### PR TITLE
Fix tapret description and update RGB references to v0.11.1

### DIFF
--- a/_topics/en/client-side-validation.md
+++ b/_topics/en/client-side-validation.md
@@ -26,6 +26,9 @@ primary_sources:
   - title: "RGB I.0: Scalable Consensus for Client-Side Validated Smart Contracts"
     link: https://yellowpaper.rgb.tech/
 
+  - title: "RGB v0.11.1 technical documentation"
+    link: https://docs.rgb.info/commitment-layer/deterministic-bitcoin-commitments-dbc/tapret
+
 ## Optional.  Each entry requires "title" and "url".  May also use "feature:
 ## true" to bold entry and "date"
 optech_mentions:
@@ -97,9 +100,10 @@ created by Alice is correctly formatted to assign the token to a UTXO
 that Bob controls.
 
 **[RGB][]** is a client-side validation protocol for working with arbitrary
-reachable state and Turing-complete state evolution rules. It uses
-taproot-embedded OP_RETURN commitments (named **tapret**) to allow
-transactions to commit to smart contract state.
+reachable state and Turing-complete state evolution rules. It supports
+two commitment schemes: **tapret**, which embeds the commitment as an
+unspendable script leaf in taproot's script tree, and **opret**, which
+embeds the commitment in a standalone on-chain OP_RETURN output.
 
 **[Taproot Assets][]**, formerly called **Taro**, is a protocol heavily
 inspired by RGB that uses [taproot][topic taproot]'s commitment
@@ -126,5 +130,6 @@ with RGB and Taproot Assets look like regular Bitcoin transactions.
 
 {% include references.md %}
 {% include linkers/issues.md issues="" %}
-[rgb]: https://rgb.tech/
+[rgb]: https://rgb.info/
+[docs.rgb.info]: https://docs.rgb.info/
 [taproot assets]: https://docs.lightning.engineering/the-lightning-network/taproot-assets/


### PR DESCRIPTION
Hello, this is MariJ from the RGB Protocol Association.
I am sending this PR because I found a technical ambiguity in the text. Since you are keeping a valuable resource for the Bitcoin community, I thought it was important to contribute.

The current text says RGB "uses taproot-embedded OP_RETURN commitments (named tapret)" --> It is incorrect: tapret embeds commitments as **unspendable leaves in taproot's script tree**.

To explain better, it's basically an OP_RETURN type **script** inside the taproot leaf, only used to tell the software that the leaf does not contain satoshis to be spent.
The second scheme is indeed OP_RETURN and it is a separate scheme named opret. 
I hope it can clarify the information.
Source: https://docs.rgb.info/commitment-layer/deterministic-bitcoin-commitments-dbc/tapret

Because of the correction, I added docs.rgb.info as a primary source for the v0.11.1 commitment scheme documentation.

Since I was at it, I also updated the references to include the now official version which is the v0.11.1:
- **RGB v0.11.1** launched on Bitcoin mainnet in July 2025 and is the current production-ready implementation (rgb.info, github.com/rgb-protocol)
- To give you some proof, consider that [Tether announced USDT issuance on RGB **v0.11.1**](https://tether.io/news/tether-to-launch-usdt-on-rgb-expanding-native-bitcoin-stablecoin-support/)
- I also updated the [rgb] link from rgb.tech to rgb.info, since the latter is the production-ready implementation's website.

- RGB v0.12 is an "**unfinished proposal to rewrite the protocol**, promoted by the owner of the RGB-WG organization" (source: https://docs.rgb.info/) --> it is not the implementation supported by the RGB Protocol Association.

Kindly update at least the description of taptree. People see you as an authoritative source, so it's important to give precise information. I'm available for any question, if needed :)

Thanks for your attention. 

MariJ
RGB Protocol Association
  

