### PR TITLE
docs: fix double-slash URL in ZH newsletter #39

### DIFF
--- a/_posts/zh/newsletters/2019-03-26-newsletter.md
+++ b/_posts/zh/newsletters/2019-03-26-newsletter.md
@@ -75,4 +75,4 @@ lang: zh
 [taproot]: https://gnusha.org/url/https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-January/015614.html
 [v2 transport]: https://gnusha.org/url/https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-March/016806.html
 [bech32 series]: /zh/bech32-sending-support/
-[newsletter #10]: /zh/newsletters/2018/08/28//#pr-opened-for-initial-bip151-support
+[newsletter #10]: /zh/newsletters/2018/08/28/#pr-opened-for-initial-bip151-support


### PR DESCRIPTION
ZH Newsletter #39 linked Newsletter #10 with a double slash before the fragment (`/zh/newsletters/2018/08/28//#pr-opened-for-initial-bip151-support`). The EN sibling already uses a single slash. Netlify 301-strips `//` and can drop the deep-link; destination anchor verified on the live ZH #10 page.


---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
