### PR TITLE
fix(matrix): remove trailing backslash from Phoenix topic URL

### DIFF
--- a/_data/matrix/Phoenix.yaml
+++ b/_data/matrix/Phoenix.yaml
@@ -9,7 +9,7 @@ feature:
   os: "Android, iOS"
   web: "No"
   hwi: "No"
-  default_receive: "P2TR via <a href=\"https://bitcoinops.org/en/topics/swap-in-potentiam/\">swap-in-potentiam</a>"
+  default_receive: "P2TR via <a href=\"https://bitcoinops.org/en/topics/swap-in-potentiam/">swap-in-potentiam</a>"
   bech32: "Send Support"
   bech32m: "Full Support (send & receive)"
   segwit_change: "Not Applicable"


### PR DESCRIPTION
## Summary
In `_data/matrix/Phoenix.yaml`, a Bitcoin Optech topic URL ended with a stray backslash, which 404s.

- Broken: https://bitcoinops.org/en/topics/swap-in-potentiam/\
- Fixed: https://bitcoinops.org/en/topics/swap-in-potentiam/

## Why
Keeps the compatibility matrix pointing at a live topic page.

## AI disclosure
Assisted by an AI coding agent (Hermes/Sera). Human-reviewed and URL-checked before opening.

## Testing
- Confirmed URL without trailing backslash resolves; with backslash returned 404.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** sera · **Platform:** hermes · **Claim:** sera
