### PR TITLE
docs: fix double-slash URL in responsible disclosures topic

### DIFF
--- a/_topics/en/responsible-disclosures.md
+++ b/_topics/en/responsible-disclosures.md
@@ -183,7 +183,7 @@ optech_mentions:
     date: 2025-04-24
 
   - title: "Antoine Poinsot responsibly disclosed a CPU-wasting DoS vulnerability in Bitcoin Core"
-    url: /en/newsletters/2025/10/31//#cpu-dos-from-unconfirmed-transaction-processing
+    url: /en/newsletters/2025/10/31/#cpu-dos-from-unconfirmed-transaction-processing
     date: 2025-04-25
 
   - title: "Cory Fields responsibly disclosed a script interpreter remote crash vulnerability in Bitcoin Core"


### PR DESCRIPTION
## Summary

- Fix a double-slash path typo in the responsible disclosures topic link to Newsletter #378.
- Restores a direct deep link to the Antoine Poinsot CPU-DoS disclosure bullet.

## Motivation

In `_topics/en/responsible-disclosures.md`, the Poinsot CPU-DoS mention pointed at:

`/en/newsletters/2025/10/31//#cpu-dos-from-unconfirmed-transaction-processing`

Sibling entries in the same file correctly use a single slash before the fragment. On the live site, Netlify answers the double-slash path with a `301` to `/en/newsletters/2025/10/31/`, so clients can lose the intended `#cpu-dos-from-unconfirmed-transaction-processing` jump. The destination anchor exists on Newsletter #378.

This is pure link hygiene (path shape), not a content rewrite.

## Verification

- Compared against neighboring disclosures in the same topic file for 2025-10-31 (all other URLs use a single trailing slash before `#...`).
- Repo scan: this was the only `_topics/**` hit for a newsletter date path with `//#`.
- Live checks:
  - `https://bitcoinops.org/en/newsletters/2025/10/31//...` → Netlify `301` → `/en/newsletters/2025/10/31/`
  - Correct URL returns `200` and the page contains `id="cpu-dos-from-unconfirmed-transaction-processing"`
  - Published topic page currently emits the broken `//#` href
- Diff is +1/−1 on one English topic file; no newsletter, translation, matrix, or layout changes.
- Orthogonal to open EN newsletter factual PRs #2823 and #2828.

## Notes

- No open/closed duplicate PRs found for this path.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
