### PR TITLE
Remove wrong documentation

### DIFF
--- a/_topics/en/client-side-validation.md
+++ b/_topics/en/client-side-validation.md
@@ -23,9 +23,6 @@ primary_sources:
   - title: "Shielded CSV: Private and Efficient Client-Side Validation"
     link: https://github.com/ShieldedCSV/ShieldedCSV/releases/latest/download/shieldedcsv.pdf
 
-  - title: "RGB I.0: Scalable Consensus for Client-Side Validated Smart Contracts"
-    link: https://yellowpaper.rgb.tech/
-
   - title: "RGB v0.11.1 technical documentation"
     link: https://docs.rgb.info/commitment-layer/deterministic-bitcoin-commitments-dbc/tapret
 


### PR DESCRIPTION
Hello @murchandamus, I'm Marij from RGB Protocol Association. I previously sent a [PR](https://github.com/bitcoinops/bitcoinops.github.io/pull/2739) to fix the errors in the file dedicated to client-side validation. 

Here, I'm fixing another error. 
I realized that the paper cited in the article is not valid and was [not supported](https://github.com/rgb-protocol/.github/blob/master/WHY_v0.11.1.md) by the developer in the RGB-Protocol, now actively developing on v0.11.1. 
Please allow me to remove it, so we don't confuse both our users regarding the right sources, which are rgb.info and docs.rgb.info.

Thanks for your patience and understanding.
MariJ