### PR TITLE
docs: add Gustavo Flores Echaiz to contributors list

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -30,6 +30,11 @@ contributors:
     quote: >-
       "In an ever-changing world, the Bitcoin revolution represents a pivotal movement combining financial and social shifts. Recognizing the need to understand this, I've translated bitcoinops.org newsletters into French to democratize access to key developments. My aim is to enable broader participation in shaping the future. Proud to join esteemed contributors, I echo Antoine de Saint-Exupéry's sentiment: 'As for the future, it's not about predicting it, but making it possible.'"
   -
+    name: Gustavo Flores Echaiz
+    github: gustavojfe
+    avatar: https://avatars.githubusercontent.com/u/106698848?v=4
+    other_affiliation: Product Manager, <a href="https://veriphi.io/">Veriphi</a>
+  -
     name: Jiří Jakeš
     github: jirijakes
     avatar: jirijakes.jpg


### PR DESCRIPTION
Gustavo Flores Echaiz (github: gustavojfe) is missing from the Optech contributors list on the about page. Add his bio with name, GitHub link, avatar, and Veriphi affiliation.

Closes #2633.