### PR TITLE
docs: fix empty repo link and typo in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,14 @@ standardized:
 - Using a commit message similar to `news70: add Japanese translation` helps
   keep translations easily visible in the commit log
 - Testing your translation
-  - Follow the instuctions in the [README.md](https://github.com/bitcoinops/bitcoinops.github.io/blob/master/README.md)
+  - Follow the instructions in the [README.md](https://github.com/bitcoinops/bitcoinops.github.io/blob/master/README.md)
     - `make preview` to view the local website and review
     - `make production` to run additional checks (link checking, linting, etc)
   - For the page you have translated, ensure that the language code link shows
     up on the `en` language variant
   - Check that the page renders properly
 - Create a pull request to the
-  [https://github.com/bitcoinops/bitcoinops.github.io]() repository
+  [https://github.com/bitcoinops/bitcoinops.github.io](https://github.com/bitcoinops/bitcoinops.github.io) repository
   - One newsletter per PR allows for easier review
   - Allowing edits from maintainers permits maintainers to make additional
     commits to your PR branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ standardized:
     up on the `en` language variant
   - Check that the page renders properly
 - Create a pull request to the
-  [https://github.com/bitcoinops/bitcoinops.github.io](https://github.com/bitcoinops/bitcoinops.github.io) repository
+  [bitcoinops/bitcoinops.github.io](https://github.com/bitcoinops/bitcoinops.github.io) repository
   - One newsletter per PR allows for easier review
   - Allowing edits from maintainers permits maintainers to make additional
     commits to your PR branch


### PR DESCRIPTION
## Summary

- Fix the empty markdown link target for the Optech GitHub repo under Translations in `CONTRIBUTING.md`.
- Correct the nearby typo: `instuctions` → `instructions`.

## Motivation

Line 72 of `CONTRIBUTING.md` told translators to open PRs against:

```markdown
[https://github.com/bitcoinops/bitcoinops.github.io]() repository
```

The visible text was the repo URL, but the markdown destination was empty, so the link was non-functional for anyone following the guide. While in the same bullet list, fixed the spelling of "instructions" on the README pointer.

## Verification

- Grepped the tree for other empty `]()` markdown links — this was the only hit outside generated sites.
- Manually confirmed the target URL resolves: `https://github.com/bitcoinops/bitcoinops.github.io`
- Diff limited to 2 lines in `CONTRIBUTING.md`; no newsletter, matrix, or site layout changes.

## Notes

- Orthogonal to open #2823 (News346 wording) and does not touch translated newsletters.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h

