### PR TITLE
docs: fix 14 batched spelling errors in topic pages and newsletter

### DIFF
--- a/_posts/en/newsletters/2023-08-09-newsletter.md
+++ b/_posts/en/newsletters/2023-08-09-newsletter.md
@@ -177,7 +177,7 @@ infrastructure software.
   stolen---but if you used a variation on the process, you might still
   have a chance to move your bitcoins to safety.  If you use a wallet
   or other software that you think might use Libbitcoin, please
-  advise the developers about the vulnernability and ask them to
+  advise the developers about the vulnerability and ask them to
   investigate.
 
   We thank the researchers for their significant efforts in making a

--- a/_topics/en/acc.md
+++ b/_topics/en/acc.md
@@ -67,7 +67,7 @@ optech_mentions:
   - title: Discussion about transaction weight limit in response to large BitVM transactions
     url: /en/newsletters/2025/06/06/#transaction-weight-limit-with-exception-to-prevent-confiscation
 
-  - title: "Improvments to BitVM-style contracts allowing disprove transactions to be just 200 bytes"
+  - title: "Improvements to BitVM-style contracts allowing disprove transactions to be just 200 bytes"
     url: /en/newsletters/2025/06/20/#improvements-to-bitvm-style-contracts
 
   - title: "Continued discussion about CTV+CSFS advantages for BitVM"

--- a/_topics/en/coinjoin.md
+++ b/_topics/en/coinjoin.md
@@ -43,7 +43,7 @@ optech_mentions:
   - title: Question about Wasabi coinjoin mixing and exchange blacklisting
     url: /en/newsletters/2018/09/25/#how-likely-are-you-to-get-blacklisted-by-an-exchange-if-you-use-wasabi-wallet-s-coinjoin-mixing
 
-  - title: Fidelity bonds for imporoved sybil resistance in distributed coinjoin
+  - title: Fidelity bonds for improved sybil resistance in distributed coinjoin
     url: /en/newsletters/2019/07/31/#fidelity-bonds-for-improved-sybil-resistance
 
   - title: "Simple Non-Interactive Coinjoin with Keys for Encryption Reused (SNICKER)"

--- a/_topics/en/covenants.md
+++ b/_topics/en/covenants.md
@@ -82,7 +82,7 @@ optech_mentions:
   - title: "Proposal to use covenants and merkle trees to enable generalized smart contracts"
     url: /en/newsletters/2022/11/16/#general-smart-contracts-in-bitcoin-via-covenants
 
-  - title: "Proposal for `OP_VAULT` and `OP_UNVAULT` opcodes to enable convenant-based valuts"
+  - title: "Proposal for `OP_VAULT` and `OP_UNVAULT` opcodes to enable covenant-based vaults"
     url: /en/newsletters/2023/01/18/#proposal-for-new-vault-specific-opcodes
 
   - title: "Proposal for alternative design for `OP_VAULT` inspired by `OP_TLUV`"

--- a/_topics/en/default-minimum-transaction-relay-feerates.md
+++ b/_topics/en/default-minimum-transaction-relay-feerates.md
@@ -29,7 +29,7 @@ optech_mentions:
   - title: Discussion about lowering the default minimum relay feerate
     url: /en/newsletters/2018/07/10/#discussion-min-fee-discussion-about-minimum-relay-fee
 
-  - title: Accidentially creating transaction below the default min relay feerate
+  - title: Accidentally creating transaction below the default min relay feerate
     url: /en/newsletters/2018/07/10/#unrelayable-transactions
 
   - title: "Bitcoin Core #16507 fixes a rounding issue related to the minimum relay feerate"

--- a/_topics/en/eltoo.md
+++ b/_topics/en/eltoo.md
@@ -60,7 +60,7 @@ optech_mentions:
   - title: Eltoo demo implementation with new blog post overview
     url: /en/newsletters/2021/09/01/#eltoo-example-channel
 
-  - title: "Inherited identifiers proposal with an alternative channel commiment mechanism to eltoo"
+  - title: Inherited identifiers proposal with an alternative channel commitment mechanism to eltoo
     url: /en/newsletters/2021/10/06/#proposal-for-transaction-heritage-identifiers
 
   - title: "LN PTLC proposal providing some of the same benefits of eltoo without a soft fork"

--- a/_topics/en/expiration-floods.md
+++ b/_topics/en/expiration-floods.md
@@ -36,7 +36,7 @@ optech_mentions:
   - title: Concern about forced expiration spam in very large channel factories
     url: /en/newsletters/2023/09/27/#using-covenants-to-improve-ln-scalability
 
