### PR TITLE
topics: replace hijacked coinjoins.org link on the coinjoin page

### DIFF
--- a/_topics/en/coinjoin.md
+++ b/_topics/en/coinjoin.md
@@ -102,8 +102,8 @@ see_also:
     link: https://en.bitcoin.it/Privacy#CoinJoin
   - title: "Privacy Wiki"
     link: https://en.bitcoin.it/wiki/Privacy
-  - title: "Coinjoins.org - Learn about collaborative bitcoin transactions"
-    link: https://coinjoins.org/
+  - title: "CoinJoin (LearnBitcoin glossary)"
+    link: https://www.learnbitcoin.com/glossary/coinjoin
 
 ---
 


### PR DESCRIPTION
`coinjoins.org`, linked from the coinjoin topic's `see_also`, now serves a "No Verification Crypto Casinos USA" page with sponsored casino links (the source repo CoinjoinsOrg/coinjoins last pushed 2024-04-28, so the domain appears to have lapsed and been picked up). This removes it.

As a replacement I have put in LearnBitcoin's CoinJoin entry, which covers the mechanism, its limits (visible participation, toxic change), the 2024 coordinator shutdowns, and what survived (JoinMarket, Joinstr). Disclosure: I run LearnBitcoin. It is CC-BY-SA, no ads, no affiliates, sources on every page. If you would rather just drop the dead link without a replacement, say so and I will amend.
