### PR TITLE
docs: fix double-slash FR blog URL in newsletter #282

### DIFF
--- a/_posts/fr/newsletters/2023-12-20-newsletter.md
+++ b/_posts/fr/newsletters/2023-12-20-newsletter.md
@@ -787,7 +787,7 @@ mercredi 3 janvier.*
 [oct pss]: /fr/newsletters/2023/10/04/#division-et-commutation-des-paiements
 [oct sidepool]: /fr/newsletters/2023/10/04/#liquidite-mutualisee-pour-ln
 [oct txhash]: /fr/newsletters/2023/10/11/#specification-pour-op-txhash-proposee
-[policy series]: /fr/blog//waiting-for-confirmation/
+[policy series]: /fr/blog/waiting-for-confirmation/
 [sep lnscale]: /fr/newsletters/2023/09/27/#utilisation-de-covenants-pour-ameliorer-la-scalabilite-de-ln
 [sep secp]: /fr/newsletters/2023/09/06/#libsecp256k1-0-4-0
 [sept compress]: /fr/newsletters/2023/09/06/#compression-des-transactions-bitcoin


### PR DESCRIPTION
FR year-in-review (#282) linked the mempool policy series as `/fr/blog//waiting-for-confirmation/`. Drop the extra slash so it matches the live FR permalink and the EN sibling. Destination returns 200; the double-slash form is a Netlify 301.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