-  - title: Mitigating expiration floods with fee-depedent timelocks
+  - title: Mitigating expiration floods with fee-dependent timelocks
     url: /en/newsletters/2024/01/03/#fee-dependent-timelocks
 
 ## Optional.  Same format as "primary_sources" above

--- a/_topics/en/offers.md
+++ b/_topics/en/offers.md
@@ -105,7 +105,7 @@ optech_mentions:
   - title: "LDK #3082 adds an interface for building static reusable offers"
     url: /en/newsletters/2024/06/21/#ldk-3082
 
-  - title: "Discussion of fully implementing offers versus incremently adding features from it"
+  - title: "Discussion of fully implementing offers versus incrementally adding features from it"
     url: /en/newsletters/2024/07/05/#adding-a-bolt11-invoice-field-for-blinded-paths
 
   - title: "Core Lightning #7461 adds support for nodes to self-fetch and self-pay BOLT12 offers and invoices"

--- a/_topics/en/onion-messages.md
+++ b/_topics/en/onion-messages.md
@@ -41,7 +41,7 @@ optech_mentions:
   - title: "2021 year-in-review: onion messages"
     url: /en/newsletters/2021/12/22/#offers
 
-  - title: "Eclair #2099 adds onion message configuration option for controling when to relay messages"
+  - title: "Eclair #2099 adds onion message configuration option for controlling when to relay messages"
     url: /en/newsletters/2022/01/05/#eclair-2099
 
   - title: "Eclair #2117 adds onion message replies in preparation for supporting offers"

--- a/_topics/en/replace-by-fee.md
+++ b/_topics/en/replace-by-fee.md
@@ -84,7 +84,7 @@ optech_mentions:
   - title: Proposal of initial RBF rules for mempool package acceptance before implementing package relay
     url: /en/newsletters/2021/09/22/#package-mempool-acceptance-and-package-rbf
 
-  - title: "2021 year-in-review: BIP125 opt-in replace-by-fee discrepency"
+  - title: "2021 year-in-review: BIP125 opt-in replace-by-fee discrepancy"
     url: /en/newsletters/2021/12/22/#bip125
 
   - title: "2021 year-in-review: default transaction replacement by fee"

--- a/_topics/en/signet.md
+++ b/_topics/en/signet.md
@@ -90,7 +90,7 @@ optech_mentions:
   - title: "Bitcoin Core #19937 adds utilities for mining signet blocks"
     url: /en/newsletters/2021/01/20/#bitcoin-core-19937
 
-  - title: "Discussion about multiple signet compatibilty with soft fork activation"
+  - title: "Discussion about multiple signet compatibility with soft fork activation"
     url: /en/newsletters/2021/04/14/#taproot-activation-discussion
 
   - title: "LND #5025 adds basic support for using signet"

--- a/_topics/en/simplicity.md
+++ b/_topics/en/simplicity.md
@@ -45,7 +45,7 @@ optech_mentions:
   - title: "BTC-Script (based on Chia Lisp) as an alternative to Simplicity"
     url: /en/newsletters/2022/03/16/#using-chia-lisp
 
-  - title: "Comparisons betwen Simplicity and BTC Lisp"
+  - title: "Comparisons between Simplicity and BTC Lisp"
     url: /en/newsletters/2024/03/20/#overview-of-btc-lisp
 
   - title: "Flexible coin earmarks probably compatible with Simplicity"

--- a/_topics/en/time-warp.md
+++ b/_topics/en/time-warp.md
@@ -45,7 +45,7 @@ optech_mentions:
   - title: "Question: how many blocks per second can sustainably be created using a time warp attack?"
     url: /en/newsletters/2024/07/26/#how-many-blocks-per-second-can-sustainably-be-created-using-a-time-warp-attack
 
-  - title: "New time warp vulnernability affecting testnet4 despite previous time warp fixes"
+  - title: "New time warp vulnerability affecting testnet4 despite previous time warp fixes"
     url: /en/newsletters/2024/08/16/#new-time-warp-vulnerability-in-testnet4
 
   - title: "Discussion about fixing Murch-Zawy time warp in consensus cleanup"


### PR DESCRIPTION
14 spelling errors in topic mention titles and one newsletter paragraph — all display text only, no link or anchor changes.

<!-- fleet-pr-claim: agent_id=sera platform=hermes -->Agent-Owner: sera · Platform: hermes · Claim-TTL: 24h