### PR TITLE
News346: correct waitNext() fee_threshold / MAX_MONEY description

### DIFF
--- a/_posts/en/newsletters/2025-03-21-newsletter.md
+++ b/_posts/en/newsletters/2025-03-21-newsletter.md
@@ -153,11 +153,14 @@ repo], and [BINANAs][binana repo]._
   centralized element. {% assign timestamp="1:03:19" %}
 
 - [Bitcoin Core #31283][] introduces a new `waitNext()` method to the
-  `BlockTemplate` interface, which will only return a new template if the chain
-  tip changes or the mempool fees increase above the `MAX_MONEY` threshold.
-  Previously, miners would receive a new template with every request, resulting
-  in unnecessary template generation. This change aligns with the [Stratum
-  V2][topic pooled mining] protocol specification. {% assign timestamp="37:27" %}
+  `BlockTemplate` interface, which returns a new template only when the chain
+  tip changes or when total fees in a freshly assembled template rise by at
+  least a caller-specified `fee_threshold`. The default `fee_threshold` is
+  `MAX_MONEY`, which skips the expensive fee comparison and effectively waits
+  only for a tip change (or timeout). Previously, miners would receive a new
+  template with every request, resulting in unnecessary template generation.
+  This change aligns with the [Stratum V2][topic pooled mining] protocol
+  specification. {% assign timestamp="37:27" %}
 
 - [Eclair #3037][] enhances the `listoffers` command (See Newsletter
   [#345][news345 offers]) to return all relevant [offer][topic offers] data,

--- a/_posts/en/newsletters/2025-03-21-newsletter.md
+++ b/_posts/en/newsletters/2025-03-21-newsletter.md
@@ -155,9 +155,9 @@ repo], and [BINANAs][binana repo]._
 - [Bitcoin Core #31283][] introduces a new `waitNext()` method to the
   `BlockTemplate` interface, which returns a new template only when the chain
   tip changes or when total fees in a freshly assembled template rise by at
-  least a caller-specified `fee_threshold`. The default `fee_threshold` is
-  `MAX_MONEY`, which skips the expensive fee comparison and effectively waits
-  only for a tip change (or timeout). Previously, miners would receive a new
+  least a caller-specified `fee_threshold`. If no `fee_threshold` is supplied,
+  the expensive fee comparison is skipped and a new template is generated
+  only after a tip change. Previously, miners would receive a new
   template with every request, resulting in unnecessary template generation.
   This change aligns with the [Stratum V2][topic pooled mining] protocol
   specification. {% assign timestamp="37:27" %}


### PR DESCRIPTION
News #346 said waitNext() returns when mempool fees rise "above MAX_MONEY". That is wrong: fee_threshold defaults to MAX_MONEY and that default skips the fee check so the wait is tip-change (or timeout) only. Callers who want fee-triggered updates set a lower threshold.

Closes #2591.

English only; translations of #346 can follow.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
