### PR TITLE
docs: fix 'transfered' typo in payment probes topic

### DIFF
--- a/_topics/en/payment-probes.md
+++ b/_topics/en/payment-probes.md
@@ -91,7 +91,7 @@ excerpt: >
   currently handle a payment of a certain size or how many bitcoins are
   allocated to each participant in the channel.  Probes use the regular
   payment (HTLC) mechanism but are designed to always fail, preventing
-  any funds from being transfered.  Probing can be useful, but it can
+  any funds from being transferred.  Probing can be useful, but it can
   also reduce user privacy.
 
 ---


### PR DESCRIPTION
## Summary

- Fix spelling in the payment probes topic excerpt: `transfered` → `transferred`.

## Motivation

The topic excerpt is one-paragraph site copy (and topics index blurbs). `transfered` is a misspelling in both American and British English; the standard form is `transferred`.

## Verification

- Sitewide source search: single `transfered` hit was this line in `_topics/en/payment-probes.md`.
- Diff is +1/−1 on that file only; wording otherwise unchanged.
- No open/closed duplicate PRs found for this string on bitcoinops/bitcoinops.github.io.

## Notes

- Path-orthogonal to open #2823 / #2828 (newsletter EN files).
- Left nearby older copy like `targetted` on the 2019 exec briefing for a separate change if wanted.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 48h
