### PR TITLE
docs: fix 'commiting' typo in taproot signature-adaptors special

### DIFF
--- a/_includes/specials/taproot/en/08-signature-adaptors.md
+++ b/_includes/specials/taproot/en/08-signature-adaptors.md
@@ -71,7 +71,7 @@ of the hidden number.  Alice can just as easily create an invalid
 signature by not committing to the scalar she doesn't know but still
 committing to the EC point she does know.  She does this by creating her
 own nonce pair, using the private form when creating her (invalid)
-signature but commiting to the aggregation of the public form of her
+signature but committing to the aggregation of the public form of her
 nonce and the EC point from the donor's signature adaptor.
 This produces a
 signature adaptor for a transaction that pays Bob.  If Bob learns the


### PR DESCRIPTION
## Summary

- Fix a spelling typo in the English Preparing for Taproot special on signature adaptors: `commiting` → `committing`.
- No content or technical-meaning change — spelling only.

## Motivation

In `_includes/specials/taproot/en/08-signature-adaptors.md`, the sentence describing how Alice builds an adaptor currently says "commiting to the aggregation…". Adjacent sentences already use the correct "committing", so this is a straightforward orthography fix that keeps the article consistent for readers.

## Verification

- Grep: only this one `commiting` occurrence sitewide in markdown source.
- Diff is a single character addition (`t`) on one line in the EN special; JA/ZH copies of the series are unaffected (different wording).
- Did not change: technical explanation of adaptor construction, other specials, or newsletters.


---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
